### PR TITLE
add IPv6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,7 @@ Key Features
    * mDNS
    * Example of HTTP server and Telnet
    * TFTP server
+   * IPV6 support (contact XMOS support for further information)
 
 Firmware Overview
 =================

--- a/module_xtcp/doc/overview.rst
+++ b/module_xtcp/doc/overview.rst
@@ -7,7 +7,10 @@ clients to connect to it and send and receive on multiple TCP or UDP
 connections. The stack has been designed for a low memory 
 embedded programming environment and despite its low memory footprint
 provides a complete stack including ARP, IP, UDP, TCP, DHCP, IPv4LL,
-ICMP and IGMP protocols.
+ICMP, IGMP and IPV6 protocols.
+
+.. note:: For IPV6 support, please contact XMOS support for further 
+          information.
 
 The stack is based on the open-source stack uIP with modifications to
 work efficiently on the XMOS architecture and communicate between tasks
@@ -44,7 +47,7 @@ Component Summary
  +-------------------------------------------------------------------+
  |                       **Supported Standards**                     |
  +-------------------------------------------------------------------+
- | IP, UDP, TCP, DHCP, IPv4LL, ICMP, IGMP                            |
+ | IP, UDP, TCP, DHCP, IPv4LL, ICMP, IGMP, IPV6                      |
  +-------------------------------------------------------------------+
  |                       **Supported Devices**                       |
  +------------------------------+------------------------------------+

--- a/module_xtcp/module_build_info
+++ b/module_xtcp/module_build_info
@@ -1,14 +1,18 @@
 DEPENDENT_MODULES = module_ethernet module_otp_board_info
 
+ifeq ($(XTCP_IPV6),1)
+XTCP_SOURCE_DIRS = src src/xtcp_uip6/*
+EXCLUDE_FILES += uip_arp.c autoip.c dhcp.c igmp.c rpl.c rpl-dag.c rpl-ext-header.c \
+                 rpl-icmp6.c rpl-mrhof.c rpl-of0.c rpl-timers.c
+else
 XTCP_SOURCE_DIRS = src src/xtcp_uip/*
+EXCLUDE_FILES += uip-fw.c uip-neighbor.c
+endif
 
 SOURCE_DIRS += $(XTCP_SOURCE_DIRS)
-
 INCLUDE_DIRS += $(XTCP_SOURCE_DIRS)
-
-EXCLUDE_FILES += uip-fw.c uip-neighbor.c
-
 OPTIONAL_HEADERS += xtcp_client_conf.h xtcp_conf.h
+MODULE_XCC_FLAGS = $(XCC_FLAGS)
 
 ifeq ($(USE_XTCP_MAC_CUSTOM_FILTER),1)
 INCLUDE_DIRS += src/mac_custom_filter
@@ -28,4 +32,3 @@ XCC_FLAGS_uip_single_server.xc = $(XCC_FLAGS) -fsubword-select
 #  $(warning ****Building parts of xtcp at -O0 to help debugging****** )
 #  XCC_FLAGS_uip_xtcp.c = $(XCC_FLAGS) -O0 -g
 #  XCC_FLAGS_uip.c = $(XCC_FLAGS) -O0 -g
-

--- a/module_xtcp/src/xtcp_client.h
+++ b/module_xtcp/src/xtcp_client.h
@@ -21,7 +21,28 @@
 
 #include "xtcp_bufinfo.h"
 
+#if IPV6
+#define UIP_CONF_IPV6 1
+#else
+#define UIP_CONF_IPV6 0
+#endif
+
 typedef unsigned int xtcp_appstate_t;
+
+#if UIP_CONF_IPV6
+/** XTCP IP address.
+ *
+ *  This data type represents a single ipv6 address in the XTCP
+ *  stack.
+ */
+typedef union xtcp_ip6addr_t {
+  unsigned char  u8[16];			/* Initialiser, must come first. */
+  unsigned short u16[8];
+} xtcp_ip6addr_t;
+
+typedef xtcp_ip6addr_t xtcp_ipaddr_t;
+
+#else /* UIP_CONF_IPV6 -> UIP_CONF_IPV4 */
 
 /** XTCP IP address.
  *
@@ -30,17 +51,26 @@ typedef unsigned int xtcp_appstate_t;
  */
 typedef unsigned char xtcp_ipaddr_t[4];
 
+#endif /* UIP_CONF_IPV6 */
+
 /** IP configuration information structure.
  *
  *  This structure describes IP configuration for an ip node.
  *
  **/
+#if UIP_CONF_IPV6
+typedef struct xtcp_ipconfig_t {
+  int v;		           /**< used ip protocol version */
+  xtcp_ipaddr_t ipaddr;    /**< The IP Address of the node */
+} xtcp_ipconfig_t;
+#else
 typedef struct xtcp_ipconfig_t {
   xtcp_ipaddr_t ipaddr;    /**< The IP Address of the node */
-  xtcp_ipaddr_t netmask;   /**< The netmask of the node. The mask used
+  xtcp_ipaddr_t netmask;   /**< The netmask of the node. The mask used 
                                 to determine which address are routed locally.*/
   xtcp_ipaddr_t gateway;   /**< The gateway of the node */
 } xtcp_ipconfig_t;
+#endif
 
 /** XTCP protocol type.
  *
@@ -179,6 +209,42 @@ typedef struct xtcp_connection_t {
 } xtcp_connection_t;
 
 
+#if UIP_CONF_IPV6
+#define XTCP_IPADDR_CPY(dest, src) do { dest[0]  = src[0]; \
+								dest[1]  = src[1]; \
+								dest[2]  = src[2]; \
+								dest[3]  = src[3]; \
+								dest[4]  = src[4]; \
+								dest[5]  = src[5]; \
+								dest[6]  = src[6]; \
+								dest[7]  = src[7]; \
+								dest[8]  = src[8]; \
+								dest[9]  = src[9]; \
+								dest[10] = src[10]; \
+								dest[11] = src[11]; \
+								dest[12] = src[12]; \
+								dest[13] = src[13]; \
+								dest[14] = src[14]; \
+								dest[15] = src[15]; \
+							  } while (0)
+
+#define XTCP_IPADDR_CMP(a, b) (a[0]  == b[0] && \
+                               a[1]  == b[1] && \
+                               a[2]  == b[2] && \
+                               a[3]  == b[3] && \
+                               a[4]  == b[4] && \
+                               a[5]  == b[5] && \
+                               a[6]  == b[6] && \
+                               a[7]  == b[7] && \
+                               a[8]  == b[8] && \
+                               a[9]  == b[9] && \
+                               a[10] == b[10] && \
+                               a[11] == b[11] && \
+                               a[12] == b[12] && \
+                               a[13] == b[13] && \
+                               a[14] == b[14] && \
+                               a[15] == b[15])
+#else
 #define XTCP_IPADDR_CPY(dest, src) do { dest[0] = src[0]; \
                                         dest[1] = src[1]; \
                                         dest[2] = src[2]; \
@@ -190,6 +256,7 @@ typedef struct xtcp_connection_t {
                                a[1] == b[1] && \
                                a[2] == b[2] && \
                                a[3] == b[3])
+#endif
 
 #include "xtcp_blocking_client.h"
 

--- a/module_xtcp/src/xtcp_client.xc
+++ b/module_xtcp/src/xtcp_client.xc
@@ -43,9 +43,14 @@ void xtcp_connect(chanend c_xtcp,
 {
   send_cmd(c_xtcp, XTCP_CMD_CONNECT, 0);
   master {
-	  c_xtcp <: port_number;
+    c_xtcp <: port_number;
+#if UIP_CONF_IPV6
+    for(int i=0;i<sizeof(xtcp_ipaddr_t);i++)
+      c_xtcp <: ipaddr.u8[i];
+#else
     for(int i=0;i<4;i++)
     	c_xtcp <: ipaddr[i];
+#endif
     c_xtcp <: p;
   }
 }
@@ -64,8 +69,13 @@ void xtcp_bind_remote(chanend c_xtcp, xtcp_connection_t &conn,
 {
   send_cmd(c_xtcp, XTCP_CMD_BIND_REMOTE, conn.id);
   master {
+#if UIP_CONF_IPV6
+    for (int i=0;i<sizeof(xtcp_ipaddr_t);i++)
+    	c_xtcp <: addr.u8[i];
+#else
     for (int i=0;i<4;i++)
     	c_xtcp <: addr[i];
+#endif
     c_xtcp <: port_number;
   }
 }
@@ -213,6 +223,7 @@ void xtcp_send(chanend c_xtcp,
   xtcp_sendi(c_xtcp, data, 0, len);
 }
 
+#if !UIP_CONF_IPV6
 void xtcp_uint_to_ipaddr(xtcp_ipaddr_t ipaddr, unsigned int i) {
   ipaddr[0] = i & 0xff;
   i >>= 8;
@@ -222,6 +233,7 @@ void xtcp_uint_to_ipaddr(xtcp_ipaddr_t ipaddr, unsigned int i) {
   i >>= 8;
   ipaddr[3] = i & 0xff;
 }
+#endif
 
 void xtcp_set_poll_interval(chanend c_xtcp,
                             REFERENCE_PARAM(xtcp_connection_t, conn),
@@ -233,6 +245,7 @@ void xtcp_set_poll_interval(chanend c_xtcp,
   }
 }
 
+#if !UIP_CONF_IPV6
 void xtcp_join_multicast_group(chanend c_xtcp,
                                xtcp_ipaddr_t addr)
 {
@@ -256,6 +269,7 @@ void xtcp_leave_multicast_group(chanend c_xtcp,
     c_xtcp <: addr[3];
   }
 }
+#endif
 
 void xtcp_get_mac_address(chanend c_xtcp, unsigned char mac_addr[])
 {
@@ -271,8 +285,18 @@ void xtcp_get_mac_address(chanend c_xtcp, unsigned char mac_addr[])
 void xtcp_get_ipconfig(chanend c_xtcp,
                        xtcp_ipconfig_t &ipconfig)
 {
+#if UIP_CONF_IPV6
+  char *c_ptr;
+#endif
   send_cmd(c_xtcp, XTCP_CMD_GET_IPCONFIG, 0);
+#if UIP_CONF_IPV6
+  c_ptr = (char *)&ipconfig;
+#endif
   slave {
+#if UIP_CONF_IPV6
+	  for(int i=0; i<sizeof(xtcp_ipconfig_t); i++)
+		  c_xtcp :> c_ptr[i];
+#else
     c_xtcp :> ipconfig.ipaddr[0];
     c_xtcp :> ipconfig.ipaddr[1];
     c_xtcp :> ipconfig.ipaddr[2];
@@ -285,6 +309,7 @@ void xtcp_get_ipconfig(chanend c_xtcp,
     c_xtcp :> ipconfig.gateway[1];
     c_xtcp :> ipconfig.gateway[2];
     c_xtcp :> ipconfig.gateway[3];
+#endif
   }
 }
 

--- a/module_xtcp/src/xtcp_server.h
+++ b/module_xtcp/src/xtcp_server.h
@@ -9,6 +9,11 @@
 #include "xtcp_client.h"
 #include "xtcp_server_conf.h"
 
+#if UIP_CONF_IPV6
+#include "process.h"
+#include "uip-conf.h"
+#endif
+
 #define MAX_XTCP_CLIENTS 10
 
 typedef struct xtcpd_state_t {

--- a/module_xtcp/src/xtcp_server.xc
+++ b/module_xtcp/src/xtcp_server.xc
@@ -51,8 +51,13 @@ static void handle_xtcp_cmd(chanend c,
       xtcp_protocol_t protocol;
       slave {
         c :> port_number;
+#if UIP_CONF_IPV6
+        for (int j=0;j<sizeof(xtcp_ipaddr_t);j++)
+          c :> ipaddr.u8[j];
+#else
         for (int j=0;j<4;j++)
           c :> ipaddr[j];
+#endif
         c :> protocol;
         xtcpd_connect(i, port_number, ipaddr, protocol);
       }
@@ -64,8 +69,13 @@ static void handle_xtcp_cmd(chanend c,
       xtcp_ipaddr_t ipaddr;
       int port_number;
       slave {
+#if UIP_CONF_IPV6
+        for (int j=0;j<sizeof(xtcp_ipaddr_t);j++)
+          c :> ipaddr.u8[j];
+#else
         for (int j=0;j<4;j++)
           c :> ipaddr[j];
+#endif
         c :> port_number;
       }
       xtcpd_bind_remote(i, conn_id, ipaddr, port_number);
@@ -123,10 +133,16 @@ static void handle_xtcp_cmd(chanend c,
     case XTCP_CMD_JOIN_GROUP: {
       xtcp_ipaddr_t ipaddr;
       slave {
+#if UIP_CONF_IPV6
+    	  for(int i = 0; i<sizeof(xtcp_ipaddr_t); i++){
+    		  c:> ipaddr.u8[i];
+    	  }
+#else
         c :> ipaddr[0];
         c :> ipaddr[1];
         c :> ipaddr[2];
         c :> ipaddr[3];
+#endif
       }
       xtcpd_join_group(ipaddr);
       }
@@ -136,10 +152,16 @@ static void handle_xtcp_cmd(chanend c,
     case XTCP_CMD_LEAVE_GROUP: {
       xtcp_ipaddr_t ipaddr;
       slave {
+#if UIP_CONF_IPV6
+    	  for(int i = 0; i<sizeof(xtcp_ipaddr_t); i++){
+    		  c:> ipaddr.u8[i];
+    	  }
+#else
         c :> ipaddr[0];
         c :> ipaddr[1];
         c :> ipaddr[2];
         c :> ipaddr[3];
+#endif
       }
       xtcpd_leave_group(ipaddr);
       }
@@ -161,9 +183,19 @@ static void handle_xtcp_cmd(chanend c,
 #ifndef XTCP_EXCLUDE_GET_IPCONFIG
     case XTCP_CMD_GET_IPCONFIG: {
       {
+#if UIP_CONF_IPV6
+    	char *c_ptr;
+#endif
         xtcp_ipconfig_t ipconfig;
         xtcpd_get_ipconfig(ipconfig);
+#if UIP_CONF_IPV6
+        c_ptr = (char *)&ipconfig;
+#endif
         master {
+#if UIP_CONF_IPV6
+          for (int i=0;i<sizeof(xtcp_ipconfig_t);i++)
+            c <: c_ptr[i];
+#else
           for (int i=0;i<4;i++)
             c <: ipconfig.ipaddr[i];
 
@@ -172,6 +204,7 @@ static void handle_xtcp_cmd(chanend c,
 
           for (int i=0;i<4;i++)
             c <: ipconfig.gateway[i];
+#endif
         }
       }
       break;

--- a/module_xtcp/src/xtcp_uip6/README
+++ b/module_xtcp/src/xtcp_uip6/README
@@ -1,0 +1,5 @@
+This implementation of an XTCP server is based on uIP v1.0.
+
+uIP is a very small implementation of the TCP/IP stack that is written
+by Adam Dunkels <adam@sics.se>. More information can be obtained 
+at the uIP homepage at http://www.sics.se/~adam/uip/.

--- a/module_xtcp/src/xtcp_uip6/contiki/contiki-net.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/contiki-net.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2005, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ * Author: Adam Dunkels <adam@sics.se>
+ *
+ */
+#ifndef __CONTIKI_NET_H__
+#define __CONTIKI_NET_H__
+
+#include "contiki.h"
+
+#include "net/tcpip.h"
+#include "net/uip.h"
+#if NO_XMOS_PROJECT
+#include "net/uip-fw.h"
+#include "net/uip-fw-drv.h"
+#endif /* NO_XMOS_PROJECT */
+#include "net/uip_arp.h"
+#if NO_XMOS_PROJECT
+#include "net/uiplib.h"
+#include "net/uip-udp-packet.h"
+#include "net/simple-udp.h"
+#endif /* NO_XMOS_PROJECT */
+
+#if UIP_CONF_IPV6
+#include "net/uip-icmp6.h"
+#include "net/uip-ds6.h"
+#endif /* UIP_CONF_IPV6 */
+
+#if NO_XMOS_PROJECT
+#include "net/resolv.h"
+#endif /* NO_XMOS_PROJECT */
+
+#include "net/psock.h"
+
+#if NO_XMOS_PROJECT
+#include "net/rime.h"
+#endif /* NO_XMOS_PROJECT */
+
+#if NO_XMOS_PROJECT
+#include "net/netstack.h"
+#endif /* NO_XMOS_PROJECT */
+
+#endif /* __CONTIKI_NET_H__ */

--- a/module_xtcp/src/xtcp_uip6/contiki/contiki.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/contiki.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2004, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ * Author: Adam Dunkels <adam@sics.se>
+ *
+ */
+#ifndef __CONTIKI_H__
+#define __CONTIKI_H__
+
+#if NO_XMOS_PROJECT
+#include "contiki-version.h"
+#include "contiki-conf.h"
+#include "contiki-default-conf.h"
+#endif NO_XMOS_PROJECT
+
+#include "sys/process.h"
+#if NO_XMOS_PROJECT
+#include "sys/autostart.h"
+#endif NO_XMOS_PROJECT
+
+#include "sys/timer.h"
+#include "sys/ctimer.h"
+#include "sys/etimer.h"
+#if NO_XMOS_PROJECT
+#include "sys/rtimer.h"
+#endif NO_XMOS_PROJECT
+
+#include "sys/pt.h"
+
+
+#if NO_XMOS_PROJECT
+#include "sys/procinit.h"
+#endif NO_XMOS_PROJECT
+
+#if NO_XMOS_PROJECT
+#include "sys/loader.h"
+#endif NO_XMOS_PROJECT
+#include "sys/clock.h"
+
+#if NO_XMOS_PROJECT
+#include "sys/energest.h"
+#endif NO_XMOS_PROJECT
+
+#endif /* __CONTIKI_H__ */

--- a/module_xtcp/src/xtcp_uip6/contiki/lib/list.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/lib/list.c
@@ -1,0 +1,329 @@
+/**
+ * \addtogroup list
+ * @{
+ */
+
+/**
+ * \file
+ * Linked list library implementation.
+ *
+ * \author Adam Dunkels <adam@sics.se>
+ *
+ */
+
+/*
+ * Copyright (c) 2004, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ * Author: Adam Dunkels <adam@sics.se>
+ *
+ */
+#include "lib/list.h"
+
+#define NULL 0
+
+struct list {
+  struct list *next;
+};
+
+/*---------------------------------------------------------------------------*/
+/**
+ * Initialize a list.
+ *
+ * This function initalizes a list. The list will be empty after this
+ * function has been called.
+ *
+ * \param list The list to be initialized.
+ */
+void
+list_init(list_t list)
+{
+  *list = NULL;
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * Get a pointer to the first element of a list.
+ *
+ * This function returns a pointer to the first element of the
+ * list. The element will \b not be removed from the list.
+ *
+ * \param list The list.
+ * \return A pointer to the first element on the list.
+ *
+ * \sa list_tail()
+ */
+void *
+list_head(list_t list)
+{
+  return *list;
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * Duplicate a list.
+ *
+ * This function duplicates a list by copying the list reference, but
+ * not the elements.
+ *
+ * \note This function does \b not copy the elements of the list, but
+ * merely duplicates the pointer to the first element of the list.
+ *
+ * \param dest The destination list.
+ * \param src The source list.
+ */
+void
+list_copy(list_t dest, list_t src)
+{
+  *dest = *src;
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * Get the tail of a list.
+ *
+ * This function returns a pointer to the elements following the first
+ * element of a list. No elements are removed by this function.
+ *
+ * \param list The list
+ * \return A pointer to the element after the first element on the list.
+ *
+ * \sa list_head()
+ */
+void *
+list_tail(list_t list)
+{
+  struct list *l;
+  
+  if(*list == NULL) {
+    return NULL;
+  }
+  
+  for(l = *list; l->next != NULL; l = l->next);
+  
+  return l;
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * Add an item at the end of a list.
+ *
+ * This function adds an item to the end of the list.
+ *
+ * \param list The list.
+ * \param item A pointer to the item to be added.
+ *
+ * \sa list_push()
+ *
+ */
+void
+list_add(list_t list, void *item)
+{
+  struct list *l;
+
+  /* Make sure not to add the same element twice */
+  list_remove(list, item);
+
+  ((struct list *)item)->next = NULL;
+  
+  l = list_tail(list);
+
+  if(l == NULL) {
+    *list = item;
+  } else {
+    l->next = item;
+  }
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * Add an item to the start of the list.
+ */
+void
+list_push(list_t list, void *item)
+{
+  /*  struct list *l;*/
+
+  /* Make sure not to add the same element twice */
+  list_remove(list, item);
+
+  ((struct list *)item)->next = *list;
+  *list = item;
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * Remove the last object on the list.
+ *
+ * This function removes the last object on the list and returns it.
+ *
+ * \param list The list
+ * \return The removed object
+ *
+ */
+void *
+list_chop(list_t list)
+{
+  struct list *l, *r;
+  
+  if(*list == NULL) {
+    return NULL;
+  }
+  if(((struct list *)*list)->next == NULL) {
+    l = *list;
+    *list = NULL;
+    return l;
+  }
+  
+  for(l = *list; l->next->next != NULL; l = l->next);
+
+  r = l->next;
+  l->next = NULL;
+  
+  return r;
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * Remove the first object on a list.
+ *
+ * This function removes the first object on the list and returns a
+ * pointer to it.
+ *
+ * \param list The list.
+ * \return Pointer to the removed element of list.
+ */
+/*---------------------------------------------------------------------------*/
+void *
+list_pop(list_t list)
+{
+  struct list *l;
+  l = *list;
+  if(*list != NULL) {
+    *list = ((struct list *)*list)->next;
+  }
+
+  return l;
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * Remove a specific element from a list.
+ *
+ * This function removes a specified element from the list.
+ *
+ * \param list The list.
+ * \param item The item that is to be removed from the list.
+ *
+ */
+/*---------------------------------------------------------------------------*/
+void
+list_remove(list_t list, void *item)
+{
+  struct list *l, *r;
+  
+  if(*list == NULL) {
+    return;
+  }
+  
+  r = NULL;
+  for(l = *list; l != NULL; l = l->next) {
+    if(l == item) {
+      if(r == NULL) {
+	/* First on list */
+	*list = l->next;
+      } else {
+	/* Not first on list */
+	r->next = l->next;
+      }
+      l->next = NULL;
+      return;
+    }
+    r = l;
+  }
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * Get the length of a list.
+ *
+ * This function counts the number of elements on a specified list.
+ *
+ * \param list The list.
+ * \return The length of the list.
+ */
+/*---------------------------------------------------------------------------*/
+int
+list_length(list_t list)
+{
+  struct list *l;
+  int n = 0;
+
+  for(l = *list; l != NULL; l = l->next) {
+    ++n;
+  }
+
+  return n;
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * \brief      Insert an item after a specified item on the list
+ * \param list The list
+ * \param previtem The item after which the new item should be inserted
+ * \param newitem  The new item that is to be inserted
+ * \author     Adam Dunkels
+ *
+ *             This function inserts an item right after a specified
+ *             item on the list. This function is useful when using
+ *             the list module to ordered lists.
+ *
+ *             If previtem is NULL, the new item is placed at the
+ *             start of the list.
+ *
+ */
+void
+list_insert(list_t list, void *previtem, void *newitem)
+{
+  if(previtem == NULL) {
+    list_push(list, newitem);
+  } else {
+  
+    ((struct list *)newitem)->next = ((struct list *)previtem)->next;
+    ((struct list *)previtem)->next = newitem;
+  }
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * \brief      Get the next item following this item
+ * \param item A list item
+ * \returns    A next item on the list
+ *
+ *             This function takes a list item and returns the next
+ *             item on the list, or NULL if there are no more items on
+ *             the list. This function is used when iterating through
+ *             lists.
+ */
+void *
+list_item_next(void *item)
+{
+  return item == NULL? NULL: ((struct list *)item)->next;
+}
+/*---------------------------------------------------------------------------*/
+/** @} */

--- a/module_xtcp/src/xtcp_uip6/contiki/lib/list.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/lib/list.h
@@ -1,0 +1,159 @@
+/** \addtogroup lib
+    @{ */
+/**
+ * \defgroup list Linked list library
+ *
+ * The linked list library provides a set of functions for
+ * manipulating linked lists.
+ *
+ * A linked list is made up of elements where the first element \b
+ * must be a pointer. This pointer is used by the linked list library
+ * to form lists of the elements.
+ *
+ * Lists are declared with the LIST() macro. The declaration specifies
+ * the name of the list that later is used with all list functions.
+ *
+ * Lists can be manipulated by inserting or removing elements from
+ * either sides of the list (list_push(), list_add(), list_pop(),
+ * list_chop()). A specified element can also be removed from inside a
+ * list with list_remove(). The head and tail of a list can be
+ * extracted using list_head() and list_tail(), respectively.
+ *
+ * @{
+ */
+
+/**
+ * \file
+ * Linked list manipulation routines.
+ * \author Adam Dunkels <adam@sics.se>
+ *
+ *
+ */
+
+
+
+/*
+ * Copyright (c) 2004, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ * Author: Adam Dunkels <adam@sics.se>
+ *
+ */
+#ifndef __LIST_H__
+#define __LIST_H__
+
+#define LIST_CONCAT2(s1, s2) s1##s2
+#define LIST_CONCAT(s1, s2) LIST_CONCAT2(s1, s2)
+
+/**
+ * Declare a linked list.
+ *
+ * This macro declares a linked list with the specified \c type. The
+ * type \b must be a structure (\c struct) with its first element
+ * being a pointer. This pointer is used by the linked list library to
+ * form the linked lists.
+ *
+ * The list variable is declared as static to make it easy to use in a
+ * single C module without unnecessarily exporting the name to other
+ * modules. 
+ *
+ * \param name The name of the list.
+ */
+#define LIST(name) \
+         static void *LIST_CONCAT(name,_list) = NULL; \
+         static list_t name = (list_t)&LIST_CONCAT(name,_list)
+
+/**
+ * Declare a linked list inside a structure declaraction.
+ *
+ * This macro declares a linked list with the specified \c type. The
+ * type \b must be a structure (\c struct) with its first element
+ * being a pointer. This pointer is used by the linked list library to
+ * form the linked lists.
+ *
+ * Internally, the list is defined as two items: the list itself and a
+ * pointer to the list. The pointer has the name of the parameter to
+ * the macro and the name of the list is a concatenation of the name
+ * and the suffix "_list". The pointer must point to the list for the
+ * list to work. Thus the list must be initialized before using.
+ *
+ * The list is initialized with the LIST_STRUCT_INIT() macro.
+ *
+ * \param name The name of the list.
+ */
+#define LIST_STRUCT(name) \
+         void *LIST_CONCAT(name,_list); \
+         list_t name
+
+/**
+ * Initialize a linked list that is part of a structure.
+ *
+ * This macro sets up the internal pointers in a list that has been
+ * defined as part of a struct. This macro must be called before using
+ * the list.
+ *
+ * \param struct_ptr A pointer to the struct
+ * \param name The name of the list.
+ */
+#define LIST_STRUCT_INIT(struct_ptr, name)                              \
+    do {                                                                \
+       (struct_ptr)->name = &((struct_ptr)->LIST_CONCAT(name,_list));   \
+       (struct_ptr)->LIST_CONCAT(name,_list) = NULL;                    \
+       list_init((struct_ptr)->name);                                   \
+    } while(0)
+
+/**
+ * The linked list type.
+ *
+ */
+typedef void ** list_t;
+
+void   list_init(list_t list);
+void * list_head(list_t list);
+void * list_tail(list_t list);
+void * list_pop (list_t list);
+void   list_push(list_t list, void *item);
+
+void * list_chop(list_t list);
+
+void   list_add(list_t list, void *item);
+void   list_remove(list_t list, void *item);
+
+int    list_length(list_t list);
+
+void   list_copy(list_t dest, list_t src);
+
+void   list_insert(list_t list, void *previtem, void *newitem);
+
+void * list_item_next(void *item);
+
+#endif /* __LIST_H__ */
+
+/** @} */
+/** @} */

--- a/module_xtcp/src/xtcp_uip6/contiki/lib/memb.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/lib/memb.c
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2004, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ * Author: Adam Dunkels <adam@sics.se>
+ *
+ */
+
+/**
+ * \addtogroup memb
+ * @{
+ */
+
+ /**
+ * \file
+ * Memory block allocation routines.
+ * \author Adam Dunkels <adam@sics.se>
+ */
+#include <string.h>
+#if NO_XMOS_PROJECT
+#include "contiki.h"
+#endif
+#include "lib/memb.h"
+
+/*---------------------------------------------------------------------------*/
+void
+memb_init(struct memb *m)
+{
+  memset(m->count, 0, m->num);
+  memset(m->mem, 0, m->size * m->num);
+}
+/*---------------------------------------------------------------------------*/
+void *
+memb_alloc(struct memb *m)
+{
+  int i;
+
+  for(i = 0; i < m->num; ++i) {
+    if(m->count[i] == 0) {
+      /* If this block was unused, we increase the reference count to
+	 indicate that it now is used and return a pointer to the
+	 memory block. */
+      ++(m->count[i]);
+      return (void *)((char *)m->mem + (i * m->size));
+    }
+  }
+
+  /* No free block was found, so we return NULL to indicate failure to
+     allocate block. */
+  return NULL;
+}
+/*---------------------------------------------------------------------------*/
+char
+memb_free(struct memb *m, void *ptr)
+{
+  int i;
+  char *ptr2;
+
+  /* Walk through the list of blocks and try to find the block to
+     which the pointer "ptr" points to. */
+  ptr2 = (char *)m->mem;
+  for(i = 0; i < m->num; ++i) {
+    
+    if(ptr2 == (char *)ptr) {
+      /* We've found to block to which "ptr" points so we decrease the
+	 reference count and return the new value of it. */
+      if(m->count[i] > 0) {
+	/* Make sure that we don't deallocate free memory. */
+	--(m->count[i]);
+      }
+      return m->count[i];
+    }
+    ptr2 += m->size;
+  }
+  return -1;
+}
+/*---------------------------------------------------------------------------*/
+int
+memb_inmemb(struct memb *m, void *ptr)
+{
+  return (char *)ptr >= (char *)m->mem &&
+    (char *)ptr < (char *)m->mem + (m->num * m->size);
+}
+/*---------------------------------------------------------------------------*/
+
+/** @} */

--- a/module_xtcp/src/xtcp_uip6/contiki/lib/memb.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/lib/memb.h
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2004, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ * Author: Adam Dunkels <adam@sics.se>
+ *
+ */
+
+/**
+ * \addtogroup mem
+ * @{
+ */
+
+
+/**
+ * \defgroup memb Memory block management functions
+ *
+ * The memory block allocation routines provide a simple yet powerful
+ * set of functions for managing a set of memory blocks of fixed
+ * size. A set of memory blocks is statically declared with the
+ * MEMB() macro. Memory blocks are allocated from the declared
+ * memory by the memb_alloc() function, and are deallocated with the
+ * memb_free() function.
+ *
+ * @{
+ */
+
+
+/**
+ * \file
+ *         Memory block allocation routines.
+ * \author
+ *         Adam Dunkels <adam@sics.se>
+ *
+ */
+
+#ifndef __MEMB_H__
+#define __MEMB_H__
+
+#include "sys/cc.h"
+
+/**
+ * Declare a memory block.
+ *
+ * This macro is used to statically declare a block of memory that can
+ * be used by the block allocation functions. The macro statically
+ * declares a C array with a size that matches the specified number of
+ * blocks and their individual sizes.
+ *
+ * Example:
+ \code
+MEMB(connections, struct connection, 16);
+ \endcode
+ *
+ * \param name The name of the memory block (later used with
+ * memb_init(), memb_alloc() and memb_free()).
+ *
+ * \param structure The name of the struct that the memory block holds
+ *
+ * \param num The total number of memory chunks in the block.
+ *
+ */
+#define MEMB(name, structure, num) \
+        static char CC_CONCAT(name,_memb_count)[num]; \
+        static structure CC_CONCAT(name,_memb_mem)[num]; \
+        static struct memb name = {sizeof(structure), num, \
+                                          CC_CONCAT(name,_memb_count), \
+                                          (void *)CC_CONCAT(name,_memb_mem)}
+
+struct memb {
+  unsigned short size;
+  unsigned short num;
+  char *count;
+  void *mem;
+};
+
+/**
+ * Initialize a memory block that was declared with MEMB().
+ *
+ * \param m A memory block previously declared with MEMB().
+ */
+void  memb_init(struct memb *m);
+
+/**
+ * Allocate a memory block from a block of memory declared with MEMB().
+ *
+ * \param m A memory block previously declared with MEMB().
+ */
+void *memb_alloc(struct memb *m);
+
+/**
+ * Deallocate a memory block from a memory block previously declared
+ * with MEMB().
+ *
+ * \param m m A memory block previously declared with MEMB().
+ *
+ * \param ptr A pointer to the memory block that is to be deallocated.
+ *
+ * \return The new reference count for the memory block (should be 0
+ * if successfully deallocated) or -1 if the pointer "ptr" did not
+ * point to a legal memory block.
+ */
+char  memb_free(struct memb *m, void *ptr);
+
+int memb_inmemb(struct memb *m, void *ptr);
+
+
+/** @} */
+/** @} */
+
+#endif /* __MEMB_H__ */

--- a/module_xtcp/src/xtcp_uip6/contiki/lib/random.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/lib/random.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2005, Swedish Institute of Computer Science
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+
+#include "lib/random.h"
+
+#include <stdlib.h>
+
+/*---------------------------------------------------------------------------*/
+void
+random_init(unsigned short seed)
+{
+  srand(seed);
+}
+/*---------------------------------------------------------------------------*/
+unsigned short
+random_rand(void)
+{
+/* In gcc int rand() uses RAND_MAX and long random() uses RANDOM_MAX=0x7FFFFFFF */
+/* RAND_MAX varies depending on the architecture */
+
+  return (unsigned short)rand();
+}
+/*---------------------------------------------------------------------------*/

--- a/module_xtcp/src/xtcp_uip6/contiki/lib/random.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/lib/random.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2005, Swedish Institute of Computer Science
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+#ifndef __RANDOM_H__
+#define __RANDOM_H__
+
+/*
+ * Initialize the pseudo-random generator.
+ *
+ */
+void random_init(unsigned short seed);
+
+/*
+ * Calculate a pseudo random number between 0 and 65535.
+ *
+ * \return A pseudo-random number between 0 and 65535.
+ */
+unsigned short random_rand(void);
+
+/* In gcc int rand() uses RAND_MAX and long random() uses RANDOM_MAX */
+/* Since random_rand casts to unsigned short, we'll use this maxmimum */
+#define RANDOM_RAND_MAX 65535U
+
+#endif /* __RANDOM_H__ */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/nbr-table.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/nbr-table.c
@@ -1,0 +1,351 @@
+/*
+ * Copyright (c) 2013, Swedish Institute of Computer Science
+ * Copyright (c) 2010, Vrije Universiteit Brussel
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *
+ * Authors: Simon Duquennoy <simonduq@sics.se>
+ *          Joris Borms <joris.borms@vub.ac.be>
+ */
+#if NO_XMOS_PROJECT
+#include "contiki.h"
+#endif
+#include <stddef.h>
+#include <string.h>
+#include "lib/memb.h"
+#include "lib/list.h"
+#include "net/nbr-table.h"
+
+/* List of link-layer addresses of the neighbors, used as key in the tables */
+typedef struct nbr_table_key {
+  struct nbr_table_key *next;
+  rimeaddr_t lladdr;
+} nbr_table_key_t;
+
+/* For each neighbor, a map of the tables that use the neighbor.
+ * As we are using uint8_t, we have a maximum of 8 tables in the system */
+static uint8_t used_map[NBR_TABLE_MAX_NEIGHBORS];
+/* For each neighbor, a map of the tables that lock the neighbor */
+static uint8_t locked_map[NBR_TABLE_MAX_NEIGHBORS];
+/* The maximum number of tables */
+#define MAX_NUM_TABLES 8
+/* A list of pointers to tables in use */
+static struct nbr_table *all_tables[MAX_NUM_TABLES];
+/* The current number of tables */
+static unsigned num_tables;
+
+/* The neighbor address table */
+MEMB(neighbor_addr_mem, nbr_table_key_t, NBR_TABLE_MAX_NEIGHBORS);
+LIST(nbr_table_keys);
+
+/*---------------------------------------------------------------------------*/
+/* Get a key from a neighbor index */
+static nbr_table_key_t *
+key_from_index(int index)
+{
+  return index != -1 ? &((nbr_table_key_t *)neighbor_addr_mem.mem)[index] : NULL;
+}
+/*---------------------------------------------------------------------------*/
+/* Get an item from its neighbor index */
+static nbr_table_item_t *
+item_from_index(nbr_table_t *table, int index)
+{
+  return table != NULL && index != -1 ? (char *)table->data + index * table->item_size : NULL;
+}
+/*---------------------------------------------------------------------------*/
+/* Get the neighbor index of an item */
+static int
+index_from_key(nbr_table_key_t *key)
+{
+  return key != NULL ? key - (nbr_table_key_t *)neighbor_addr_mem.mem : -1;
+}
+/*---------------------------------------------------------------------------*/
+/* Get the neighbor index of an item */
+static int
+index_from_item(nbr_table_t *table, nbr_table_item_t *item)
+{
+  return table != NULL && item != NULL ? ((int)((char *)item - (char *)table->data)) / table->item_size : -1;
+}
+/*---------------------------------------------------------------------------*/
+/* Get an item from its key */
+static nbr_table_item_t *
+item_from_key(nbr_table_t *table, nbr_table_key_t *key)
+{
+  return item_from_index(table, index_from_key(key));
+}
+/*---------------------------------------------------------------------------*/
+/* Get the key af an item */
+static nbr_table_key_t *
+key_from_item(nbr_table_t *table, nbr_table_item_t *item)
+{
+  return key_from_index(index_from_item(table, item));
+}
+/*---------------------------------------------------------------------------*/
+/* Get the index of a neighbor from its link-layer address */
+static int
+index_from_lladdr(const rimeaddr_t *lladdr)
+{
+  nbr_table_key_t *key;
+  /* Allow lladdr-free insertion, useful e.g. for IPv6 ND.
+   * Only one such entry is possible at a time, indexed by rimeaddr_null. */
+  if(lladdr == NULL) {
+    lladdr = &rimeaddr_null;
+  }
+  key = list_head(nbr_table_keys);
+  while(key != NULL) {
+    if(lladdr && rimeaddr_cmp(lladdr, &key->lladdr)) {
+      return index_from_key(key);
+    }
+    key = list_item_next(key);
+  }
+  return -1;
+}
+/*---------------------------------------------------------------------------*/
+/* Get bit from "used" or "locked" bitmap */
+static int
+nbr_get_bit(uint8_t *bitmap, nbr_table_t *table, nbr_table_item_t *item)
+{
+  int item_index = index_from_item(table, item);
+  if(table != NULL && item_index != -1) {
+    return (bitmap[item_index] & (1 << table->index)) != 0;
+  } else {
+    return 0;
+  }
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+/* Set bit in "used" or "locked" bitmap */
+static int
+nbr_set_bit(uint8_t *bitmap, nbr_table_t *table, nbr_table_item_t *item, int value)
+{
+  int item_index = index_from_item(table, item);
+  if(table != NULL && item_index != -1) {
+    if(value) {
+      bitmap[item_index] |= 1 << table->index;
+    } else {
+      bitmap[item_index] &= ~(1 << table->index);
+    }
+    return 1;
+  } else {
+    return 0;
+  }
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+static nbr_table_key_t *
+nbr_table_allocate(void)
+{
+  nbr_table_key_t *key;
+  int least_used_count = 0;
+  nbr_table_key_t *least_used_key = NULL;
+
+  key = memb_alloc(&neighbor_addr_mem);
+  if(key != NULL) {
+    return key;
+  } else { /* No more space, try to free a neighbor.
+            * The replacement policy is the following: remove neighbor that is:
+            * (1) not locked
+            * (2) used by fewest tables
+            * (3) oldest (the list is ordered by insertion time)
+            * */
+    /* Get item from first key */
+    key = list_head(nbr_table_keys);
+    while(key != NULL) {
+      int item_index = index_from_key(key);
+      int locked = locked_map[item_index];
+      /* Never delete a locked item */
+      if(!locked) {
+        int used = used_map[item_index];
+        int used_count = 0;
+        /* Count how many tables are using this item */
+        while(used != 0) {
+          if((used & 1) == 1) {
+            used_count++;
+          }
+          used >>= 1;
+        }
+        /* Find least used item */
+        if(least_used_key == NULL || used_count < least_used_count) {
+          least_used_key = key;
+          least_used_count = used_count;
+          if(used_count == 0) { /* We won't find any least used item */
+            break;
+          }
+        }
+      }
+      key = list_item_next(key);
+    }
+    if(least_used_key == NULL) {
+      /* We haven't found any unlocked item, allocation fails */
+      return NULL;
+    } else {
+      /* Reuse least used item */
+      int i;
+      for(i = 0; i<MAX_NUM_TABLES; i++) {
+        if(all_tables[i] != NULL && all_tables[i]->callback != NULL) {
+          /* Call table callback for each table that uses this item */
+          nbr_table_item_t *removed_item = item_from_key(all_tables[i], least_used_key);
+          if(nbr_get_bit(used_map, all_tables[i], removed_item) == 1) {
+            all_tables[i]->callback(removed_item);
+          }
+        }
+      }
+      /* Empty used map */
+      used_map[index_from_key(least_used_key)] = 0;
+      /* Remove neighbor from list */
+      list_remove(nbr_table_keys, least_used_key);
+      /* Return associated key */
+      return least_used_key;
+    }
+  }
+}
+/*---------------------------------------------------------------------------*/
+/* Register a new neighbor table. To be used at initialization by modules
+ * using a neighbor table */
+int
+nbr_table_register(nbr_table_t *table, nbr_table_callback *callback)
+{
+  if(num_tables < MAX_NUM_TABLES) {
+    table->index = num_tables++;
+    table->callback = callback;
+    all_tables[table->index] = table;
+    return 1;
+  } else {
+    /* Maximum number of tables exceeded */
+    return 0;
+  }
+}
+/*---------------------------------------------------------------------------*/
+/* Returns the first item of the current table */
+nbr_table_item_t *
+nbr_table_head(nbr_table_t *table)
+{
+  /* Get item from first key */
+  nbr_table_item_t *item = item_from_key(table, list_head(nbr_table_keys));
+  /* Item is the first neighbor, now check is it is in the current table */
+  if(nbr_get_bit(used_map, table, item)) {
+    return item;
+  } else {
+    return nbr_table_next(table, item);
+  }
+}
+/*---------------------------------------------------------------------------*/
+/* Iterates over the current table */
+nbr_table_item_t *
+nbr_table_next(nbr_table_t *table, nbr_table_item_t *item)
+{
+  do {
+    void *key = key_from_item(table, item);
+    key = list_item_next(key);
+    /* Loop until the next item is in the current table */
+    item = item_from_key(table, key);
+  } while(item && !nbr_get_bit(used_map, table, item));
+  return item;
+}
+/*---------------------------------------------------------------------------*/
+/* Add a neighbor indexed with its link-layer address */
+#pragma stackfunction 50	//TODO: CHSC find out, how mutch stack is realy used
+nbr_table_item_t *
+nbr_table_add_lladdr(nbr_table_t *table, const rimeaddr_t *lladdr)
+{
+  int index;
+  nbr_table_item_t *item;
+  nbr_table_key_t *key;
+
+  /* Allow lladdr-free insertion, useful e.g. for IPv6 ND.
+   * Only one such entry is possible at a time, indexed by rimeaddr_null. */
+  if(lladdr == NULL) {
+    lladdr = &rimeaddr_null;
+  }
+
+  if((index = index_from_lladdr(lladdr)) == -1) {
+     /* Neighbor not yet in table, let's try to allocate one */
+    key = nbr_table_allocate();
+
+    /* No space available for new entry */
+    if(key == NULL) {
+      return NULL;
+    }
+
+    /* Add neighbor to list */
+    list_add(nbr_table_keys, key);
+
+    /* Get index from newly allocated neighbor */
+    index = index_from_key(key);
+
+    /* Set link-layer address */
+    rimeaddr_copy(&key->lladdr, lladdr);
+  }
+
+  /* Get item in the current table */
+  item = item_from_index(table, index);
+
+  /* Initialize item data and set "used" bit */
+  memset(item, 0, table->item_size);
+  nbr_set_bit(used_map, table, item, 1);
+
+  return item;
+}
+/*---------------------------------------------------------------------------*/
+/* Get an item from its link-layer address */
+void *
+nbr_table_get_from_lladdr(nbr_table_t *table, const rimeaddr_t *lladdr)
+{
+  void *item = item_from_index(table, index_from_lladdr(lladdr));
+  return nbr_get_bit(used_map, table, item) ? item : NULL;
+}
+/*---------------------------------------------------------------------------*/
+/* Removes a neighbor from the current table (unset "used" bit) */
+int
+nbr_table_remove(nbr_table_t *table, void *item)
+{
+  int ret = nbr_set_bit(used_map, table, item, 0);
+  nbr_set_bit(locked_map, table, item, 0);
+  return ret;
+}
+/*---------------------------------------------------------------------------*/
+/* Lock a neighbor for the current table (set "locked" bit) */
+int
+nbr_table_lock(nbr_table_t *table, void *item)
+{
+  return nbr_set_bit(locked_map, table, item, 1);
+}
+/*---------------------------------------------------------------------------*/
+/* Release the lock on a neighbor for the current table (unset "locked" bit) */
+int
+nbr_table_unlock(nbr_table_t *table, void *item)
+{
+  return nbr_set_bit(locked_map, table, item, 0);
+}
+/*---------------------------------------------------------------------------*/
+/* Get link-layer address of an item */
+rimeaddr_t *
+nbr_table_get_lladdr(nbr_table_t *table, void *item)
+{
+  nbr_table_key_t *key = key_from_item(table, item);
+  return key != NULL ? &key->lladdr : NULL;
+}

--- a/module_xtcp/src/xtcp_uip6/contiki/net/nbr-table.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/nbr-table.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2013, Swedish Institute of Computer Science
+ * Copyright (c) 2010, Vrije Universiteit Brussel
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *
+ * Authors: Simon Duquennoy <simonduq@sics.se>
+ *          Joris Borms <joris.borms@vub.ac.be>
+ */
+
+#ifndef _NBR_TABLE_H_
+#define _NBR_TABLE_H_
+
+#if NO_XMOS_PROJECT
+#include "net/netstack.h"
+#endif
+#include "uip-conf.h"
+#include "net/rime/rimeaddr.h"
+
+/* Neighbor table size */
+#ifdef NBR_TABLE_CONF_MAX_NEIGHBORS
+#define NBR_TABLE_MAX_NEIGHBORS NBR_TABLE_CONF_MAX_NEIGHBORS
+#else /* NBR_TABLE_CONF_MAX_NEIGHBORS */
+#define NBR_TABLE_MAX_NEIGHBORS 8
+#endif /* NBR_TABLE_CONF_MAX_NEIGHBORS */
+
+/* An item in a neighbor table */
+typedef void nbr_table_item_t;
+
+/* Callback function, called when removing an item from a table */
+typedef void(nbr_table_callback)(nbr_table_item_t *item);
+
+/* A neighbor table */
+typedef struct nbr_table {
+  int index;
+  int item_size;
+  nbr_table_callback *callback;
+  nbr_table_item_t *data;
+} nbr_table_t;
+
+/** \brief A static neighbor table. To be initialized through nbr_table_register(name) */
+#define NBR_TABLE(type, name) \
+  static type _##name##_mem[NBR_TABLE_MAX_NEIGHBORS]; \
+  static nbr_table_t name##_struct = { 0, sizeof(type), NULL, (nbr_table_item_t *)_##name##_mem }; \
+  static nbr_table_t *name = &name##_struct \
+
+/** \brief A non-static neighbor table. To be initialized through nbr_table_register(name) */
+#define NBR_TABLE_GLOBAL(type, name) \
+  static type _##name##_mem[NBR_TABLE_MAX_NEIGHBORS]; \
+  static nbr_table_t name##_struct = { 0, sizeof(type), NULL, (nbr_table_item_t *)_##name##_mem }; \
+  nbr_table_t *name = &name##_struct \
+
+/** \brief Declaration of non-static neighbor tables */
+#define NBR_TABLE_DECLARE(name) extern nbr_table_t *name
+
+/** \name Neighbor tables: register and loop through table elements */
+/** @{ */
+int nbr_table_register(nbr_table_t *table, nbr_table_callback *callback);
+nbr_table_item_t *nbr_table_head(nbr_table_t *table);
+nbr_table_item_t *nbr_table_next(nbr_table_t *table, nbr_table_item_t *item);
+/** @} */
+
+/** \name Neighbor tables: add and get data */
+/** @{ */
+nbr_table_item_t *nbr_table_add_lladdr(nbr_table_t *table, const rimeaddr_t *lladdr);
+nbr_table_item_t *nbr_table_get_from_lladdr(nbr_table_t *table, const rimeaddr_t *lladdr);
+/** @} */
+
+/** \name Neighbor tables: set flags (unused, locked, unlocked) */
+/** @{ */
+int nbr_table_remove(nbr_table_t *table, nbr_table_item_t *item);
+int nbr_table_lock(nbr_table_t *table, nbr_table_item_t *item);
+int nbr_table_unlock(nbr_table_t *table, nbr_table_item_t *item);
+/** @} */
+
+/** \name Neighbor tables: address manipulation */
+/** @{ */
+rimeaddr_t *nbr_table_get_lladdr(nbr_table_t *table, nbr_table_item_t *item);
+/** @} */
+
+#endif /* _NBR_TABLE_H_ */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/packetbuf.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/packetbuf.c
@@ -1,0 +1,313 @@
+/**
+ * \addtogroup packetbuf
+ * @{
+ */
+
+/*
+ * Copyright (c) 2006, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+/**
+ * \file
+ *         Rime buffer (packetbuf) management
+ * \author
+ *         Adam Dunkels <adam@sics.se>
+ */
+
+#include <string.h>
+
+#include "contiki-net.h"
+#include "net/packetbuf.h"
+
+struct packetbuf_attr packetbuf_attrs[PACKETBUF_NUM_ATTRS];
+struct packetbuf_addr packetbuf_addrs[PACKETBUF_NUM_ADDRS];
+
+
+static uint16_t buflen, bufptr;
+static uint8_t hdrptr;
+
+/* The declarations below ensure that the packet buffer is aligned on
+   an even 16-bit boundary. On some platforms (most notably the
+   msp430), having apotentially misaligned packet buffer may lead to
+   problems when accessing 16-bit values. */
+static uint16_t packetbuf_aligned[(PACKETBUF_SIZE + PACKETBUF_HDR_SIZE) / 2 + 1];
+static uint8_t *packetbuf = (uint8_t *)packetbuf_aligned;
+
+static uint8_t *packetbufptr;
+
+#define DEBUG 0
+#if DEBUG
+#include <stdio.h>
+#define PRINTF(...) printf(__VA_ARGS__)
+#else
+#define PRINTF(...)
+#endif
+
+/*---------------------------------------------------------------------------*/
+void
+packetbuf_clear(void)
+{
+  buflen = bufptr = 0;
+  hdrptr = PACKETBUF_HDR_SIZE;
+
+  packetbufptr = &packetbuf[PACKETBUF_HDR_SIZE];
+  packetbuf_attr_clear();
+}
+/*---------------------------------------------------------------------------*/
+void
+packetbuf_clear_hdr(void)
+{
+  hdrptr = PACKETBUF_HDR_SIZE;
+}
+/*---------------------------------------------------------------------------*/
+int
+packetbuf_copyfrom(const void *from, uint16_t len)
+{
+  uint16_t l;
+
+  packetbuf_clear();
+  l = len > PACKETBUF_SIZE? PACKETBUF_SIZE: len;
+  memcpy(packetbufptr, from, l);
+  buflen = l;
+  return l;
+}
+/*---------------------------------------------------------------------------*/
+void
+packetbuf_compact(void)
+{
+  int i, len;
+
+  if(packetbuf_is_reference()) {
+    memcpy(&packetbuf[PACKETBUF_HDR_SIZE], packetbuf_reference_ptr(),
+	   packetbuf_datalen());
+  } else if(bufptr > 0) {
+    len = packetbuf_datalen() + PACKETBUF_HDR_SIZE;
+    for(i = PACKETBUF_HDR_SIZE; i < len; i++) {
+      packetbuf[i] = packetbuf[bufptr + i];
+    }
+
+    bufptr = 0;
+  }
+}
+/*---------------------------------------------------------------------------*/
+int
+packetbuf_copyto_hdr(uint8_t *to)
+{
+#if DEBUG_LEVEL > 0
+  {
+    int i;
+    PRINTF("packetbuf_write_hdr: header:\n");
+    for(i = hdrptr; i < PACKETBUF_HDR_SIZE; ++i) {
+      PRINTF("0x%02x, ", packetbuf[i]);
+    }
+    PRINTF("\n");
+  }
+#endif /* DEBUG_LEVEL */
+  memcpy(to, packetbuf + hdrptr, PACKETBUF_HDR_SIZE - hdrptr);
+  return PACKETBUF_HDR_SIZE - hdrptr;
+}
+/*---------------------------------------------------------------------------*/
+int
+packetbuf_copyto(void *to)
+{
+#if DEBUG_LEVEL > 0
+  {
+    int i;
+    char buffer[1000];
+    char *bufferptr = buffer;
+    
+    bufferptr[0] = 0;
+    for(i = hdrptr; i < PACKETBUF_HDR_SIZE; ++i) {
+      bufferptr += sprintf(bufferptr, "0x%02x, ", packetbuf[i]);
+    }
+    PRINTF("packetbuf_write: header: %s\n", buffer);
+    bufferptr = buffer;
+    bufferptr[0] = 0;
+    for(i = bufptr; i < buflen + bufptr; ++i) {
+      bufferptr += sprintf(bufferptr, "0x%02x, ", packetbufptr[i]);
+    }
+    PRINTF("packetbuf_write: data: %s\n", buffer);
+  }
+#endif /* DEBUG_LEVEL */
+  if(PACKETBUF_HDR_SIZE - hdrptr + buflen > PACKETBUF_SIZE) {
+    /* Too large packet */
+    return 0;
+  }
+  memcpy(to, packetbuf + hdrptr, PACKETBUF_HDR_SIZE - hdrptr);
+  memcpy((uint8_t *)to + PACKETBUF_HDR_SIZE - hdrptr, packetbufptr + bufptr,
+	 buflen);
+  return PACKETBUF_HDR_SIZE - hdrptr + buflen;
+}
+/*---------------------------------------------------------------------------*/
+int
+packetbuf_hdralloc(int size)
+{
+  if(hdrptr >= size && packetbuf_totlen() + size <= PACKETBUF_SIZE) {
+    hdrptr -= size;
+    return 1;
+  }
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+void
+packetbuf_hdr_remove(int size)
+{
+  hdrptr += size;
+}
+/*---------------------------------------------------------------------------*/
+int
+packetbuf_hdrreduce(int size)
+{
+  if(buflen < size) {
+    return 0;
+  }
+
+  bufptr += size;
+  buflen -= size;
+  return 1;
+}
+/*---------------------------------------------------------------------------*/
+void
+packetbuf_set_datalen(uint16_t len)
+{
+  PRINTF("packetbuf_set_len: len %d\n", len);
+  buflen = len;
+}
+/*---------------------------------------------------------------------------*/
+void *
+packetbuf_dataptr(void)
+{
+  return (void *)(&packetbuf[bufptr + PACKETBUF_HDR_SIZE]);
+}
+/*---------------------------------------------------------------------------*/
+void *
+packetbuf_hdrptr(void)
+{
+  return (void *)(&packetbuf[hdrptr]);
+}
+/*---------------------------------------------------------------------------*/
+void
+packetbuf_reference(void *ptr, uint16_t len)
+{
+  packetbuf_clear();
+  packetbufptr = ptr;
+  buflen = len;
+}
+/*---------------------------------------------------------------------------*/
+int
+packetbuf_is_reference(void)
+{
+  return packetbufptr != &packetbuf[PACKETBUF_HDR_SIZE];
+}
+/*---------------------------------------------------------------------------*/
+void *
+packetbuf_reference_ptr(void)
+{
+  return packetbufptr;
+}
+/*---------------------------------------------------------------------------*/
+uint16_t
+packetbuf_datalen(void)
+{
+  return buflen;
+}
+/*---------------------------------------------------------------------------*/
+uint8_t
+packetbuf_hdrlen(void)
+{
+  return PACKETBUF_HDR_SIZE - hdrptr;
+}
+/*---------------------------------------------------------------------------*/
+uint16_t
+packetbuf_totlen(void)
+{
+  return packetbuf_hdrlen() + packetbuf_datalen();
+}
+/*---------------------------------------------------------------------------*/
+void
+packetbuf_attr_clear(void)
+{
+  int i;
+  for(i = 0; i < PACKETBUF_NUM_ATTRS; ++i) {
+    packetbuf_attrs[i].val = 0;
+  }
+  for(i = 0; i < PACKETBUF_NUM_ADDRS; ++i) {
+    rimeaddr_copy(&packetbuf_addrs[i].addr, &rimeaddr_null);
+  }
+}
+/*---------------------------------------------------------------------------*/
+void
+packetbuf_attr_copyto(struct packetbuf_attr *attrs,
+		    struct packetbuf_addr *addrs)
+{
+  memcpy(attrs, packetbuf_attrs, sizeof(packetbuf_attrs));
+  memcpy(addrs, packetbuf_addrs, sizeof(packetbuf_addrs));
+}
+/*---------------------------------------------------------------------------*/
+void
+packetbuf_attr_copyfrom(struct packetbuf_attr *attrs,
+		      struct packetbuf_addr *addrs)
+{
+  memcpy(packetbuf_attrs, attrs, sizeof(packetbuf_attrs));
+  memcpy(packetbuf_addrs, addrs, sizeof(packetbuf_addrs));
+}
+/*---------------------------------------------------------------------------*/
+#if !PACKETBUF_CONF_ATTRS_INLINE
+int
+packetbuf_set_attr(uint8_t type, const packetbuf_attr_t val)
+{
+/*   packetbuf_attrs[type].type = type; */
+  packetbuf_attrs[type].val = val;
+  return 1;
+}
+/*---------------------------------------------------------------------------*/
+packetbuf_attr_t
+packetbuf_attr(uint8_t type)
+{
+  return packetbuf_attrs[type].val;
+}
+/*---------------------------------------------------------------------------*/
+int
+packetbuf_set_addr(uint8_t type, const rimeaddr_t *addr)
+{
+/*   packetbuf_addrs[type - PACKETBUF_ADDR_FIRST].type = type; */
+  rimeaddr_copy(&packetbuf_addrs[type - PACKETBUF_ADDR_FIRST].addr, addr);
+  return 1;
+}
+/*---------------------------------------------------------------------------*/
+const rimeaddr_t *
+packetbuf_addr(uint8_t type)
+{
+  return &packetbuf_addrs[type - PACKETBUF_ADDR_FIRST].addr;
+}
+/*---------------------------------------------------------------------------*/
+#endif /* PACKETBUF_CONF_ATTRS_INLINE */
+/** @} */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/packetbuf.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/packetbuf.h
@@ -1,0 +1,450 @@
+/**
+ * \addtogroup rime
+ * @{
+ */
+
+/**
+ * \defgroup packetbuf Rime buffer management
+ * @{
+ *
+ * The packetbuf module does Rime's buffer management.
+ */
+
+/*
+ * Copyright (c) 2006, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+/**
+ * \file
+ *         Header file for the Rime buffer (packetbuf) management
+ * \author
+ *         Adam Dunkels <adam@sics.se>
+ */
+
+#ifndef __PACKETBUF_H__
+#define __PACKETBUF_H__
+
+#if NO_XMOS_PROJECT
+#include "contiki-conf.h"
+#else
+#include "uip-conf.h"
+#endif
+#include "net/rime/rimeaddr.h"
+
+/**
+ * \brief      The size of the packetbuf, in bytes
+ */
+#ifdef PACKETBUF_CONF_SIZE
+#define PACKETBUF_SIZE PACKETBUF_CONF_SIZE
+#else
+#define PACKETBUF_SIZE 128
+#endif
+
+/**
+ * \brief      The size of the packetbuf header, in bytes
+ */
+#ifdef PACKETBUF_CONF_HDR_SIZE
+#define PACKETBUF_HDR_SIZE PACKETBUF_CONF_HDR_SIZE
+#else
+#define PACKETBUF_HDR_SIZE 48
+#endif
+
+/**
+ * \brief      Clear and reset the packetbuf
+ *
+ *             This function clears the packetbuf and resets all
+ *             internal state pointers (header size, header pointer,
+ *             external data pointer). It is used before preparing a
+ *             packet in the packetbuf.
+ *
+ */
+void packetbuf_clear(void);
+
+/**
+ * \brief      Clear and reset the header of the packetbuf
+ *
+ *             This function clears the header of the packetbuf and
+ *             resets all the internal state pointers pertaining to
+ *             the header (header size, header pointer, but not
+ *             external data pointer). It is used before after sending
+ *             a packet in the packetbuf, to be able to reuse the
+ *             packet buffer for a later retransmission.
+ *
+ */
+void packetbuf_clear_hdr(void);
+
+void packetbuf_hdr_remove(int bytes);
+
+/**
+ * \brief      Get a pointer to the data in the packetbuf
+ * \return     Pointer to the packetbuf data
+ *
+ *             This function is used to get a pointer to the data in
+ *             the packetbuf. The data is either stored in the packetbuf,
+ *             or referenced to an external location.
+ *
+ *             For outbound packets, the packetbuf consists of two
+ *             parts: header and data. The header is accessed with the
+ *             packetbuf_hdrptr() function.
+ *
+ *             For incoming packets, both the packet header and the
+ *             packet data is stored in the data portion of the
+ *             packetbuf. Thus this function is used to get a pointer to
+ *             the header for incoming packets.
+ *
+ */
+void *packetbuf_dataptr(void);
+
+/**
+ * \brief      Get a pointer to the header in the packetbuf, for outbound packets
+ * \return     Pointer to the packetbuf header
+ *
+ *             For outbound packets, the packetbuf consists of two
+ *             parts: header and data. This function is used to get a
+ *             pointer to the header in the packetbuf. The header is
+ *             stored in the packetbuf.
+ *
+ */
+void *packetbuf_hdrptr(void);
+
+/**
+ * \brief      Get the length of the header in the packetbuf, for outbound packets
+ * \return     Length of the header in the packetbuf
+ *
+ *             For outbound packets, the packetbuf consists of two
+ *             parts: header and data. This function is used to get
+ *             the length of the header in the packetbuf. The header is
+ *             stored in the packetbuf and accessed via the
+ *             packetbuf_hdrptr() function.
+ *
+ */
+uint8_t packetbuf_hdrlen(void);
+
+
+/**
+ * \brief      Get the length of the data in the packetbuf
+ * \return     Length of the data in the packetbuf
+ *
+ *             For outbound packets, the packetbuf consists of two
+ *             parts: header and data. This function is used to get
+ *             the length of the data in the packetbuf. The data is
+ *             stored in the packetbuf and accessed via the
+ *             packetbuf_dataptr() function.
+ *
+ *             For incoming packets, both the packet header and the
+ *             packet data is stored in the data portion of the
+ *             packetbuf. This function is then used to get the total
+ *             length of the packet - both header and data.
+ *
+ */
+uint16_t packetbuf_datalen(void);
+
+/**
+ * \brief      Get the total length of the header and data in the packetbuf
+ * \return     Length of data and header in the packetbuf
+ *
+ */
+uint16_t packetbuf_totlen(void);
+
+/**
+ * \brief      Set the length of the data in the packetbuf
+ * \param len  The length of the data
+ *
+ *             For outbound packets, the packetbuf consists of two
+ *             parts: header and data. This function is used to set
+ *             the length of the data in the packetbuf.
+ */
+void packetbuf_set_datalen(uint16_t len);
+
+/**
+ * \brief      Point the packetbuf to external data
+ * \param ptr  A pointer to the external data
+ * \param len  The length of the external data
+ *
+ *             For outbound packets, the packetbuf consists of two
+ *             parts: header and data. This function is used to make
+ *             the packetbuf point to external data. The function also
+ *             specifies the length of the external data that the
+ *             packetbuf references.
+ */
+void packetbuf_reference(void *ptr, uint16_t len);
+
+/**
+ * \brief      Check if the packetbuf references external data
+ * \retval     Non-zero if the packetbuf references external data, zero otherwise.
+ *
+ *             For outbound packets, the packetbuf consists of two
+ *             parts: header and data. This function is used to check
+ *             if the packetbuf points to external data that has
+ *             previously been referenced with packetbuf_reference().
+ *
+ */
+int packetbuf_is_reference(void);
+
+/**
+ * \brief      Get a pointer to external data referenced by the packetbuf
+ * \retval     A pointer to the external data
+ *
+ *             For outbound packets, the packetbuf consists of two
+ *             parts: header and data. The data may point to external
+ *             data that has previously been referenced with
+ *             packetbuf_reference(). This function is used to get a
+ *             pointer to the external data.
+ *
+ */
+void *packetbuf_reference_ptr(void);
+
+/**
+ * \brief      Compact the packetbuf
+ *
+ *             This function compacts the packetbuf by copying the data
+ *             portion of the packetbuf so that becomes consecutive to
+ *             the header. It also copies external data that has
+ *             previously been referenced with packetbuf_reference()
+ *             into the packetbuf.
+ *
+ *             This function is called by the Rime code before a
+ *             packet is to be sent by a device driver. This assures
+ *             that the entire packet is consecutive in memory.
+ *
+ */
+void packetbuf_compact(void);
+
+/**
+ * \brief      Copy from external data into the packetbuf
+ * \param from A pointer to the data from which to copy
+ * \param len  The size of the data to copy
+ * \retval     The number of bytes that was copied into the packetbuf
+ *
+ *             This function copies data from a pointer into the
+ *             packetbuf. If the data that is to be copied is larger
+ *             than the packetbuf, only the data that fits in the
+ *             packetbuf is copied. The number of bytes that could be
+ *             copied into the rimbuf is returned.
+ *
+ */
+int packetbuf_copyfrom(const void *from, uint16_t len);
+
+/**
+ * \brief      Copy the entire packetbuf to an external buffer
+ * \param to   A pointer to the buffer to which the data is to be copied
+ * \retval     The number of bytes that was copied to the external buffer
+ *
+ *             This function copies the packetbuf to an external
+ *             buffer. Both the data portion and the header portion of
+ *             the packetbuf is copied. If the packetbuf referenced
+ *             external data (referenced with packetbuf_reference()) the
+ *             external data is copied.
+ *
+ *             The external buffer to which the packetbuf is to be
+ *             copied must be able to accomodate at least
+ *             (PACKETBUF_SIZE + PACKETBUF_HDR_SIZE) bytes. The number of
+ *             bytes that was copied to the external buffer is
+ *             returned.
+ *
+ */
+int packetbuf_copyto(void *to);
+
+/**
+ * \brief      Copy the header portion of the packetbuf to an external buffer
+ * \param to   A pointer to the buffer to which the data is to be copied
+ * \retval     The number of bytes that was copied to the external buffer
+ *
+ *             This function copies the header portion of the packetbuf
+ *             to an external buffer.
+ *
+ *             The external buffer to which the packetbuf is to be
+ *             copied must be able to accomodate at least
+ *             PACKETBUF_HDR_SIZE bytes. The number of bytes that was
+ *             copied to the external buffer is returned.
+ *
+ */
+int packetbuf_copyto_hdr(uint8_t *to);
+
+/**
+ * \brief      Extend the header of the packetbuf, for outbound packets
+ * \param size The number of bytes the header should be extended
+ * \retval     Non-zero if the header could be extended, zero otherwise
+ *
+ *             This function is used to allocate extra space in the
+ *             header portion in the packetbuf, when preparing outbound
+ *             packets for transmission. If the function is unable to
+ *             allocate sufficient header space, the function returns
+ *             zero and does not allocate anything.
+ *
+ */
+int packetbuf_hdralloc(int size);
+
+/**
+ * \brief      Reduce the header in the packetbuf, for incoming packets
+ * \param size The number of bytes the header should be reduced
+ * \retval     Non-zero if the header could be reduced, zero otherwise
+ *
+ *             This function is used to remove the first part of the
+ *             header in the packetbuf, when processing incoming
+ *             packets. If the function is unable to remove the
+ *             requested amount of header space, the function returns
+ *             zero and does not allocate anything.
+ *
+ */
+int packetbuf_hdrreduce(int size);
+
+/* Packet attributes stuff below: */
+
+typedef uint16_t packetbuf_attr_t;
+
+struct packetbuf_attr {
+/*   uint8_t type; */
+  packetbuf_attr_t val;
+};
+struct packetbuf_addr {
+/*   uint8_t type; */
+  rimeaddr_t addr;
+};
+
+#define PACKETBUF_ATTR_PACKET_TYPE_DATA      0
+#define PACKETBUF_ATTR_PACKET_TYPE_ACK       1
+#define PACKETBUF_ATTR_PACKET_TYPE_STREAM    2
+#define PACKETBUF_ATTR_PACKET_TYPE_STREAM_END 3
+#define PACKETBUF_ATTR_PACKET_TYPE_TIMESTAMP 4
+
+enum {
+  PACKETBUF_ATTR_NONE,
+
+  /* Scope 0 attributes: used only on the local node. */
+  PACKETBUF_ATTR_CHANNEL,
+  PACKETBUF_ATTR_NETWORK_ID,
+  PACKETBUF_ATTR_LINK_QUALITY,
+  PACKETBUF_ATTR_RSSI,
+  PACKETBUF_ATTR_TIMESTAMP,
+  PACKETBUF_ATTR_RADIO_TXPOWER,
+  PACKETBUF_ATTR_LISTEN_TIME,
+  PACKETBUF_ATTR_TRANSMIT_TIME,
+  PACKETBUF_ATTR_MAX_MAC_TRANSMISSIONS,
+  PACKETBUF_ATTR_MAC_SEQNO,
+  PACKETBUF_ATTR_MAC_ACK,
+
+  /* Scope 1 attributes: used between two neighbors only. */
+  PACKETBUF_ATTR_RELIABLE,
+  PACKETBUF_ATTR_PACKET_ID,
+  PACKETBUF_ATTR_PACKET_TYPE,
+  PACKETBUF_ATTR_REXMIT,
+  PACKETBUF_ATTR_MAX_REXMIT,
+  PACKETBUF_ATTR_NUM_REXMIT,
+  PACKETBUF_ATTR_PENDING,
+  
+  /* Scope 2 attributes: used between end-to-end nodes. */
+  PACKETBUF_ATTR_HOPS,
+  PACKETBUF_ATTR_TTL,
+  PACKETBUF_ATTR_EPACKET_ID,
+  PACKETBUF_ATTR_EPACKET_TYPE,
+  PACKETBUF_ATTR_ERELIABLE,
+
+  /* These must be last */
+  PACKETBUF_ADDR_SENDER,
+  PACKETBUF_ADDR_RECEIVER,
+  PACKETBUF_ADDR_ESENDER,
+  PACKETBUF_ADDR_ERECEIVER,
+  
+  PACKETBUF_ATTR_MAX
+};
+
+#define PACKETBUF_NUM_ADDRS 4
+#define PACKETBUF_NUM_ATTRS (PACKETBUF_ATTR_MAX - PACKETBUF_NUM_ADDRS)
+#define PACKETBUF_ADDR_FIRST PACKETBUF_ADDR_SENDER
+
+#define PACKETBUF_IS_ADDR(type) ((type) >= PACKETBUF_ADDR_FIRST)
+
+#if PACKETBUF_CONF_ATTRS_INLINE
+
+extern struct packetbuf_attr packetbuf_attrs[];
+extern struct packetbuf_addr packetbuf_addrs[];
+
+static int               packetbuf_set_attr(uint8_t type, const packetbuf_attr_t val);
+static packetbuf_attr_t    packetbuf_attr(uint8_t type);
+static int               packetbuf_set_addr(uint8_t type, const rimeaddr_t *addr);
+static const rimeaddr_t *packetbuf_addr(uint8_t type);
+
+static inline int
+packetbuf_set_attr(uint8_t type, const packetbuf_attr_t val)
+{
+/*   packetbuf_attrs[type].type = type; */
+  packetbuf_attrs[type].val = val;
+  return 1;
+}
+static inline packetbuf_attr_t
+packetbuf_attr(uint8_t type)
+{
+  return packetbuf_attrs[type].val;
+}
+
+static inline int
+packetbuf_set_addr(uint8_t type, const rimeaddr_t *addr)
+{
+/*   packetbuf_addrs[type - PACKETBUF_ADDR_FIRST].type = type; */
+  rimeaddr_copy(&packetbuf_addrs[type - PACKETBUF_ADDR_FIRST].addr, addr);
+  return 1;
+}
+
+static inline const rimeaddr_t *
+packetbuf_addr(uint8_t type)
+{
+  return &packetbuf_addrs[type - PACKETBUF_ADDR_FIRST].addr;
+}
+#else /* PACKETBUF_CONF_ATTRS_INLINE */
+int               packetbuf_set_attr(uint8_t type, const packetbuf_attr_t val);
+packetbuf_attr_t packetbuf_attr(uint8_t type);
+int               packetbuf_set_addr(uint8_t type, const rimeaddr_t *addr);
+const rimeaddr_t *packetbuf_addr(uint8_t type);
+#endif /* PACKETBUF_CONF_ATTRS_INLINE */
+
+void              packetbuf_attr_clear(void);
+
+void              packetbuf_attr_copyto(struct packetbuf_attr *attrs,
+				      struct packetbuf_addr *addrs);
+void              packetbuf_attr_copyfrom(struct packetbuf_attr *attrs,
+					struct packetbuf_addr *addrs);
+
+#define PACKETBUF_ATTRIBUTES(...) { __VA_ARGS__ PACKETBUF_ATTR_LAST }
+#define PACKETBUF_ATTR_LAST { PACKETBUF_ATTR_NONE, 0 }
+
+#define PACKETBUF_ATTR_BIT  1
+#define PACKETBUF_ATTR_BYTE 8
+#define PACKETBUF_ADDRSIZE (sizeof(rimeaddr_t) * PACKETBUF_ATTR_BYTE)
+
+struct packetbuf_attrlist {
+  uint8_t type;
+  uint8_t len;
+};
+
+#endif /* __PACKETBUF_H__ */
+/** @} */
+/** @} */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/packetbuf_d.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/packetbuf_d.h
@@ -1,0 +1,39 @@
+/*****************************************************************************
+*
+* Filename:         packetbuf_d.h
+* Author:           Christian Schlittler
+* Version:          1.0
+* Creation date:	18.11.2013
+*
+* Copyright:        Christian Schlittler, christian.schlittler@gmx.ch
+*
+* Project:			XMOS and 6LoWPAN
+* Target:			XMOS sliceKIT with RFSlice extension
+* Compiler:        
+*
+* -----------------------------------------------------------------------------
+*
+* History:
+*
+* -----------------------------------------------------------------------------
+*
+* Usage:
+*
+**************************************************************************** */
+
+#ifndef PACKETBUF_D_H_
+#define PACKETBUF_D_H_
+
+#include <stdint.h>
+#include <xccompat.h>
+#include "net/rime/rimeaddr.h"
+
+enum{
+    PACKETBUF_D_ADDR_SENDER,
+};
+
+int               packetbuf_d_set_addr(uint8_t type, NULLABLE_ARRAY_OF(const rimeaddr_t, addr));
+#if !__XC__
+const rimeaddr_t *packetbuf_d_addr(uint8_t type);
+#endif /* __XC__ */
+#endif /* PACKETBUF_D_H_ */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/packetubf_d.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/packetubf_d.c
@@ -1,0 +1,59 @@
+/*****************************************************************************
+*
+* Filename:         packetubf_d.c
+* Author:           Christian Schlittler
+* Version:          1.0
+* Creation date:	18.11.2013
+*
+* Copyright:        Christian Schlittler, christian.schlittler@gmx.ch
+*
+* Project:			XMOS and 6LoWPAN
+* Target:			XMOS sliceKIT with RFSlice extension
+* Compiler:        
+*
+* -----------------------------------------------------------------------------
+*
+* History:
+*
+* The package buffer is based on the sources of contiki-os. The problem was, that
+* contiki-os runs on a single core, shared memory cpu. But, for the XMOS implementation
+* this is not true. The MAC and the IPv6 stack could be on different tiles with
+* no shared memory.
+* The RPL alogrithm needs access to the sender MAC address and normally this is
+* done by the shared packet buffer. So, here we need to copy the address in a
+* dummy packet buffer.
+*
+* -----------------------------------------------------------------------------
+*
+* Usage:
+*
+**************************************************************************** */
+
+#include <string.h>
+#include "net/packetbuf_d.h"
+
+static rimeaddr_t packetbuf_d_addr_sender;
+
+int packetbuf_d_set_addr(uint8_t type, const rimeaddr_t *addr){
+
+    switch(type){
+    case PACKETBUF_D_ADDR_SENDER:
+        memcpy(&packetbuf_d_addr_sender, addr, sizeof(rimeaddr_t));
+        return 1;
+        break;
+
+    default:
+        return 0;
+        break;
+    }
+
+}
+
+/*----------------------------------------------------------------------------*/
+const rimeaddr_t *packetbuf_d_addr(uint8_t type){
+    if(type == PACKETBUF_D_ADDR_SENDER){
+        return &packetbuf_d_addr_sender;
+    } else {
+        return NULL;
+    }
+}

--- a/module_xtcp/src/xtcp_uip6/contiki/net/psock.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/psock.c
@@ -1,0 +1,346 @@
+// Copyright (c) 2011, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+
+/*
+ * Copyright (c) 2004, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the uIP TCP/IP stack
+ *
+ * Author: Adam Dunkels <adam@sics.se>
+ *
+ * $Id: psock.c,v 1.2 2006/06/12 08:00:30 adam Exp $
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "uipopt.h"
+#include "psock.h"
+#include "uip.h"
+
+#define STATE_NONE 0
+#define STATE_ACKED 1
+#define STATE_READ 2
+#define STATE_BLOCKED_NEWDATA 3
+#define STATE_BLOCKED_CLOSE 4
+#define STATE_BLOCKED_SEND 5
+#define STATE_DATA_SENT 6
+
+/*
+ * Return value of the buffering functions that indicates that a
+ * buffer was not filled by incoming data.
+ *
+ */
+#define BUF_NOT_FULL 0
+#define BUF_NOT_FOUND 0
+
+/*
+ * Return value of the buffering functions that indicates that a
+ * buffer was completely filled by incoming data.
+ *
+ */
+#define BUF_FULL 1
+
+/*
+ * Return value of the buffering functions that indicates that an
+ * end-marker byte was found.
+ *
+ */
+#define BUF_FOUND 2
+
+/*---------------------------------------------------------------------------*/
+static void
+buf_setup(struct psock_buf *buf,
+	  uint8_t *bufptr, uint16_t bufsize)
+{
+  buf->ptr = bufptr;
+  buf->left = bufsize;
+}
+/*---------------------------------------------------------------------------*/
+static uint8_t
+buf_bufdata(struct psock_buf *buf, uint16_t len,
+	    uint8_t **dataptr, uint16_t *datalen)
+{
+  if(*datalen < buf->left) {
+    memcpy(buf->ptr, *dataptr, *datalen);
+    buf->ptr += *datalen;
+    buf->left -= *datalen;
+    *dataptr += *datalen;
+    *datalen = 0;
+    return BUF_NOT_FULL;
+  } else if(*datalen == buf->left) {
+    memcpy(buf->ptr, *dataptr, *datalen);
+    buf->ptr += *datalen;
+    buf->left = 0;
+    *dataptr += *datalen;
+    *datalen = 0;
+    return BUF_FULL;
+  } else {
+    memcpy(buf->ptr, *dataptr, buf->left);
+    buf->ptr += buf->left;
+    *datalen -= buf->left;
+    *dataptr += buf->left;
+    buf->left = 0;
+    return BUF_FULL;
+  }
+}
+/*---------------------------------------------------------------------------*/
+static uint8_t
+buf_bufto(register struct psock_buf *buf, uint8_t endmarker,
+	  register uint8_t **dataptr, register uint16_t *datalen)
+{
+  uint8_t c;
+  while(buf->left > 0 && *datalen > 0) {
+    c = *buf->ptr = **dataptr;
+    ++*dataptr;
+    ++buf->ptr;
+    --*datalen;
+    --buf->left;
+    
+    if(c == endmarker) {
+      return BUF_FOUND;
+    }
+  }
+
+  if(*datalen == 0) {
+    return BUF_NOT_FOUND;
+  }
+
+  while(*datalen > 0) {
+    c = **dataptr;
+    --*datalen;
+    ++*dataptr;
+    
+    if(c == endmarker) {
+      return BUF_FOUND | BUF_FULL;
+    }
+  }
+  
+  return BUF_FULL;
+}
+/*---------------------------------------------------------------------------*/
+static char
+send_data(register struct psock *s)
+{
+  if(s->state != STATE_DATA_SENT || uip_rexmit()) {
+    if(s->sendlen > uip_mss()) {
+      uip_send(s->sendptr, uip_mss());
+    } else {
+      uip_send(s->sendptr, s->sendlen);
+    }
+    s->state = STATE_DATA_SENT;
+    return 1;
+  }
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+static char
+data_acked(register struct psock *s)
+{
+  if(s->state == STATE_DATA_SENT && uip_acked()) {
+    if(s->sendlen > uip_mss()) {
+      s->sendlen -= uip_mss();
+      s->sendptr += uip_mss();
+    } else {
+      s->sendptr += s->sendlen;
+      s->sendlen = 0;
+    }
+    s->state = STATE_ACKED;
+    return 1;
+  }
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+PT_THREAD(psock_send(register struct psock *s, const char *buf,
+		     unsigned int len))
+{
+  PT_BEGIN(&s->psockpt);
+
+  /* If there is no data to send, we exit immediately. */
+  if(len == 0) {
+    PT_EXIT(&s->psockpt);
+  }
+
+  /* Save the length of and a pointer to the data that is to be
+     sent. */
+  s->sendptr = (unsigned char *) buf;
+  s->sendlen = len;
+
+  s->state = STATE_NONE;
+
+  /* We loop here until all data is sent. The s->sendlen variable is
+     updated by the data_sent() function. */
+  while(s->sendlen > 0) {
+
+    /*
+     * The condition for this PT_WAIT_UNTIL is a little tricky: the
+     * protothread will wait here until all data has been acknowledged
+     * (data_acked() returns true) and until all data has been sent
+     * (send_data() returns true). The two functions data_acked() and
+     * send_data() must be called in succession to ensure that all
+     * data is sent. Therefore the & operator is used instead of the
+     * && operator, which would cause only the data_acked() function
+     * to be called when it returns false.
+     */
+    PT_WAIT_UNTIL(&s->psockpt, data_acked(s) & send_data(s));
+  }
+
+  s->state = STATE_NONE;
+  
+  PT_END(&s->psockpt);
+}
+/*---------------------------------------------------------------------------*/
+#pragma stackfunction 20
+PT_THREAD(psock_generator_send(register struct psock *s,
+			       unsigned short (*generate)(void *), void *arg))
+{
+  PT_BEGIN(&s->psockpt);
+
+  /* Ensure that there is a generator function to call. */
+  if(generate == NULL) {
+    PT_EXIT(&s->psockpt);
+  }
+
+  /* Call the generator function to generate the data in the
+     uip_appdata buffer. */
+  s->sendlen = generate(arg);
+  s->sendptr = uip_appdata;
+
+  s->state = STATE_NONE;  
+  do {
+    /* Call the generator function again if we are called to perform a
+       retransmission. */
+    if(uip_rexmit()) {
+      generate(arg);
+    }
+    /* Wait until all data is sent and acknowledged. */
+    PT_WAIT_UNTIL(&s->psockpt, data_acked(s) & send_data(s));
+  } while(s->sendlen > 0);
+  
+  s->state = STATE_NONE;
+  
+  PT_END(&s->psockpt);
+}
+/*---------------------------------------------------------------------------*/
+uint16_t
+psock_datalen(struct psock *psock)
+{
+  return psock->bufsize - psock->buf.left;
+}
+/*---------------------------------------------------------------------------*/
+char
+psock_newdata(struct psock *s)
+{
+  if(s->readlen > 0) {
+    /* There is data in the uip_appdata buffer that has not yet been
+       read with the PSOCK_READ functions. */
+    return 1;
+  } else if(s->state == STATE_READ) {
+    /* All data in uip_appdata buffer already consumed. */
+    s->state = STATE_BLOCKED_NEWDATA;
+    return 0;
+  } else if(uip_newdata()) {
+    /* There is new data that has not been consumed. */
+    return 1;
+  } else {
+    /* There is no new data. */
+    return 0;
+  }
+}
+/*---------------------------------------------------------------------------*/
+PT_THREAD(psock_readto(register struct psock *psock, unsigned char c))
+{
+  PT_BEGIN(&psock->psockpt);
+
+  buf_setup(&psock->buf, (unsigned char *) psock->bufptr, psock->bufsize);
+  
+  /* XXX: Should add buf_checkmarker() before do{} loop, if
+     incoming data has been handled while waiting for a write. */
+
+  do {
+    if(psock->readlen == 0) {
+      PT_WAIT_UNTIL(&psock->psockpt, psock_newdata(psock));
+      psock->state = STATE_READ;
+      psock->readptr = (uint8_t *)uip_appdata;
+      psock->readlen = uip_datalen();
+    }
+  } while((buf_bufto(&psock->buf, c,
+		     &psock->readptr,
+		     &psock->readlen) & BUF_FOUND) == 0);
+  
+  if(psock_datalen(psock) == 0) {
+    psock->state = STATE_NONE;
+    PT_RESTART(&psock->psockpt);
+  }
+  PT_END(&psock->psockpt);
+}
+/*---------------------------------------------------------------------------*/
+PT_THREAD(psock_readbuf(register struct psock *psock))
+{
+  PT_BEGIN(&psock->psockpt);
+
+  buf_setup(&psock->buf, (unsigned char *)psock->bufptr, psock->bufsize);
+  
+  /* XXX: Should add buf_checkmarker() before do{} loop, if
+     incoming data has been handled while waiting for a write. */
+  
+  /* read len bytes or to end of data */
+  do {
+    if(psock->readlen == 0) {
+      PT_WAIT_UNTIL(&psock->psockpt, psock_newdata(psock));
+      psock->state = STATE_READ;
+      psock->readptr = (uint8_t *)uip_appdata;
+      psock->readlen = uip_datalen();
+    }
+  } while(buf_bufdata(&psock->buf, psock->bufsize,
+			 &psock->readptr,
+			 &psock->readlen) != BUF_FULL);
+
+  if(psock_datalen(psock) == 0) {
+    psock->state = STATE_NONE;
+    PT_RESTART(&psock->psockpt);
+  }
+  PT_END(&psock->psockpt);
+}
+
+/*---------------------------------------------------------------------------*/
+void
+psock_init(register struct psock *psock, char *buffer, unsigned int buffersize)
+{
+  psock->state = STATE_NONE;
+  psock->readlen = 0;
+  psock->bufptr = buffer;
+  psock->bufsize = buffersize;
+  buf_setup(&psock->buf, (unsigned char *) buffer, buffersize);
+  PT_INIT(&psock->pt);
+  PT_INIT(&psock->psockpt);
+}
+/*---------------------------------------------------------------------------*/

--- a/module_xtcp/src/xtcp_uip6/contiki/net/psock.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/psock.h
@@ -1,0 +1,387 @@
+// Copyright (c) 2011, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+
+/*
+ * Copyright (c) 2004, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the uIP TCP/IP stack
+ *
+ * Author: Adam Dunkels <adam@sics.se>
+ *
+ * $Id: psock.h,v 1.3 2006/06/12 08:00:30 adam Exp $
+ */
+
+/**
+ * \defgroup psock Protosockets library
+ * @{
+ *
+ * The protosocket library provides an interface to the uIP stack that is
+ * similar to the traditional BSD socket interface. Unlike programs
+ * written for the ordinary uIP event-driven interface, programs
+ * written with the protosocket library are executed in a sequential
+ * fashion and does not have to be implemented as explicit state
+ * machines.
+ *
+ * Protosockets only work with TCP connections.
+ *
+ * The protosocket library uses \ref pt protothreads to provide
+ * sequential control flow. This makes the protosockets lightweight in
+ * terms of memory, but also means that protosockets inherits the
+ * functional limitations of protothreads. Each protosocket lives only
+ * within a single function. Automatic variables (stack variables) are
+ * not retained across a protosocket library function call.
+ *
+ * \note Because the protosocket library uses protothreads, local
+ * variables will not always be saved across a call to a protosocket
+ * library function. It is therefore advised that local variables are
+ * used with extreme care.
+ *
+ * The protosocket library provides functions for sending data without
+ * having to deal with retransmissions and acknowledgements, as well
+ * as functions for reading data without having to deal with data
+ * being split across more than one TCP segment.
+ *
+ * Because each protosocket runs as a protothread, the protosocket has to be
+ * started with a call to PSOCK_BEGIN() at the start of the function
+ * in which the protosocket is used. Similarly, the protosocket protothread can
+ * be terminated by a call to PSOCK_EXIT().
+ *
+ */
+
+/**
+ * \file
+ * Protosocket library header file
+ * \author
+ * Adam Dunkels <adam@sics.se>
+ *
+ */
+
+#ifndef __PSOCK_H__
+#define __PSOCK_H__
+
+#include "uipopt.h"
+#include "pt.h"
+
+ /*
+ * The structure that holds the state of a buffer.
+ *
+ * This structure holds the state of a uIP buffer. The structure has
+ * no user-visible elements, but is used through the functions
+ * provided by the library.
+ *
+ */
+struct psock_buf {
+  uint8_t *ptr;
+  unsigned short left;
+};
+
+/**
+ * The representation of a protosocket.
+ *
+ * The protosocket structrure is an opaque structure with no user-visible
+ * elements.
+ */
+struct psock {
+  struct pt pt, psockpt; /* Protothreads - one that's using the psock
+			    functions, and one that runs inside the
+			    psock functions. */
+  const uint8_t *sendptr;   /* Pointer to the next data to be sent. */
+  uint8_t *readptr;         /* Pointer to the next data to be read. */
+  
+  char *bufptr;          /* Pointer to the buffer used for buffering
+			    incoming data. */
+  
+  uint16_t sendlen;         /* The number of bytes left to be sent. */
+  uint16_t readlen;         /* The number of bytes left to be read. */
+
+  struct psock_buf buf;  /* The structure holding the state of the
+			    input buffer. */
+  unsigned int bufsize;  /* The size of the input buffer. */
+  
+  unsigned char state;   /* The state of the protosocket. */
+};
+
+void psock_init(struct psock *psock, char *buffer, unsigned int buffersize);
+/**
+ * Initialize a protosocket.
+ *
+ * This macro initializes a protosocket and must be called before the
+ * protosocket is used. The initialization also specifies the input buffer
+ * for the protosocket.
+ *
+ * \param psock (struct psock *) A pointer to the protosocket to be
+ * initialized
+ *
+ * \param buffer (char *) A pointer to the input buffer for the
+ * protosocket.
+ *
+ * \param buffersize (unsigned int) The size of the input buffer.
+ *
+ * \hideinitializer
+ */
+#define PSOCK_INIT(psock, buffer, buffersize) \
+  psock_init(psock, buffer, buffersize)
+
+/**
+ * Start the protosocket protothread in a function.
+ *
+ * This macro starts the protothread associated with the protosocket and
+ * must come before other protosocket calls in the function it is used.
+ *
+ * \param psock (struct psock *) A pointer to the protosocket to be
+ * started.
+ *
+ * \hideinitializer
+ */
+#define PSOCK_BEGIN(psock) PT_BEGIN(&((psock)->pt))
+
+PT_THREAD(psock_send(struct psock *psock, const char *buf, unsigned int len));
+/**
+ * Send data.
+ *
+ * This macro sends data over a protosocket. The protosocket protothread blocks
+ * until all data has been sent and is known to have been received by
+ * the remote end of the TCP connection.
+ *
+ * \param psock (struct psock *) A pointer to the protosocket over which
+ * data is to be sent.
+ *
+ * \param data (char *) A pointer to the data that is to be sent.
+ *
+ * \param datalen (unsigned int) The length of the data that is to be
+ * sent.
+ *
+ * \hideinitializer
+ */
+#define PSOCK_SEND(psock, data, datalen)		\
+    PT_WAIT_THREAD(&((psock)->pt), psock_send(psock, data, datalen))
+
+/**
+ * \brief      Send a null-terminated string.
+ * \param psock Pointer to the protosocket.
+ * \param str  The string to be sent.
+ *
+ *             This function sends a null-terminated string over the
+ *             protosocket.
+ *
+ * \hideinitializer
+ */
+#define PSOCK_SEND_STR(psock, str)      		\
+    PT_WAIT_THREAD(&((psock)->pt), psock_send(psock, str, strlen(str)))
+
+PT_THREAD(psock_generator_send(struct psock *psock,
+				unsigned short (*f)(void *), void *arg));
+
+/**
+ * \brief      Generate data with a function and send it
+ * \param psock Pointer to the protosocket.
+ * \param generator Pointer to the generator function
+ * \param arg   Argument to the generator function
+ *
+ *             This function generates data and sends it over the
+ *             protosocket. This can be used to dynamically generate
+ *             data for a transmission, instead of generating the data
+ *             in a buffer beforehand. This function reduces the need for
+ *             buffer memory. The generator function is implemented by
+ *             the application, and a pointer to the function is given
+ *             as an argument with the call to PSOCK_GENERATOR_SEND().
+ *
+ *             The generator function should place the generated data
+ *             directly in the uip_appdata buffer, and return the
+ *             length of the generated data. The generator function is
+ *             called by the protosocket layer when the data first is
+ *             sent, and once for every retransmission that is needed.
+ *
+ * \hideinitializer
+ */
+#define PSOCK_GENERATOR_SEND(psock, generator, arg)     \
+    PT_WAIT_THREAD(&((psock)->pt),					\
+		   psock_generator_send(psock, generator, arg))
+
+
+/**
+ * Close a protosocket.
+ *
+ * This macro closes a protosocket and can only be called from within the
+ * protothread in which the protosocket lives.
+ *
+ * \param psock (struct psock *) A pointer to the protosocket that is to
+ * be closed.
+ *
+ * \hideinitializer
+ */
+#define PSOCK_CLOSE(psock) uip_close()
+
+PT_THREAD(psock_readbuf(struct psock *psock));
+/**
+ * Read data until the buffer is full.
+ *
+ * This macro will block waiting for data and read the data into the
+ * input buffer specified with the call to PSOCK_INIT(). Data is read
+ * until the buffer is full..
+ *
+ * \param psock (struct psock *) A pointer to the protosocket from which
+ * data should be read.
+ *
+ * \hideinitializer
+ */
+#define PSOCK_READBUF(psock)				\
+  PT_WAIT_THREAD(&((psock)->pt), psock_readbuf(psock))
+
+PT_THREAD(psock_readto(struct psock *psock, unsigned char c));
+/**
+ * Read data up to a specified character.
+ *
+ * This macro will block waiting for data and read the data into the
+ * input buffer specified with the call to PSOCK_INIT(). Data is only
+ * read until the specified character appears in the data stream.
+ *
+ * \param psock (struct psock *) A pointer to the protosocket from which
+ * data should be read.
+ *
+ * \param c (char) The character at which to stop reading.
+ *
+ * \hideinitializer
+ */
+#define PSOCK_READTO(psock, c)				\
+  PT_WAIT_THREAD(&((psock)->pt), psock_readto(psock, c))
+
+/**
+ * The length of the data that was previously read.
+ *
+ * This macro returns the length of the data that was previously read
+ * using PSOCK_READTO() or PSOCK_READ().
+ *
+ * \param psock (struct psock *) A pointer to the protosocket holding the data.
+ *
+ * \hideinitializer
+ */
+#define PSOCK_DATALEN(psock) psock_datalen(psock)
+
+uint16_t psock_datalen(struct psock *psock);
+
+/**
+ * Exit the protosocket's protothread.
+ *
+ * This macro terminates the protothread of the protosocket and should
+ * almost always be used in conjunction with PSOCK_CLOSE().
+ *
+ * \sa PSOCK_CLOSE_EXIT()
+ *
+ * \param psock (struct psock *) A pointer to the protosocket.
+ *
+ * \hideinitializer
+ */
+#define PSOCK_EXIT(psock) PT_EXIT(&((psock)->pt))
+
+/**
+ * Close a protosocket and exit the protosocket's protothread.
+ *
+ * This macro closes a protosocket and exits the protosocket's protothread.
+ *
+ * \param psock (struct psock *) A pointer to the protosocket.
+ *
+ * \hideinitializer
+ */
+#define PSOCK_CLOSE_EXIT(psock)		\
+  do {						\
+    PSOCK_CLOSE(psock);			\
+    PSOCK_EXIT(psock);			\
+  } while(0)
+
+/**
+ * Declare the end of a protosocket's protothread.
+ *
+ * This macro is used for declaring that the protosocket's protothread
+ * ends. It must always be used together with a matching PSOCK_BEGIN()
+ * macro.
+ *
+ * \param psock (struct psock *) A pointer to the protosocket.
+ *
+ * \hideinitializer
+ */
+#define PSOCK_END(psock) PT_END(&((psock)->pt))
+
+char psock_newdata(struct psock *s);
+
+/**
+ * Check if new data has arrived on a protosocket.
+ *
+ * This macro is used in conjunction with the PSOCK_WAIT_UNTIL()
+ * macro to check if data has arrived on a protosocket.
+ *
+ * \param psock (struct psock *) A pointer to the protosocket.
+ *
+ * \hideinitializer
+ */
+#define PSOCK_NEWDATA(psock) psock_newdata(psock)
+
+/**
+ * Wait until a condition is true.
+ *
+ * This macro blocks the protothread until the specified condition is
+ * true. The macro PSOCK_NEWDATA() can be used to check if new data
+ * arrives when the protosocket is waiting.
+ *
+ * Typically, this macro is used as follows:
+ *
+ \code
+ PT_THREAD(thread(struct psock *s, struct uip_timer *t))
+ {
+   PSOCK_BEGIN(s);
+
+   PSOCK_WAIT_UNTIL(s, PSOCK_NEWADATA(s) || timer_expired(t));
+   
+   if(PSOCK_NEWDATA(s)) {
+     PSOCK_READTO(s, '\n');
+   } else {
+     handle_timed_out(s);
+   }
+   
+   PSOCK_END(s);
+ }
+ \endcode
+ *
+ * \param psock (struct psock *) A pointer to the protosocket.
+ * \param condition The condition to wait for.
+ *
+ * \hideinitializer
+ */
+#define PSOCK_WAIT_UNTIL(psock, condition)    \
+  PT_WAIT_UNTIL(&((psock)->pt), (condition));
+
+#define PSOCK_WAIT_THREAD(psock, condition)   \
+  PT_WAIT_THREAD(&((psock)->pt), (condition))
+
+#endif /* __PSOCK_H__ */
+
+/** @} */
+/** @} */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/rime/rimeaddr.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/rime/rimeaddr.c
@@ -1,0 +1,77 @@
+/**
+ * \addtogroup rimeaddr
+ * @{
+ */
+
+/*
+ * Copyright (c) 2007, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+/**
+ * \file
+ *         Functions for manipulating Rime addresses
+ * \author
+ *         Adam Dunkels <adam@sics.se>
+ */
+
+#include "net/rime/rimeaddr.h"
+#include <string.h>
+
+rimeaddr_t rimeaddr_node_addr;
+#if RIMEADDR_SIZE == 2
+const rimeaddr_t rimeaddr_null = { { 0, 0 } };
+#else /*RIMEADDR_SIZE == 2*/
+#if RIMEADDR_SIZE == 8
+const rimeaddr_t rimeaddr_null = { { 0, 0, 0, 0, 0, 0, 0, 0 } };
+#endif /*RIMEADDR_SIZE == 8*/
+#endif /*RIMEADDR_SIZE == 2*/
+
+
+/*---------------------------------------------------------------------------*/
+void
+rimeaddr_copy(rimeaddr_t *dest, const rimeaddr_t *src)
+{
+	memcpy(dest, src, RIMEADDR_SIZE);
+}
+/*---------------------------------------------------------------------------*/
+int
+rimeaddr_cmp(const rimeaddr_t *addr1, const rimeaddr_t *addr2)
+{
+	return (memcmp(addr1, addr2, RIMEADDR_SIZE) == 0);
+}
+/*---------------------------------------------------------------------------*/
+void
+rimeaddr_set_node_addr(rimeaddr_t *t)
+{
+  rimeaddr_copy(&rimeaddr_node_addr, t);
+}
+/*---------------------------------------------------------------------------*/
+/** @} */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/rime/rimeaddr.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/rime/rimeaddr.h
@@ -1,0 +1,131 @@
+/**
+ * \addtogroup rime
+ * @{
+ */
+
+/**
+ * \defgroup rimeaddr Rime addresses
+ * @{
+ *
+ * The rimeaddr module is an abstract representation of addresses in
+ * Rime.
+ *
+ */
+
+/*
+ * Copyright (c) 2007, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+/**
+ * \file
+ *         Header file for the Rime address representation
+ * \author
+ *         Adam Dunkels <adam@sics.se>
+ */
+
+#ifndef __RIMEADDR_H__
+#define __RIMEADDR_H__
+
+#include "uip-conf.h"
+
+#ifdef RIMEADDR_CONF_SIZE
+#define RIMEADDR_SIZE RIMEADDR_CONF_SIZE
+#else /* RIMEADDR_SIZE */
+#define RIMEADDR_SIZE 2
+#endif /* RIMEADDR_SIZE */
+
+typedef union {
+  unsigned char u8[RIMEADDR_SIZE];
+} rimeaddr_t;
+
+
+/**
+ * \brief      Copy a Rime address
+ * \param dest The destination
+ * \param from The source
+ *
+ *             This function copies a Rime address from one location
+ *             to another.
+ *
+ */
+void rimeaddr_copy(rimeaddr_t *dest, const rimeaddr_t *from);
+
+/**
+ * \brief      Compare two Rime addresses
+ * \param addr1 The first address
+ * \param addr2 The second address
+ * \return     Non-zero if the addresses are the same, zero if they are different
+ *
+ *             This function compares two Rime addresses and returns
+ *             the result of the comparison. The function acts like
+ *             the '==' operator and returns non-zero if the addresses
+ *             are the same, and zero if the addresses are different.
+ *
+ */
+int rimeaddr_cmp(const rimeaddr_t *addr1, const rimeaddr_t *addr2);
+
+
+/**
+ * \brief      Set the address of the current node
+ * \param addr The address
+ *
+ *             This function sets the Rime address of the node.
+ *
+ */
+void rimeaddr_set_node_addr(rimeaddr_t *addr);
+
+/**
+ * \brief      The Rime address of the node
+ *
+ *             This variable contains the Rime address of the
+ *             node. This variable should not be changed directly;
+ *             rather, the rimeaddr_set_node_addr() function should be
+ *             used.
+ *
+ */
+extern rimeaddr_t rimeaddr_node_addr;
+
+/**
+ * \brief      The null Rime address
+ *
+ *             This variable contains the null Rime address. The null
+ *             address is used in route tables to indicate that the
+ *             table entry is unused. Nodes with no configured address
+ *             has the null address. Nodes with their node address set
+ *             to the null address will have problems communicating
+ *             with other nodes.
+ *
+ */
+extern const rimeaddr_t rimeaddr_null;
+
+#endif /* __RIMEADDR_H__ */
+/** @} */
+/** @} */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/rpl/rpl-conf.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/rpl/rpl-conf.h
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2010, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ * \file
+ *	Public configuration and API declarations for ContikiRPL.
+ * \author
+ *	Joakim Eriksson <joakime@sics.se> & Nicolas Tsiftes <nvt@sics.se>
+ *
+ */
+
+#ifndef RPL_CONF_H
+#define RPL_CONF_H
+
+#include "uip-conf.h"
+
+/* Set to 1 to enable RPL statistics */
+#ifndef RPL_CONF_STATS
+#define RPL_CONF_STATS 0
+#endif /* RPL_CONF_STATS */
+
+/* 
+ * Select routing metric supported at runtime. This must be a valid
+ * DAG Metric Container Object Type (see below). Currently, we only 
+ * support RPL_DAG_MC_ETX and RPL_DAG_MC_ENERGY.
+ * When MRHOF (RFC6719) is used with ETX, no metric container must
+ * be used; instead the rank carries ETX directly.
+ */
+#ifdef RPL_CONF_DAG_MC
+#define RPL_DAG_MC RPL_CONF_DAG_MC
+#else
+#define RPL_DAG_MC RPL_DAG_MC_NONE
+#endif /* RPL_CONF_DAG_MC */
+
+/*
+ * The objective function used by RPL is configurable through the 
+ * RPL_CONF_OF parameter. This should be defined to be the name of an 
+ * rpl_of object linked into the system image, e.g., rpl_of0.
+ */
+#ifdef RPL_CONF_OF
+#define RPL_OF RPL_CONF_OF
+#else
+/* ETX is the default objective function. */
+#define RPL_OF rpl_mrhof
+#endif /* RPL_CONF_OF */
+
+/* This value decides which DAG instance we should participate in by default. */
+#ifdef RPL_CONF_DEFAULT_INSTANCE
+#define RPL_DEFAULT_INSTANCE RPL_CONF_DEFAULT_INSTANCE
+#else
+#define RPL_DEFAULT_INSTANCE	       0x1e
+#endif /* RPL_CONF_DEFAULT_INSTANCE */
+
+/*
+ * This value decides if this node must stay as a leaf or not
+ * as allowed by draft-ietf-roll-rpl-19#section-8.5
+ */
+#ifdef RPL_CONF_LEAF_ONLY
+#define RPL_LEAF_ONLY RPL_CONF_LEAF_ONLY
+#else
+#define RPL_LEAF_ONLY 0
+#endif
+
+/*
+ * Maximum of concurent RPL instances.
+ */
+#ifdef RPL_CONF_MAX_INSTANCES
+#define RPL_MAX_INSTANCES     RPL_CONF_MAX_INSTANCES
+#else
+#define RPL_MAX_INSTANCES     1
+#endif /* RPL_CONF_MAX_INSTANCES */
+
+/*
+ * Maximum number of DAGs within an instance.
+ */
+#ifdef RPL_CONF_MAX_DAG_PER_INSTANCE
+#define RPL_MAX_DAG_PER_INSTANCE     RPL_CONF_MAX_DAG_PER_INSTANCE
+#else
+#define RPL_MAX_DAG_PER_INSTANCE     2
+#endif /* RPL_CONF_MAX_DAG_PER_INSTANCE */
+
+/*
+ * 
+ */
+#ifndef RPL_CONF_DAO_SPECIFY_DAG
+  #if RPL_MAX_DAG_PER_INSTANCE > 1
+    #define RPL_DAO_SPECIFY_DAG 1
+  #else
+    #define RPL_DAO_SPECIFY_DAG 0
+  #endif /* RPL_MAX_DAG_PER_INSTANCE > 1 */
+#else
+  #define RPL_DAO_SPECIFY_DAG RPL_CONF_DAO_SPECIFY_DAG
+#endif /* RPL_CONF_DAO_SPECIFY_DAG */
+
+/*
+ * The DIO interval (n) represents 2^n ms.
+ *
+ * According to the specification, the default value is 3 which
+ * means 8 milliseconds. That is far too low when using duty cycling
+ * with wake-up intervals that are typically hundreds of milliseconds.
+ * ContikiRPL thus sets the default to 2^12 ms = 4.096 s.
+ */
+#ifdef RPL_CONF_DIO_INTERVAL_MIN
+#define RPL_DIO_INTERVAL_MIN        RPL_CONF_DIO_INTERVAL_MIN
+#else
+#define RPL_DIO_INTERVAL_MIN        12
+#endif
+
+/*
+ * Maximum amount of timer doublings.
+ *
+ * The maximum interval will by default be 2^(12+8) ms = 1048.576 s.
+ * RFC 6550 suggests a default value of 20, which of course would be
+ * unsuitable when we start with a minimum interval of 2^12.
+ */
+#ifdef RPL_CONF_DIO_INTERVAL_DOUBLINGS
+#define RPL_DIO_INTERVAL_DOUBLINGS  RPL_CONF_DIO_INTERVAL_DOUBLINGS
+#else
+#define RPL_DIO_INTERVAL_DOUBLINGS  8
+#endif
+
+/*
+ * DIO redundancy. To learn more about this, see RFC 6206.
+ *
+ * RFC 6550 suggests a default value of 10. It is unclear what the basis
+ * of this suggestion is. Network operators might attain more efficient
+ * operation by tuning this parameter for specific deployments.
+ */
+#ifdef RPL_CONF_DIO_REDUNDANCY
+#define RPL_DIO_REDUNDANCY          RPL_CONF_DIO_REDUNDANCY
+#else
+#define RPL_DIO_REDUNDANCY          10
+#endif
+
+/*
+ * Initial metric attributed to a link when the ETX is unknown
+ */
+#ifndef RPL_CONF_INIT_LINK_METRIC
+#define RPL_INIT_LINK_METRIC        5
+#else
+#define RPL_INIT_LINK_METRIC        RPL_CONF_INIT_LINK_METRIC
+#endif
+
+/*
+ * Default route lifetime unit. This is the granularity of time
+ * used in RPL lifetime values, in seconds.
+ */
+#ifndef RPL_CONF_DEFAULT_LIFETIME_UNIT
+#define RPL_DEFAULT_LIFETIME_UNIT       0xffff
+#else
+#define RPL_DEFAULT_LIFETIME_UNIT       RPL_CONF_DEFAULT_LIFETIME_UNIT
+#endif
+
+/*
+ * Default route lifetime as a multiple of the lifetime unit.
+ */
+#ifndef RPL_CONF_DEFAULT_LIFETIME
+#define RPL_DEFAULT_LIFETIME            0xff
+#else
+#define RPL_DEFAULT_LIFETIME            RPL_CONF_DEFAULT_LIFETIME
+#endif
+
+#endif /* RPL_CONF_H */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/rpl/rpl-dag.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/rpl/rpl-dag.c
@@ -1,0 +1,1276 @@
+/**
+ * \addtogroup uip6
+ * @{
+ */
+/*
+ * Copyright (c) 2010, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+/**
+ * \file
+ *         Logic for Directed Acyclic Graphs in RPL.
+ *
+ * \author Joakim Eriksson <joakime@sics.se>, Nicolas Tsiftes <nvt@sics.se>
+ */
+
+
+#include "contiki.h"
+#include "net/rpl/rpl-private.h"
+#include "net/uip.h"
+#include "net/uip-nd6.h"
+#include "net/nbr-table.h"
+#include "lib/list.h"
+#include "lib/memb.h"
+#include "sys/ctimer.h"
+
+#include <limits.h>
+#include <string.h>
+
+#define DEBUG DEBUG_NONE
+#include "net/uip-debug.h"
+
+#if UIP_CONF_IPV6
+/*---------------------------------------------------------------------------*/
+extern rpl_of_t RPL_OF;
+static rpl_of_t * const objective_functions[] = {&RPL_OF};
+
+/*---------------------------------------------------------------------------*/
+/* RPL definitions. */
+
+#ifndef RPL_CONF_GROUNDED
+#define RPL_GROUNDED                    0
+#else
+#define RPL_GROUNDED                    RPL_CONF_GROUNDED
+#endif /* !RPL_CONF_GROUNDED */
+
+/*---------------------------------------------------------------------------*/
+/* Per-parent RPL information */
+NBR_TABLE(rpl_parent_t, rpl_parents);
+/*---------------------------------------------------------------------------*/
+/* Allocate instance table. */
+rpl_instance_t instance_table[RPL_MAX_INSTANCES];
+rpl_instance_t *default_instance;
+/*---------------------------------------------------------------------------*/
+void
+rpl_dag_init(void)
+{
+  nbr_table_register(rpl_parents, (nbr_table_callback *)rpl_remove_parent);
+}
+/*---------------------------------------------------------------------------*/
+rpl_rank_t
+rpl_get_parent_rank(uip_lladdr_t *addr)
+{
+  rpl_parent_t *p = nbr_table_get_from_lladdr(rpl_parents, (rimeaddr_t *)addr);
+  if(p != NULL) {
+    return p->rank;
+  } else {
+    return 0;
+  }
+}
+/*---------------------------------------------------------------------------*/
+uint16_t
+rpl_get_parent_link_metric(uip_lladdr_t *addr)
+{
+  rpl_parent_t *p = nbr_table_get_from_lladdr(rpl_parents, (rimeaddr_t *)addr);
+  if(p != NULL) {
+    return p->link_metric;
+  } else {
+    return 0;
+  }
+}
+/*---------------------------------------------------------------------------*/
+uip_ipaddr_t *
+rpl_get_parent_ipaddr(rpl_parent_t *p)
+{
+  rimeaddr_t *lladdr = nbr_table_get_lladdr(rpl_parents, p);
+  return uip_ds6_nbr_ipaddr_from_lladdr((uip_lladdr_t *)lladdr);
+}
+/*---------------------------------------------------------------------------*/
+static void
+rpl_set_preferred_parent(rpl_dag_t *dag, rpl_parent_t *p)
+{
+  if(dag != NULL && dag->preferred_parent != p) {
+    PRINTF("RPL: rpl_set_preferred_parent ");
+    if(p != NULL) {
+      PRINT6ADDR(rpl_get_parent_ipaddr(p));
+    } else {
+      PRINTF("NULL");
+    }
+    PRINTF(" used to be ");
+    if(dag->preferred_parent != NULL) {
+      PRINT6ADDR(rpl_get_parent_ipaddr(dag->preferred_parent));
+    } else {
+      PRINTF("NULL");
+    }
+    PRINTF("\n");
+
+    /* Always keep the preferred parent locked, so it remains in the
+     * neighbor table. */
+    nbr_table_unlock(rpl_parents, dag->preferred_parent);
+    nbr_table_lock(rpl_parents, p);
+    dag->preferred_parent = p;
+  }
+}
+/*---------------------------------------------------------------------------*/
+/* Greater-than function for the lollipop counter.                      */
+/*---------------------------------------------------------------------------*/
+static int
+lollipop_greater_than(int a, int b)
+{
+  /* Check if we are comparing an initial value with an old value */
+  if(a > RPL_LOLLIPOP_CIRCULAR_REGION && b <= RPL_LOLLIPOP_CIRCULAR_REGION) {
+    return (RPL_LOLLIPOP_MAX_VALUE + 1 + b - a) > RPL_LOLLIPOP_SEQUENCE_WINDOWS;
+  }
+  /* Otherwise check if a > b and comparable => ok, or
+     if they have wrapped and are still comparable */
+  return (a > b && (a - b) < RPL_LOLLIPOP_SEQUENCE_WINDOWS) ||
+    (a < b && (b - a) > (RPL_LOLLIPOP_CIRCULAR_REGION + 1-
+			 RPL_LOLLIPOP_SEQUENCE_WINDOWS));
+}
+/*---------------------------------------------------------------------------*/
+/* Remove DAG parents with a rank that is at least the same as minimum_rank. */
+static void
+remove_parents(rpl_dag_t *dag, rpl_rank_t minimum_rank)
+{
+  rpl_parent_t *p;
+
+  PRINTF("RPL: Removing parents (minimum rank %u)\n",
+	minimum_rank);
+
+  p = nbr_table_head(rpl_parents);
+  while(p != NULL) {
+    if(dag == p->dag && p->rank >= minimum_rank) {
+      rpl_remove_parent(p);
+    }
+    p = nbr_table_next(rpl_parents, p);
+  }
+}
+/*---------------------------------------------------------------------------*/
+static void
+nullify_parents(rpl_dag_t *dag, rpl_rank_t minimum_rank)
+{
+  rpl_parent_t *p;
+
+  PRINTF("RPL: Removing parents (minimum rank %u)\n",
+	minimum_rank);
+
+  p = nbr_table_head(rpl_parents);
+  while(p != NULL) {
+    if(dag == p->dag && p->rank >= minimum_rank) {
+      rpl_nullify_parent(p);
+    }
+    p = nbr_table_next(rpl_parents, p);
+  }
+}
+/*---------------------------------------------------------------------------*/
+static int
+should_send_dao(rpl_instance_t *instance, rpl_dio_t *dio, rpl_parent_t *p)
+{
+  /* if MOP is set to no downward routes no DAO should be sent */
+  if(instance->mop == RPL_MOP_NO_DOWNWARD_ROUTES) {
+    return 0;
+  }
+  /* check if the new DTSN is more recent */
+  return p == instance->current_dag->preferred_parent &&
+    (lollipop_greater_than(dio->dtsn, p->dtsn));
+}
+/*---------------------------------------------------------------------------*/
+static int
+acceptable_rank(rpl_dag_t *dag, rpl_rank_t rank)
+{
+  return rank != INFINITE_RANK &&
+    ((dag->instance->max_rankinc == 0) ||
+     DAG_RANK(rank, dag->instance) <= DAG_RANK(dag->min_rank + dag->instance->max_rankinc, dag->instance));
+}
+/*---------------------------------------------------------------------------*/
+static rpl_dag_t *
+get_dag(uint8_t instance_id, uip_ipaddr_t *dag_id)
+{
+  rpl_instance_t *instance;
+  rpl_dag_t *dag;
+  int i;
+
+  instance = rpl_get_instance(instance_id);
+  if(instance == NULL) {
+    return NULL;
+  }
+
+  for(i = 0; i < RPL_MAX_DAG_PER_INSTANCE; ++i) {
+    dag = &instance->dag_table[i];
+    if(dag->used && uip_ipaddr_cmp(&dag->dag_id, dag_id)) {
+      return dag;
+    }
+  }
+
+  return NULL;
+}
+/*---------------------------------------------------------------------------*/
+rpl_dag_t *
+rpl_set_root(uint8_t instance_id, uip_ipaddr_t *dag_id)
+{
+  rpl_dag_t *dag;
+  rpl_instance_t *instance;
+  uint8_t version;
+
+  version = RPL_LOLLIPOP_INIT;
+  dag = get_dag(instance_id, dag_id);
+  if(dag != NULL) {
+    version = dag->version;
+    RPL_LOLLIPOP_INCREMENT(version);
+    PRINTF("RPL: Dropping a joined DAG when setting this node as root");
+    if(dag == dag->instance->current_dag) {
+      dag->instance->current_dag = NULL;
+    }
+    rpl_free_dag(dag);
+  }
+
+  dag = rpl_alloc_dag(instance_id, dag_id);
+  if(dag == NULL) {
+    PRINTF("RPL: Failed to allocate a DAG\n");
+    return NULL;
+  }
+
+  instance = dag->instance;
+
+  dag->version = version;
+  dag->joined = 1;
+  dag->grounded = RPL_GROUNDED;
+  instance->mop = RPL_MOP_DEFAULT;
+  instance->of = &RPL_OF;
+  rpl_set_preferred_parent(dag, NULL);
+
+  memcpy(&dag->dag_id, dag_id, sizeof(dag->dag_id));
+
+  instance->dio_intdoubl = RPL_DIO_INTERVAL_DOUBLINGS;
+  instance->dio_intmin = RPL_DIO_INTERVAL_MIN;
+  /* The current interval must differ from the minimum interval in order to
+     trigger a DIO timer reset. */
+  instance->dio_intcurrent = RPL_DIO_INTERVAL_MIN +
+    RPL_DIO_INTERVAL_DOUBLINGS;
+  instance->dio_redundancy = RPL_DIO_REDUNDANCY;
+  instance->max_rankinc = RPL_MAX_RANKINC;
+  instance->min_hoprankinc = RPL_MIN_HOPRANKINC;
+  instance->default_lifetime = RPL_DEFAULT_LIFETIME;
+  instance->lifetime_unit = RPL_DEFAULT_LIFETIME_UNIT;
+
+  dag->rank = ROOT_RANK(instance);
+
+  if(instance->current_dag != dag && instance->current_dag != NULL) {
+    /* Remove routes installed by DAOs. */
+    rpl_remove_routes(instance->current_dag);
+
+    instance->current_dag->joined = 0;
+  }
+
+  instance->current_dag = dag;
+  instance->dtsn_out = RPL_LOLLIPOP_INIT;
+  instance->of->update_metric_container(instance);
+  default_instance = instance;
+
+  PRINTF("RPL: Node set to be a DAG root with DAG ID ");
+  PRINT6ADDR(&dag->dag_id);
+  PRINTF("\n");
+
+  ANNOTATE("#A root=%u\n", dag->dag_id.u8[sizeof(dag->dag_id) - 1]);
+
+  rpl_reset_dio_timer(instance);
+
+  return dag;
+}
+/*---------------------------------------------------------------------------*/
+int
+rpl_repair_root(uint8_t instance_id)
+{
+  rpl_instance_t *instance;
+
+  instance = rpl_get_instance(instance_id);
+  if(instance == NULL ||
+     instance->current_dag->rank != ROOT_RANK(instance)) {
+    PRINTF("RPL: rpl_repair_root triggered but not root\n");
+    return 0;
+  }
+
+  RPL_LOLLIPOP_INCREMENT(instance->current_dag->version);
+  RPL_LOLLIPOP_INCREMENT(instance->dtsn_out);
+  PRINTF("RPL: rpl_repair_root initiating global repair with version %d\n", instance->current_dag->version);
+  rpl_reset_dio_timer(instance);
+  return 1;
+}
+/*---------------------------------------------------------------------------*/
+static void
+set_ip_from_prefix(uip_ipaddr_t *ipaddr, rpl_prefix_t *prefix)
+{
+  memset(ipaddr, 0, sizeof(uip_ipaddr_t));
+  memcpy(ipaddr, &prefix->prefix, (prefix->length + 7) / 8);
+  uip_ds6_set_addr_iid(ipaddr, &uip_lladdr);
+}
+/*---------------------------------------------------------------------------*/
+static void
+check_prefix(rpl_prefix_t *last_prefix, rpl_prefix_t *new_prefix)
+{
+  uip_ipaddr_t ipaddr;
+  uip_ds6_addr_t *rep;
+
+  if(last_prefix != NULL && new_prefix != NULL &&
+     last_prefix->length == new_prefix->length &&
+     uip_ipaddr_prefixcmp(&last_prefix->prefix, &new_prefix->prefix, new_prefix->length) &&
+     last_prefix->flags == new_prefix->flags) {
+    /* Nothing has changed. */
+    return;
+  }
+
+  if(last_prefix != NULL) {
+    set_ip_from_prefix(&ipaddr, last_prefix);
+    rep = uip_ds6_addr_lookup(&ipaddr);
+    if(rep != NULL) {
+      PRINTF("RPL: removing global IP address ");
+      PRINT6ADDR(&ipaddr);
+      PRINTF("\n");
+      uip_ds6_addr_rm(rep);
+    }
+  }
+  
+  if(new_prefix != NULL) {
+    set_ip_from_prefix(&ipaddr, new_prefix);
+    if(uip_ds6_addr_lookup(&ipaddr) == NULL) {
+      PRINTF("RPL: adding global IP address ");
+      PRINT6ADDR(&ipaddr);
+      PRINTF("\n");
+      uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
+    }
+  }
+}
+/*---------------------------------------------------------------------------*/
+int
+rpl_set_prefix(rpl_dag_t *dag, uip_ipaddr_t *prefix, unsigned len)
+{
+  rpl_prefix_t last_prefix;
+  uint8_t last_len = dag->prefix_info.length;
+  
+  if(len > 128) {
+    return 0;
+  }
+  if(dag->prefix_info.length != 0) {
+    memcpy(&last_prefix, &dag->prefix_info, sizeof(rpl_prefix_t));
+  }
+  memset(&dag->prefix_info.prefix, 0, sizeof(dag->prefix_info.prefix));
+  memcpy(&dag->prefix_info.prefix, prefix, (len + 7) / 8);
+  dag->prefix_info.length = len;
+  dag->prefix_info.flags = UIP_ND6_RA_FLAG_AUTONOMOUS;
+  PRINTF("RPL: Prefix set - will announce this in DIOs\n");
+  /* Autoconfigure an address if this node does not already have an address
+     with this prefix. Otherwise, update the prefix */
+  if(last_len == 0) {
+    PRINTF("rpl_set_prefix - prefix NULL\n");
+    check_prefix(NULL, &dag->prefix_info);
+  } else { 
+    PRINTF("rpl_set_prefix - prefix NON-NULL\n");
+    check_prefix(&last_prefix, &dag->prefix_info);
+  }
+  return 1;
+}
+/*---------------------------------------------------------------------------*/
+int
+rpl_set_default_route(rpl_instance_t *instance, uip_ipaddr_t *from)
+{
+  if(instance->def_route != NULL) {
+    PRINTF("RPL: Removing default route through ");
+    PRINT6ADDR(&instance->def_route->ipaddr);
+    PRINTF("\n");
+    uip_ds6_defrt_rm(instance->def_route);
+    instance->def_route = NULL;
+  }
+
+  if(from != NULL) {
+    PRINTF("RPL: Adding default route through ");
+    PRINT6ADDR(from);
+    PRINTF("\n");
+    instance->def_route = uip_ds6_defrt_add(from,
+        RPL_LIFETIME(instance,
+            instance->default_lifetime));
+    if(instance->def_route == NULL) {
+      return 0;
+    }
+  } else {
+    PRINTF("RPL: Removing default route\n");
+    if(instance->def_route != NULL) {
+      uip_ds6_defrt_rm(instance->def_route);
+    } else {
+      PRINTF("RPL: Not actually removing default route, since instance had no default route\n");
+    }
+  }
+  return 1;
+}
+/*---------------------------------------------------------------------------*/
+rpl_instance_t *
+rpl_alloc_instance(uint8_t instance_id)
+{
+  rpl_instance_t *instance, *end;
+
+  for(instance = &instance_table[0], end = instance + RPL_MAX_INSTANCES;
+      instance < end; ++instance) {
+    if(instance->used == 0) {
+      memset(instance, 0, sizeof(*instance));
+      instance->instance_id = instance_id;
+      instance->def_route = NULL;
+      instance->used = 1;
+      return instance;
+    }
+  }
+  return NULL;
+}
+/*---------------------------------------------------------------------------*/
+rpl_dag_t *
+rpl_alloc_dag(uint8_t instance_id, uip_ipaddr_t *dag_id)
+{
+  rpl_dag_t *dag, *end;
+  rpl_instance_t *instance;
+
+  instance = rpl_get_instance(instance_id);
+  if(instance == NULL) {
+    instance = rpl_alloc_instance(instance_id);
+    if(instance == NULL) {
+      RPL_STAT(rpl_stats.mem_overflows++);
+      return NULL;
+    }
+  }
+
+  for(dag = &instance->dag_table[0], end = dag + RPL_MAX_DAG_PER_INSTANCE; dag < end; ++dag) {
+    if(!dag->used) {
+      memset(dag, 0, sizeof(*dag));
+      dag->used = 1;
+      dag->rank = INFINITE_RANK;
+      dag->min_rank = INFINITE_RANK;
+      dag->instance = instance;
+      return dag;
+    }
+  }
+
+  RPL_STAT(rpl_stats.mem_overflows++);
+  rpl_free_instance(instance);
+  return NULL;
+}
+/*---------------------------------------------------------------------------*/
+void
+rpl_set_default_instance(rpl_instance_t *instance)
+{
+  default_instance = instance;
+}
+/*---------------------------------------------------------------------------*/
+void
+rpl_free_instance(rpl_instance_t *instance)
+{
+  rpl_dag_t *dag;
+  rpl_dag_t *end;
+
+  PRINTF("RPL: Leaving the instance %u\n", instance->instance_id);
+
+  /* Remove any DAG inside this instance */
+  for(dag = &instance->dag_table[0], end = dag + RPL_MAX_DAG_PER_INSTANCE; dag < end; ++dag) {
+    if(dag->used) {
+      rpl_free_dag(dag);
+    }
+  }
+
+  rpl_set_default_route(instance, NULL);
+
+  ctimer_stop(&instance->dio_timer);
+  ctimer_stop(&instance->dao_timer);
+
+  if(default_instance == instance) {
+    default_instance = NULL;
+  }
+
+  instance->used = 0;
+}
+/*---------------------------------------------------------------------------*/
+void
+rpl_free_dag(rpl_dag_t *dag)
+{
+  if(dag->joined) {
+    PRINTF("RPL: Leaving the DAG ");
+    PRINT6ADDR(&dag->dag_id);
+    PRINTF("\n");
+    dag->joined = 0;
+
+    /* Remove routes installed by DAOs. */
+    rpl_remove_routes(dag);
+
+   /* Remove autoconfigured address */
+    if((dag->prefix_info.flags & UIP_ND6_RA_FLAG_AUTONOMOUS)) {
+      check_prefix(&dag->prefix_info, NULL);
+    }
+
+    remove_parents(dag, 0);
+  }
+  dag->used = 0;
+}
+/*---------------------------------------------------------------------------*/
+rpl_parent_t *
+rpl_add_parent(rpl_dag_t *dag, rpl_dio_t *dio, uip_ipaddr_t *addr)
+{
+  rpl_parent_t *p = NULL;
+  /* Is the parent known by ds6? Drop this request if not.
+   * Typically, the parent is added upon receiving a DIO. */
+  uip_lladdr_t *lladdr = uip_ds6_nbr_lladdr_from_ipaddr(addr);
+
+  PRINTF("RPL: rpl_add_parent lladdr %p\n", lladdr);
+  if(lladdr != NULL) {
+    /* Add parent in rpl_parents */
+    p = nbr_table_add_lladdr(rpl_parents, (rimeaddr_t *)lladdr);
+    p->dag = dag;
+    p->rank = dio->rank;
+    p->dtsn = dio->dtsn;
+    p->link_metric = RPL_INIT_LINK_METRIC * RPL_DAG_MC_ETX_DIVISOR;
+#if RPL_DAG_MC != RPL_DAG_MC_NONE
+    memcpy(&p->mc, &dio->mc, sizeof(p->mc));
+#endif /* RPL_DAG_MC != RPL_DAG_MC_NONE */
+  }
+
+  return p;
+}
+/*---------------------------------------------------------------------------*/
+static rpl_parent_t *
+find_parent_any_dag_any_instance(uip_ipaddr_t *addr)
+{
+  uip_ds6_nbr_t *ds6_nbr = uip_ds6_nbr_lookup(addr);
+  uip_lladdr_t *lladdr = uip_ds6_nbr_get_ll(ds6_nbr);
+  return nbr_table_get_from_lladdr(rpl_parents, (rimeaddr_t *)lladdr);
+}
+/*---------------------------------------------------------------------------*/
+rpl_parent_t *
+rpl_find_parent(rpl_dag_t *dag, uip_ipaddr_t *addr)
+{
+  rpl_parent_t *p = find_parent_any_dag_any_instance(addr);
+  if(p != NULL && p->dag == dag) {
+    return p;
+  } else {
+    return NULL;
+  }
+}
+/*---------------------------------------------------------------------------*/
+static rpl_dag_t *
+find_parent_dag(rpl_instance_t *instance, uip_ipaddr_t *addr)
+{
+  rpl_parent_t *p = find_parent_any_dag_any_instance(addr);
+  if(p != NULL) {
+    return p->dag;
+  } else {
+    return NULL;
+  }
+}
+/*---------------------------------------------------------------------------*/
+rpl_parent_t *
+rpl_find_parent_any_dag(rpl_instance_t *instance, uip_ipaddr_t *addr)
+{
+  rpl_parent_t *p = find_parent_any_dag_any_instance(addr);
+  if(p && p->dag && p->dag->instance == instance) {
+    return p;
+  } else {
+    return NULL;
+  }
+}
+/*---------------------------------------------------------------------------*/
+rpl_dag_t *
+rpl_select_dag(rpl_instance_t *instance, rpl_parent_t *p)
+{
+  rpl_parent_t *last_parent;
+  rpl_dag_t *dag, *end, *best_dag;
+  rpl_rank_t old_rank;
+
+  old_rank = instance->current_dag->rank;
+  last_parent = instance->current_dag->preferred_parent;
+
+  best_dag = instance->current_dag;
+  if(best_dag->rank != ROOT_RANK(instance)) {
+    if(rpl_select_parent(p->dag) != NULL) {
+      if(p->dag != best_dag) {
+        best_dag = instance->of->best_dag(best_dag, p->dag);
+      }
+    } else if(p->dag == best_dag) {
+      best_dag = NULL;
+      for(dag = &instance->dag_table[0], end = dag + RPL_MAX_DAG_PER_INSTANCE; dag < end; ++dag) {
+        if(dag->used && dag->preferred_parent != NULL && dag->preferred_parent->rank != INFINITE_RANK) {
+          if(best_dag == NULL) {
+            best_dag = dag;
+          } else {
+            best_dag = instance->of->best_dag(best_dag, dag);
+          }
+        }
+      }
+    }
+  }
+
+  if(best_dag == NULL) {
+    /* No parent found: the calling function handle this problem. */
+    return NULL;
+  }
+
+  if(instance->current_dag != best_dag) {
+    /* Remove routes installed by DAOs. */
+    rpl_remove_routes(instance->current_dag);
+
+    PRINTF("RPL: New preferred DAG: ");
+    PRINT6ADDR(&best_dag->dag_id);
+    PRINTF("\n");
+
+    if(best_dag->prefix_info.flags & UIP_ND6_RA_FLAG_AUTONOMOUS) {
+      check_prefix(&instance->current_dag->prefix_info, &best_dag->prefix_info);
+    } else if(instance->current_dag->prefix_info.flags & UIP_ND6_RA_FLAG_AUTONOMOUS) {
+      check_prefix(&instance->current_dag->prefix_info, NULL);
+    }
+
+    best_dag->joined = 1;
+    instance->current_dag->joined = 0;
+    instance->current_dag = best_dag;
+  }
+
+  instance->of->update_metric_container(instance);
+  /* Update the DAG rank. */
+  best_dag->rank = instance->of->calculate_rank(best_dag->preferred_parent, 0);
+  if(last_parent == NULL || best_dag->rank < best_dag->min_rank) {
+    best_dag->min_rank = best_dag->rank;
+  } else if(!acceptable_rank(best_dag, best_dag->rank)) {
+    PRINTF("RPL: New rank unacceptable!\n");
+    rpl_set_preferred_parent(instance->current_dag, NULL);
+    if(instance->mop != RPL_MOP_NO_DOWNWARD_ROUTES && last_parent != NULL) {
+      /* Send a No-Path DAO to the removed preferred parent. */
+      dao_output(last_parent, RPL_ZERO_LIFETIME);
+    }
+    return NULL;
+  }
+
+  if(best_dag->preferred_parent != last_parent) {
+    rpl_set_default_route(instance, rpl_get_parent_ipaddr(best_dag->preferred_parent));
+    PRINTF("RPL: Changed preferred parent, rank changed from %u to %u\n",
+  	(unsigned)old_rank, best_dag->rank);
+    RPL_STAT(rpl_stats.parent_switch++);
+    if(instance->mop != RPL_MOP_NO_DOWNWARD_ROUTES) {
+      if(last_parent != NULL) {
+        /* Send a No-Path DAO to the removed preferred parent. */
+        dao_output(last_parent, RPL_ZERO_LIFETIME);
+      }
+      /* The DAO parent set changed - schedule a DAO transmission. */
+      RPL_LOLLIPOP_INCREMENT(instance->dtsn_out);
+      rpl_schedule_dao(instance);
+    }
+    rpl_reset_dio_timer(instance);
+  } else if(best_dag->rank != old_rank) {
+    PRINTF("RPL: Preferred parent update, rank changed from %u to %u\n",
+  	(unsigned)old_rank, best_dag->rank);
+  }
+  return best_dag;
+}
+/*---------------------------------------------------------------------------*/
+rpl_parent_t *
+rpl_select_parent(rpl_dag_t *dag)
+{
+  rpl_parent_t *p, *best;
+
+  best = NULL;
+
+  p = nbr_table_head(rpl_parents);
+  while(p != NULL) {
+    if(p->rank == INFINITE_RANK) {
+      /* ignore this neighbor */
+    } else if(best == NULL) {
+      best = p;
+    } else {
+      best = dag->instance->of->best_parent(best, p);
+    }
+    p = nbr_table_next(rpl_parents, p);
+  }
+
+  if(best != NULL) {
+    rpl_set_preferred_parent(dag, best);
+  }
+
+  return best;
+}
+/*---------------------------------------------------------------------------*/
+void
+rpl_remove_parent(rpl_parent_t *parent)
+{
+  PRINTF("RPL: Removing parent ");
+  PRINT6ADDR(rpl_get_parent_ipaddr(parent));
+  PRINTF("\n");
+
+  rpl_nullify_parent(parent);
+
+  nbr_table_remove(rpl_parents, parent);
+}
+/*---------------------------------------------------------------------------*/
+void
+rpl_nullify_parent(rpl_parent_t *parent)
+{
+  rpl_dag_t *dag = parent->dag;
+  /* This function can be called when the preferred parent is NULL, so we
+     need to handle this condition in order to trigger uip_ds6_defrt_rm. */
+  if(parent == dag->preferred_parent || dag->preferred_parent == NULL) {
+    rpl_set_preferred_parent(dag, NULL);
+    dag->rank = INFINITE_RANK;
+    if(dag->joined) {
+      if(dag->instance->def_route != NULL) {
+        PRINTF("RPL: Removing default route ");
+        PRINT6ADDR(rpl_get_parent_ipaddr(parent));
+        PRINTF("\n");
+        uip_ds6_defrt_rm(dag->instance->def_route);
+        dag->instance->def_route = NULL;
+      }
+      dao_output(parent, RPL_ZERO_LIFETIME);
+    }
+  }
+
+  PRINTF("RPL: Nullifying parent ");
+  PRINT6ADDR(rpl_get_parent_ipaddr(parent));
+  PRINTF("\n");
+}
+/*---------------------------------------------------------------------------*/
+void
+rpl_move_parent(rpl_dag_t *dag_src, rpl_dag_t *dag_dst, rpl_parent_t *parent)
+{
+  if(parent == dag_src->preferred_parent) {
+      rpl_set_preferred_parent(dag_src, NULL);
+      dag_src->rank = INFINITE_RANK;
+    if(dag_src->joined && dag_src->instance->def_route != NULL) {
+      PRINTF("RPL: Removing default route ");
+      PRINT6ADDR(rpl_get_parent_ipaddr(parent));
+      PRINTF("\n");
+      PRINTF("rpl_move_parent\n");
+      uip_ds6_defrt_rm(dag_src->instance->def_route);
+      dag_src->instance->def_route = NULL;
+    }
+  } else if(dag_src->joined) {
+    /* Remove uIPv6 routes that have this parent as the next hop. */
+    rpl_remove_routes_by_nexthop(rpl_get_parent_ipaddr(parent), dag_src);
+  }
+
+  PRINTF("RPL: Moving parent ");
+  PRINT6ADDR(rpl_get_parent_ipaddr(parent));
+  PRINTF("\n");
+
+  list_remove(dag_src->parents, parent);
+  parent->dag = dag_dst;
+  list_add(dag_dst->parents, parent);
+}
+/*---------------------------------------------------------------------------*/
+rpl_dag_t *
+rpl_get_any_dag(void)
+{
+  int i;
+
+  for(i = 0; i < RPL_MAX_INSTANCES; ++i) {
+    if(instance_table[i].used && instance_table[i].current_dag->joined) {
+      return instance_table[i].current_dag;
+    }
+  }
+  return NULL;
+}
+/*---------------------------------------------------------------------------*/
+rpl_instance_t *
+rpl_get_instance(uint8_t instance_id)
+{
+  int i;
+
+  for(i = 0; i < RPL_MAX_INSTANCES; ++i) {
+    if(instance_table[i].used && instance_table[i].instance_id == instance_id) {
+      return &instance_table[i];
+    }
+  }
+  return NULL;
+}
+/*---------------------------------------------------------------------------*/
+rpl_of_t *
+rpl_find_of(rpl_ocp_t ocp)
+{
+  unsigned int i;
+
+  for(i = 0;
+      i < sizeof(objective_functions) / sizeof(objective_functions[0]);
+      i++) {
+    if(objective_functions[i]->ocp == ocp) {
+      return objective_functions[i];
+    }
+  }
+
+  return NULL;
+}
+/*---------------------------------------------------------------------------*/
+void
+rpl_join_instance(uip_ipaddr_t *from, rpl_dio_t *dio)
+{
+  rpl_instance_t *instance;
+  rpl_dag_t *dag;
+  rpl_parent_t *p;
+  rpl_of_t *of;
+
+  dag = rpl_alloc_dag(dio->instance_id, &dio->dag_id);
+  if(dag == NULL) {
+    PRINTF("RPL: Failed to allocate a DAG object!\n");
+    return;
+  }
+
+  instance = dag->instance;
+
+  p = rpl_add_parent(dag, dio, from);
+  PRINTF("RPL: Adding ");
+  PRINT6ADDR(from);
+  PRINTF(" as a parent: ");
+  if(p == NULL) {
+    PRINTF("failed\n");
+    instance->used = 0;
+    return;
+  }
+  p->dtsn = dio->dtsn;
+  PRINTF("succeeded\n");
+
+  /* Determine the objective function by using the
+     objective code point of the DIO. */
+  of = rpl_find_of(dio->ocp);
+  if(of == NULL) {
+    PRINTF("RPL: DIO for DAG instance %u does not specify a supported OF\n",
+        dio->instance_id);
+    rpl_remove_parent(p);
+    instance->used = 0;
+    return;
+  }
+
+  /* Autoconfigure an address if this node does not already have an address
+     with this prefix. */
+  if(dio->prefix_info.flags & UIP_ND6_RA_FLAG_AUTONOMOUS) {
+    check_prefix(NULL, &dio->prefix_info);
+  }
+
+  dag->joined = 1;
+  dag->preference = dio->preference;
+  dag->grounded = dio->grounded;
+  dag->version = dio->version;
+
+  instance->of = of;
+  instance->mop = dio->mop;
+  instance->current_dag = dag;
+  instance->dtsn_out = RPL_LOLLIPOP_INIT;
+
+  instance->max_rankinc = dio->dag_max_rankinc;
+  instance->min_hoprankinc = dio->dag_min_hoprankinc;
+  instance->dio_intdoubl = dio->dag_intdoubl;
+  instance->dio_intmin = dio->dag_intmin;
+  instance->dio_intcurrent = instance->dio_intmin + instance->dio_intdoubl;
+  instance->dio_redundancy = dio->dag_redund;
+  instance->default_lifetime = dio->default_lifetime;
+  instance->lifetime_unit = dio->lifetime_unit;
+
+  memcpy(&dag->dag_id, &dio->dag_id, sizeof(dio->dag_id));
+
+  /* Copy prefix information from the DIO into the DAG object. */
+  memcpy(&dag->prefix_info, &dio->prefix_info, sizeof(rpl_prefix_t));
+
+  rpl_set_preferred_parent(dag, p);
+  instance->of->update_metric_container(instance);
+  dag->rank = instance->of->calculate_rank(p, 0);
+  /* So far this is the lowest rank we are aware of. */
+  dag->min_rank = dag->rank;
+
+  if(default_instance == NULL) {
+    default_instance = instance;
+  }
+
+  PRINTF("RPL: Joined DAG with instance ID %u, rank %hu, DAG ID ",
+         dio->instance_id, dag->rank);
+  PRINT6ADDR(&dag->dag_id);
+  PRINTF("\n");
+
+  ANNOTATE("#A join=%u\n", dag->dag_id.u8[sizeof(dag->dag_id) - 1]);
+
+  rpl_reset_dio_timer(instance);
+  rpl_set_default_route(instance, from);
+
+  if(instance->mop != RPL_MOP_NO_DOWNWARD_ROUTES) {
+    rpl_schedule_dao(instance);
+  } else {
+    PRINTF("RPL: The DIO does not meet the prerequisites for sending a DAO\n");
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+void
+rpl_add_dag(uip_ipaddr_t *from, rpl_dio_t *dio)
+{
+  rpl_instance_t *instance;
+  rpl_dag_t *dag, *previous_dag;
+  rpl_parent_t *p;
+  rpl_of_t *of;
+
+  dag = rpl_alloc_dag(dio->instance_id, &dio->dag_id);
+  if(dag == NULL) {
+    PRINTF("RPL: Failed to allocate a DAG object!\n");
+    return;
+  }
+
+  instance = dag->instance;
+
+  previous_dag = find_parent_dag(instance, from);
+  if(previous_dag == NULL) {
+    PRINTF("RPL: Adding ");
+    PRINT6ADDR(from);
+    PRINTF(" as a parent: ");
+    p = rpl_add_parent(dag, dio, from);
+    if(p == NULL) {
+      PRINTF("failed\n");
+      dag->used = 0;
+      return;
+    }
+    PRINTF("succeeded\n");
+  } else {
+    p = rpl_find_parent(previous_dag, from);
+    if(p != NULL) {
+      rpl_move_parent(previous_dag, dag, p);
+    }
+  }
+
+  /* Determine the objective function by using the
+     objective code point of the DIO. */
+  of = rpl_find_of(dio->ocp);
+  if(of != instance->of ||
+     instance->mop != dio->mop ||
+     instance->max_rankinc != dio->dag_max_rankinc ||
+     instance->min_hoprankinc != dio->dag_min_hoprankinc ||
+     instance->dio_intdoubl != dio->dag_intdoubl ||
+     instance->dio_intmin != dio->dag_intmin ||
+     instance->dio_redundancy != dio->dag_redund ||
+     instance->default_lifetime != dio->default_lifetime ||
+     instance->lifetime_unit != dio->lifetime_unit) {
+    PRINTF("RPL: DIO for DAG instance %u uncompatible with previos DIO\n",
+	   dio->instance_id);
+    rpl_remove_parent(p);
+    dag->used = 0;
+    return;
+  }
+
+  dag->used = 1;
+  dag->grounded = dio->grounded;
+  dag->preference = dio->preference;
+  dag->version = dio->version;
+
+  memcpy(&dag->dag_id, &dio->dag_id, sizeof(dio->dag_id));
+
+  /* copy prefix information into the dag */
+  memcpy(&dag->prefix_info, &dio->prefix_info, sizeof(rpl_prefix_t));
+
+  rpl_set_preferred_parent(dag, p);
+  dag->rank = instance->of->calculate_rank(p, 0);
+  dag->min_rank = dag->rank; /* So far this is the lowest rank we know of. */
+
+  PRINTF("RPL: Joined DAG with instance ID %u, rank %hu, DAG ID ",
+         dio->instance_id, dag->rank);
+  PRINT6ADDR(&dag->dag_id);
+  PRINTF("\n");
+
+  ANNOTATE("#A join=%u\n", dag->dag_id.u8[sizeof(dag->dag_id) - 1]);
+
+  rpl_process_parent_event(instance, p);
+  p->dtsn = dio->dtsn;
+}
+
+/*---------------------------------------------------------------------------*/
+static void
+global_repair(uip_ipaddr_t *from, rpl_dag_t *dag, rpl_dio_t *dio)
+{
+  rpl_parent_t *p;
+
+  remove_parents(dag, 0);
+  dag->version = dio->version;
+  dag->instance->of->reset(dag);
+  dag->min_rank = INFINITE_RANK;
+  RPL_LOLLIPOP_INCREMENT(dag->instance->dtsn_out);
+
+  p = rpl_add_parent(dag, dio, from);
+  if(p == NULL) {
+    PRINTF("RPL: Failed to add a parent during the global repair\n");
+    dag->rank = INFINITE_RANK;
+  } else {
+    dag->rank = dag->instance->of->calculate_rank(p, 0);
+    dag->min_rank = dag->rank;
+    PRINTF("RPL: rpl_process_parent_event global repair\n");
+    rpl_process_parent_event(dag->instance, p);
+  }
+
+  PRINTF("RPL: Participating in a global repair (version=%u, rank=%hu)\n",
+         dag->version, dag->rank);
+
+  RPL_STAT(rpl_stats.global_repairs++);
+}
+/*---------------------------------------------------------------------------*/
+void
+rpl_local_repair(rpl_instance_t *instance)
+{
+  int i;
+
+  if(instance == NULL) {
+    PRINTF("RPL: local repair requested for instance NULL\n");
+    return;
+  }
+  PRINTF("RPL: Starting a local instance repair\n");
+  for(i = 0; i < RPL_MAX_DAG_PER_INSTANCE; i++) {
+    if(instance->dag_table[i].used) {
+      instance->dag_table[i].rank = INFINITE_RANK;
+      nullify_parents(&instance->dag_table[i], 0);
+    }
+  }
+
+  rpl_reset_dio_timer(instance);
+
+  RPL_STAT(rpl_stats.local_repairs++);
+}
+/*---------------------------------------------------------------------------*/
+void
+rpl_recalculate_ranks(void)
+{
+  rpl_parent_t *p;
+
+  /*
+   * We recalculate ranks when we receive feedback from the system rather
+   * than RPL protocol messages. This periodical recalculation is called
+   * from a timer in order to keep the stack depth reasonably low.
+   */
+  p = nbr_table_head(rpl_parents);
+  while(p != NULL) {
+    if(p->dag != NULL && p->dag->instance && p->updated) {
+      p->updated = 0;
+      PRINTF("RPL: rpl_process_parent_event recalculate_ranks\n");
+      if(!rpl_process_parent_event(p->dag->instance, p)) {
+        PRINTF("RPL: A parent was dropped\n");
+      }
+    }
+    p = nbr_table_next(rpl_parents, p);
+  }
+}
+/*---------------------------------------------------------------------------*/
+int
+rpl_process_parent_event(rpl_instance_t *instance, rpl_parent_t *p)
+{
+  int return_value;
+
+#if DEBUG
+  rpl_rank_t old_rank;
+  old_rank = instance->current_dag->rank;
+#endif /* DEBUG */
+
+  return_value = 1;
+
+  if(!acceptable_rank(p->dag, p->rank)) {
+    /* The candidate parent is no longer valid: the rank increase resulting
+       from the choice of it as a parent would be too high. */
+    PRINTF("RPL: Unacceptable rank %u\n", (unsigned)p->rank);
+    rpl_nullify_parent(p);
+    if(p != instance->current_dag->preferred_parent) {
+      return 0;
+    } else {
+      return_value = 0;
+    }
+  }
+
+  if(rpl_select_dag(instance, p) == NULL) {
+    /* No suitable parent; trigger a local repair. */
+    PRINTF("RPL: No parents found in any DAG\n");
+    rpl_local_repair(instance);
+    return 0;
+  }
+
+#if DEBUG
+  if(DAG_RANK(old_rank, instance) != DAG_RANK(instance->current_dag->rank, instance)) {
+    PRINTF("RPL: Moving in the instance from rank %hu to %hu\n",
+	   DAG_RANK(old_rank, instance), DAG_RANK(instance->current_dag->rank, instance));
+    if(instance->current_dag->rank != INFINITE_RANK) {
+      PRINTF("RPL: The preferred parent is ");
+      PRINT6ADDR(rpl_get_parent_ipaddr(instance->current_dag->preferred_parent));
+      PRINTF(" (rank %u)\n",
+           (unsigned)DAG_RANK(instance->current_dag->preferred_parent->rank, instance));
+    } else {
+      PRINTF("RPL: We don't have any parent");
+    }
+  }
+#endif /* DEBUG */
+
+  return return_value;
+}
+/*---------------------------------------------------------------------------*/
+#pragma stackfunction 50    //TODO: CHSC find out, how mutch stack is realy used
+void
+rpl_process_dio(uip_ipaddr_t *from, rpl_dio_t *dio)
+{
+  rpl_instance_t *instance;
+  rpl_dag_t *dag, *previous_dag;
+  rpl_parent_t *p;
+
+  if(dio->mop != RPL_MOP_DEFAULT) {
+    PRINTF("RPL: Ignoring a DIO with an unsupported MOP: %d\n", dio->mop);
+    return;
+  }
+
+  dag = get_dag(dio->instance_id, &dio->dag_id);
+  instance = rpl_get_instance(dio->instance_id);
+
+  if(dag != NULL && instance != NULL) {
+    if(lollipop_greater_than(dio->version, dag->version)) {
+      if(dag->rank == ROOT_RANK(instance)) {
+	PRINTF("RPL: Root received inconsistent DIO version number\n");
+	dag->version = dio->version;
+	RPL_LOLLIPOP_INCREMENT(dag->version);
+	rpl_reset_dio_timer(instance);
+      } else {
+        PRINTF("RPL: Global Repair\n");
+        if(dio->prefix_info.length != 0) {
+          if(dio->prefix_info.flags & UIP_ND6_RA_FLAG_AUTONOMOUS) {
+            PRINTF("RPL : Prefix announced in DIO\n");
+            rpl_set_prefix(dag, &dio->prefix_info.prefix, dio->prefix_info.length);
+          }
+        }
+	global_repair(from, dag, dio);
+      }
+      return;
+    }
+
+    if(lollipop_greater_than(dag->version, dio->version)) {
+      /* The DIO sender is on an older version of the DAG. */
+      PRINTF("RPL: old version received => inconsistency detected\n");
+      if(dag->joined) {
+        rpl_reset_dio_timer(instance);
+        return;
+      }
+    }
+  }
+
+  if(instance == NULL) {
+    PRINTF("RPL: New instance detected: Joining...\n");
+    rpl_join_instance(from, dio);
+    return;
+  }
+
+  if(dag == NULL) {
+    PRINTF("RPL: Adding new DAG to known instance.\n");
+    rpl_add_dag(from, dio);
+    return;
+  }
+
+
+  if(dio->rank < ROOT_RANK(instance)) {
+    PRINTF("RPL: Ignoring DIO with too low rank: %u\n",
+           (unsigned)dio->rank);
+    return;
+  } else if(dio->rank == INFINITE_RANK && dag->joined) {
+    rpl_reset_dio_timer(instance);
+  }
+  
+  /* Prefix Information Option treated to add new prefix */
+  if(dio->prefix_info.length != 0) {
+    if(dio->prefix_info.flags & UIP_ND6_RA_FLAG_AUTONOMOUS) {
+      PRINTF("RPL : Prefix announced in DIO\n");
+      rpl_set_prefix(dag, &dio->prefix_info.prefix, dio->prefix_info.length);
+    }
+  }
+
+  if(dag->rank == ROOT_RANK(instance)) {
+    if(dio->rank != INFINITE_RANK) {
+      instance->dio_counter++;
+    }
+    return;
+  }
+
+  /*
+   * At this point, we know that this DIO pertains to a DAG that
+   * we are already part of. We consider the sender of the DIO to be
+   * a candidate parent, and let rpl_process_parent_event decide
+   * whether to keep it in the set.
+   */
+
+  p = rpl_find_parent(dag, from);
+  if(p == NULL) {
+    previous_dag = find_parent_dag(instance, from);
+    if(previous_dag == NULL) {
+      /* Add the DIO sender as a candidate parent. */
+      p = rpl_add_parent(dag, dio, from);
+      if(p == NULL) {
+        PRINTF("RPL: Failed to add a new parent (");
+        PRINT6ADDR(from);
+        PRINTF(")\n");
+        return;
+      }
+      PRINTF("RPL: New candidate parent with rank %u: ", (unsigned)p->rank);
+      PRINT6ADDR(from);
+      PRINTF("\n");
+    } else {
+      p = rpl_find_parent(previous_dag, from);
+      if(p != NULL) {
+        rpl_move_parent(previous_dag, dag, p);
+      }
+    }
+  } else {
+    if(p->rank == dio->rank) {
+      PRINTF("RPL: Received consistent DIO\n");
+      if(dag->joined) {
+        instance->dio_counter++;
+      }
+    } else {
+      p->rank=dio->rank;
+    }
+  }
+
+  PRINTF("RPL: preferred DAG ");
+  PRINT6ADDR(&instance->current_dag->dag_id);
+  PRINTF(", rank %u, min_rank %u, ",
+	 instance->current_dag->rank, instance->current_dag->min_rank);
+  PRINTF("parent rank %u, parent etx %u, link metric %u, instance etx %u\n",
+	 p->rank, -1/*p->mc.obj.etx*/, p->link_metric, instance->mc.obj.etx);
+
+  /* We have allocated a candidate parent; process the DIO further. */
+
+#if RPL_DAG_MC != RPL_DAG_MC_NONE
+  memcpy(&p->mc, &dio->mc, sizeof(p->mc));
+#endif /* RPL_DAG_MC != RPL_DAG_MC_NONE */
+  if(rpl_process_parent_event(instance, p) == 0) {
+    PRINTF("RPL: The candidate parent is rejected\n");
+    return;
+  }
+
+  /* We don't use route control, so we can have only one official parent. */
+  if(dag->joined && p == dag->preferred_parent) {
+    if(should_send_dao(instance, dio, p)) {
+      RPL_LOLLIPOP_INCREMENT(instance->dtsn_out);
+      rpl_schedule_dao(instance);
+    }
+    /* We received a new DIO from our preferred parent.
+     * Call uip_ds6_defrt_add to set a fresh value for the lifetime counter */
+    uip_ds6_defrt_add(from, RPL_LIFETIME(instance, instance->default_lifetime));
+  }
+  p->dtsn = dio->dtsn;
+}
+/*---------------------------------------------------------------------------*/
+#endif /* UIP_CONF_IPV6 */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/rpl/rpl-ext-header.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/rpl/rpl-ext-header.c
@@ -1,0 +1,358 @@
+/**
+ * \addtogroup uip6
+ * @{
+ */
+/*
+ * Copyright (c) 2009, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+/**
+ * \file
+ *         Management of extension headers for ContikiRPL.
+ *
+ * \author Vincent Brillault <vincent.brillault@imag.fr>,
+ *         Joakim Eriksson <joakime@sics.se>,
+ *         Niclas Finne <nfi@sics.se>,
+ *         Nicolas Tsiftes <nvt@sics.se>.
+ */
+
+#include "net/uip.h"
+#include "net/tcpip.h"
+#include "net/uip-ds6.h"
+#include "net/rpl/rpl-private.h"
+
+#define DEBUG DEBUG_NONE
+#include "net/uip-debug.h"
+
+#include <limits.h>
+#include <string.h>
+
+/*---------------------------------------------------------------------------*/
+#define UIP_IP_BUF                ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN])
+#define UIP_EXT_BUF               ((struct uip_ext_hdr *)&uip_buf[uip_l2_l3_hdr_len])
+#define UIP_HBHO_BUF              ((struct uip_hbho_hdr *)&uip_buf[uip_l2_l3_hdr_len])
+#define UIP_HBHO_NEXT_BUF         ((struct uip_ext_hdr *)&uip_buf[uip_l2_l3_hdr_len + RPL_HOP_BY_HOP_LEN])
+#define UIP_EXT_HDR_OPT_BUF       ((struct uip_ext_hdr_opt *)&uip_buf[uip_l2_l3_hdr_len + uip_ext_opt_offset])
+#define UIP_EXT_HDR_OPT_PADN_BUF  ((struct uip_ext_hdr_opt_padn *)&uip_buf[uip_l2_l3_hdr_len + uip_ext_opt_offset])
+#define UIP_EXT_HDR_OPT_RPL_BUF   ((struct uip_ext_hdr_opt_rpl *)&uip_buf[uip_l2_l3_hdr_len + uip_ext_opt_offset])
+/*---------------------------------------------------------------------------*/
+#if UIP_CONF_IPV6
+int
+rpl_verify_header(int uip_ext_opt_offset)
+{
+  rpl_instance_t *instance;
+  int down;
+  uint8_t sender_closer;
+
+  if(UIP_EXT_HDR_OPT_RPL_BUF->opt_len != RPL_HDR_OPT_LEN) {
+    PRINTF("RPL: Bad header option! (wrong length)\n");
+    return 1;
+  }
+
+  instance = rpl_get_instance(UIP_EXT_HDR_OPT_RPL_BUF->instance);
+  if(instance == NULL) {
+    PRINTF("RPL: Unknown instance: %u\n",
+           UIP_EXT_HDR_OPT_RPL_BUF->instance);
+    return 1;
+  }
+
+  if(UIP_EXT_HDR_OPT_RPL_BUF->flags & RPL_HDR_OPT_FWD_ERR) {
+    /* We should try to repair it by removing the neighbor that caused
+       the packet to be forwareded in the first place. We drop any
+       routes that go through the neighbor that sent the packet to
+       us. */
+    uip_ds6_route_t *route;
+    route = uip_ds6_route_lookup(&UIP_IP_BUF->destipaddr);
+    if(route != NULL) {
+      uip_ds6_route_rm(route);
+
+      /* If we are the root and just needed to remove a DAO route,
+         chances are that the network needs to be repaired. The
+         rpl_repair_root() function will cause a global repair if we
+         happen to be the root node of the dag. */
+      PRINTF("RPL: initiate global repair\n");
+      rpl_repair_root(instance->instance_id);
+    }
+
+    /* Remove the forwarding error flag and return 0 to let the packet
+       be forwarded again. */
+    UIP_EXT_HDR_OPT_RPL_BUF->flags &= ~RPL_HDR_OPT_FWD_ERR;
+    return 0;
+  }
+
+  if(!instance->current_dag->joined) {
+    PRINTF("RPL: No DAG in the instance\n");
+    return 1;
+  }
+
+  down = 0;
+  if(UIP_EXT_HDR_OPT_RPL_BUF->flags & RPL_HDR_OPT_DOWN) {
+    down = 1;
+  }
+
+  sender_closer = UIP_EXT_HDR_OPT_RPL_BUF->senderrank < instance->current_dag->rank;
+
+  PRINTF("RPL: Packet going %s, sender closer %d (%d < %d)\n", down == 1 ? "down" : "up",
+	 sender_closer,
+	 UIP_EXT_HDR_OPT_RPL_BUF->senderrank,
+	 instance->current_dag->rank
+	 );
+
+  if((down && !sender_closer) || (!down && sender_closer)) {
+    PRINTF("RPL: Loop detected - senderrank: %d my-rank: %d sender_closer: %d\n",
+	   UIP_EXT_HDR_OPT_RPL_BUF->senderrank, instance->current_dag->rank,
+	   sender_closer);
+    if(UIP_EXT_HDR_OPT_RPL_BUF->flags & RPL_HDR_OPT_RANK_ERR) {
+      PRINTF("RPL: Rank error signalled in RPL option!\n");
+      /* We should try to repair it, not implemented for the moment */
+      rpl_reset_dio_timer(instance);
+      /* Forward the packet anyway. */
+      return 0;
+    }
+    PRINTF("RPL: Single error tolerated\n");
+    UIP_EXT_HDR_OPT_RPL_BUF->flags |= RPL_HDR_OPT_RANK_ERR;
+    return 0;
+  }
+
+  PRINTF("RPL: Rank OK\n");
+
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+static void
+set_rpl_opt(unsigned uip_ext_opt_offset)
+{
+  uint8_t temp_len;
+
+  memmove(UIP_HBHO_NEXT_BUF, UIP_EXT_BUF, uip_len - UIP_IPH_LEN);
+  memset(UIP_HBHO_BUF, 0, RPL_HOP_BY_HOP_LEN);
+  UIP_HBHO_BUF->next = UIP_IP_BUF->proto;
+  UIP_IP_BUF->proto = UIP_PROTO_HBHO;
+  UIP_HBHO_BUF->len = RPL_HOP_BY_HOP_LEN - 8;
+  UIP_EXT_HDR_OPT_RPL_BUF->opt_type = UIP_EXT_HDR_OPT_RPL;
+  UIP_EXT_HDR_OPT_RPL_BUF->opt_len = RPL_HDR_OPT_LEN;
+  UIP_EXT_HDR_OPT_RPL_BUF->flags = 0;
+  UIP_EXT_HDR_OPT_RPL_BUF->instance = 0;
+  UIP_EXT_HDR_OPT_RPL_BUF->senderrank = 0;
+  uip_len += RPL_HOP_BY_HOP_LEN;
+  temp_len = UIP_IP_BUF->len[1];
+  UIP_IP_BUF->len[1] += UIP_HBHO_BUF->len + 8;
+  if(UIP_IP_BUF->len[1] < temp_len) {
+    UIP_IP_BUF->len[0]++;
+  }
+}
+/*---------------------------------------------------------------------------*/
+void
+rpl_update_header_empty(void)
+{
+  rpl_instance_t *instance;
+  int uip_ext_opt_offset;
+  int last_uip_ext_len;
+
+  last_uip_ext_len = uip_ext_len;
+  uip_ext_len = 0;
+  uip_ext_opt_offset = 2;
+
+  PRINTF("RPL: Verifying the presence of the RPL header option\n");
+
+  switch(UIP_IP_BUF->proto) {
+  case UIP_PROTO_HBHO:
+    if(UIP_HBHO_BUF->len != RPL_HOP_BY_HOP_LEN - 8) {
+      PRINTF("RPL: Non RPL Hop-by-hop options support not implemented\n");
+      uip_ext_len = last_uip_ext_len;
+      return;
+    }
+    instance = rpl_get_instance(UIP_EXT_HDR_OPT_RPL_BUF->instance);
+    if(instance == NULL || !instance->used || !instance->current_dag->joined) {
+      PRINTF("RPL: Unable to add hop-by-hop extension header: incorrect instance\n");
+      return;
+    }
+    break;
+  default:
+    PRINTF("RPL: No hop-by-hop option found, creating it\n");
+    if(uip_len + RPL_HOP_BY_HOP_LEN > UIP_BUFSIZE) {
+      PRINTF("RPL: Packet too long: impossible to add hop-by-hop option\n");
+      uip_ext_len = last_uip_ext_len;
+      return;
+    }
+    set_rpl_opt(uip_ext_opt_offset);
+    uip_ext_len = last_uip_ext_len + RPL_HOP_BY_HOP_LEN;
+    return;
+  }
+
+  switch(UIP_EXT_HDR_OPT_BUF->type) {
+  case UIP_EXT_HDR_OPT_RPL:
+    PRINTF("RPL: Updating RPL option\n");
+    UIP_EXT_HDR_OPT_RPL_BUF->senderrank = instance->current_dag->rank;
+
+    /* Check the direction of the down flag, as per Section 11.2.2.3,
+       which states that if a packet is going down it should in
+       general not go back up again. If this happens, a
+       RPL_HDR_OPT_FWD_ERR should be flagged. */
+    if((UIP_EXT_HDR_OPT_RPL_BUF->flags & RPL_HDR_OPT_DOWN)) {
+      if(uip_ds6_route_lookup(&UIP_IP_BUF->destipaddr) == NULL) {
+        UIP_EXT_HDR_OPT_RPL_BUF->flags |= RPL_HDR_OPT_FWD_ERR;
+        PRINTF("RPL forwarding error\n");
+      }
+    } else {
+      /* Set the down extension flag correctly as described in Section
+         11.2 of RFC6550. If the packet progresses along a DAO route,
+         the down flag should be set. */
+      if(uip_ds6_route_lookup(&UIP_IP_BUF->destipaddr) == NULL) {
+        /* No route was found, so this packet will go towards the RPL
+           root. If so, we should not set the down flag. */
+        UIP_EXT_HDR_OPT_RPL_BUF->flags &= ~RPL_HDR_OPT_DOWN;
+        PRINTF("RPL option going up\n");
+      } else {
+        /* A DAO route was found so we set the down flag. */
+        UIP_EXT_HDR_OPT_RPL_BUF->flags |= RPL_HDR_OPT_DOWN;
+        PRINTF("RPL option going down\n");
+      }
+    }
+
+    uip_ext_len = last_uip_ext_len;
+    return;
+  default:
+    PRINTF("RPL: Multi Hop-by-hop options not implemented\n");
+    uip_ext_len = last_uip_ext_len;
+    return;
+  }
+}
+/*---------------------------------------------------------------------------*/
+int
+rpl_update_header_final(uip_ipaddr_t *addr)
+{
+  rpl_parent_t *parent;
+  int uip_ext_opt_offset;
+  int last_uip_ext_len;
+
+  last_uip_ext_len = uip_ext_len;
+  uip_ext_len = 0;
+  uip_ext_opt_offset = 2;
+
+  if(UIP_IP_BUF->proto == UIP_PROTO_HBHO) {
+    if(UIP_HBHO_BUF->len != RPL_HOP_BY_HOP_LEN - 8) {
+      PRINTF("RPL: Non RPL Hop-by-hop options support not implemented\n");
+      uip_ext_len = last_uip_ext_len;
+      return 0;
+    }
+
+    if(UIP_EXT_HDR_OPT_BUF->type == UIP_EXT_HDR_OPT_RPL) {
+      if(UIP_EXT_HDR_OPT_RPL_BUF->senderrank == 0) {
+        PRINTF("RPL: Updating RPL option\n");
+        if(default_instance == NULL || !default_instance->used || !default_instance->current_dag->joined) {
+          PRINTF("RPL: Unable to add hop-by-hop extension header: incorrect default instance\n");
+          return 1;
+        }
+        parent = rpl_find_parent(default_instance->current_dag, addr);
+        if(parent == NULL || parent != parent->dag->preferred_parent) {
+          UIP_EXT_HDR_OPT_RPL_BUF->flags = RPL_HDR_OPT_DOWN;
+        }
+        UIP_EXT_HDR_OPT_RPL_BUF->instance = default_instance->instance_id;
+        UIP_EXT_HDR_OPT_RPL_BUF->senderrank = default_instance->current_dag->rank;
+        uip_ext_len = last_uip_ext_len;
+      }
+    }
+  }
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+void
+rpl_remove_header(void)
+{
+  uint8_t temp_len;
+
+  uip_ext_len = 0;
+
+  PRINTF("RPL: Verifying the presence of the RPL header option\n");
+  switch(UIP_IP_BUF->proto){
+  case UIP_PROTO_HBHO:
+    PRINTF("RPL: Removing the RPL header option\n");
+    UIP_IP_BUF->proto = UIP_HBHO_BUF->next;
+    temp_len = UIP_IP_BUF->len[1];
+    uip_len -= UIP_HBHO_BUF->len + 8;
+    UIP_IP_BUF->len[1] -= UIP_HBHO_BUF->len + 8;
+    if(UIP_IP_BUF->len[1] > temp_len) {
+      UIP_IP_BUF->len[0]--;
+    }
+    memmove(UIP_EXT_BUF, UIP_HBHO_NEXT_BUF, uip_len - UIP_IPH_LEN);
+    break;
+  default:
+    PRINTF("RPL: No hop-by-hop Option found\n");
+  }
+}
+/*---------------------------------------------------------------------------*/
+uint8_t
+rpl_invert_header(void)
+{
+  uint8_t uip_ext_opt_offset;
+  uint8_t last_uip_ext_len;
+
+  last_uip_ext_len = uip_ext_len;
+  uip_ext_len = 0;
+  uip_ext_opt_offset = 2;
+
+  PRINTF("RPL: Verifying the presence of the RPL header option\n");
+  switch(UIP_IP_BUF->proto) {
+  case UIP_PROTO_HBHO:
+    break;
+  default:
+    PRINTF("RPL: No hop-by-hop Option found\n");
+    uip_ext_len = last_uip_ext_len;
+    return 0;
+  }
+
+  switch (UIP_EXT_HDR_OPT_BUF->type) {
+  case UIP_EXT_HDR_OPT_RPL:
+    PRINTF("RPL: Updating RPL option (switching direction)\n");
+    UIP_EXT_HDR_OPT_RPL_BUF->flags &= RPL_HDR_OPT_DOWN;
+    UIP_EXT_HDR_OPT_RPL_BUF->flags ^= RPL_HDR_OPT_DOWN;
+    UIP_EXT_HDR_OPT_RPL_BUF->senderrank = rpl_get_instance(UIP_EXT_HDR_OPT_RPL_BUF->instance)->current_dag->rank;
+    uip_ext_len = last_uip_ext_len;
+    return RPL_HOP_BY_HOP_LEN;
+  default:
+    PRINTF("RPL: Multi Hop-by-hop options not implemented\n");
+    uip_ext_len = last_uip_ext_len;
+    return 0;
+  }
+}
+/*---------------------------------------------------------------------------*/
+void
+rpl_insert_header(void)
+{
+  uint8_t uip_ext_opt_offset;
+  if(default_instance != NULL) {
+    uip_ext_opt_offset = 2;
+    if(UIP_EXT_HDR_OPT_BUF->type == UIP_EXT_HDR_OPT_RPL) {
+      rpl_update_header_empty();
+    }
+  }
+}
+/*---------------------------------------------------------------------------*/
+#endif /* UIP_CONF_IPV6 */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/rpl/rpl-icmp6.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/rpl/rpl-icmp6.c
@@ -1,0 +1,905 @@
+/**
+ * \addtogroup uip6
+ * @{
+ */
+/*
+ * Copyright (c) 2010, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+/**
+ * \file
+ *         ICMP6 I/O for RPL control messages.
+ *
+ * \author Joakim Eriksson <joakime@sics.se>, Nicolas Tsiftes <nvt@sics.se>
+ * Contributors: Niclas Finne <nfi@sics.se>, Joel Hoglund <joel@sics.se>,
+ *               Mathieu Pouillot <m.pouillot@watteco.com>
+ */
+
+#include "net/tcpip.h"
+#include "net/uip.h"
+#include "net/uip-ds6.h"
+#include "net/uip-nd6.h"
+#include "net/uip-icmp6.h"
+#include "net/rpl/rpl-private.h"
+#include "net/packetbuf_d.h"
+
+#include <limits.h>
+#include <string.h>
+
+#define DEBUG DEBUG_NONE
+
+#include "net/uip-debug.h"
+
+#if UIP_CONF_IPV6
+/*---------------------------------------------------------------------------*/
+#define RPL_DIO_GROUNDED                 0x80
+#define RPL_DIO_MOP_SHIFT                3
+#define RPL_DIO_MOP_MASK                 0x3c
+#define RPL_DIO_PREFERENCE_MASK          0x07
+
+#define UIP_IP_BUF       ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN])
+#define UIP_ICMP_BUF     ((struct uip_icmp_hdr *)&uip_buf[uip_l2_l3_hdr_len])
+#define UIP_ICMP_PAYLOAD ((unsigned char *)&uip_buf[uip_l2_l3_icmp_hdr_len])
+/*---------------------------------------------------------------------------*/
+static void dis_input(void);
+static void dio_input(void);
+static void dao_input(void);
+static void dao_ack_input(void);
+
+/* some debug callbacks useful when debugging RPL networks */
+#ifdef RPL_DEBUG_DIO_INPUT
+void RPL_DEBUG_DIO_INPUT(uip_ipaddr_t *, rpl_dio_t *);
+#endif
+
+#ifdef RPL_DEBUG_DAO_OUTPUT
+void RPL_DEBUG_DAO_OUTPUT(rpl_parent_t *);
+#endif
+
+static uint8_t dao_sequence = RPL_LOLLIPOP_INIT;
+
+/* some debug callbacks useful when debugging RPL networks */
+#ifdef RPL_DEBUG_DIO_INPUT
+void RPL_DEBUG_DIO_INPUT(uip_ipaddr_t *, rpl_dio_t *);
+#endif
+
+#ifdef RPL_DEBUG_DAO_OUTPUT
+void RPL_DEBUG_DAO_OUTPUT(rpl_parent_t *);
+#endif
+
+extern rpl_of_t RPL_OF;
+
+/*---------------------------------------------------------------------------*/
+static int
+get_global_addr(uip_ipaddr_t *addr)
+{
+  int i;
+  int state;
+
+  for(i = 0; i < UIP_DS6_ADDR_NB; i++) {
+    state = uip_ds6_if.addr_list[i].state;
+    if(uip_ds6_if.addr_list[i].isused &&
+       (state == ADDR_TENTATIVE || state == ADDR_PREFERRED)) {
+      if(!uip_is_addr_link_local(&uip_ds6_if.addr_list[i].ipaddr)) {
+        memcpy(addr, &uip_ds6_if.addr_list[i].ipaddr, sizeof(uip_ipaddr_t));
+        return 1;
+      }
+    }
+  }
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+static uint32_t
+get32(uint8_t *buffer, int pos)
+{
+  return (uint32_t)buffer[pos] << 24 | (uint32_t)buffer[pos + 1] << 16 |
+         (uint32_t)buffer[pos + 2] << 8 | buffer[pos + 3];
+}
+/*---------------------------------------------------------------------------*/
+static void
+set32(uint8_t *buffer, int pos, uint32_t value)
+{
+  buffer[pos++] = value >> 24;
+  buffer[pos++] = (value >> 16) & 0xff;
+  buffer[pos++] = (value >> 8) & 0xff;
+  buffer[pos++] = value & 0xff;
+}
+/*---------------------------------------------------------------------------*/
+static uint16_t
+get16(uint8_t *buffer, int pos)
+{
+  return (uint16_t)buffer[pos] << 8 | buffer[pos + 1];
+}
+/*---------------------------------------------------------------------------*/
+static void
+set16(uint8_t *buffer, int pos, uint16_t value)
+{
+  buffer[pos++] = value >> 8;
+  buffer[pos++] = value & 0xff;
+}
+/*---------------------------------------------------------------------------*/
+static void
+dis_input(void)
+{
+  rpl_instance_t *instance;
+  rpl_instance_t *end;
+
+  /* DAG Information Solicitation */
+  PRINTF("RPL: Received a DIS from ");
+  PRINT6ADDR(&UIP_IP_BUF->srcipaddr);
+  PRINTF("\n");
+
+  for(instance = &instance_table[0], end = instance + RPL_MAX_INSTANCES; instance < end; ++instance) {
+    if(instance->used == 1) {
+#if RPL_LEAF_ONLY
+      if(!uip_is_addr_mcast(&UIP_IP_BUF->destipaddr)) {
+	PRINTF("RPL: LEAF ONLY Multicast DIS will NOT reset DIO timer\n");
+#else /* !RPL_LEAF_ONLY */
+      if(uip_is_addr_mcast(&UIP_IP_BUF->destipaddr)) {
+        PRINTF("RPL: Multicast DIS => reset DIO timer\n");
+        rpl_reset_dio_timer(instance);
+      } else {
+#endif /* !RPL_LEAF_ONLY */
+        PRINTF("RPL: Unicast DIS, reply to sender\n");
+        dio_output(instance, &UIP_IP_BUF->srcipaddr);
+      }
+    }
+  }
+}
+/*---------------------------------------------------------------------------*/
+void
+dis_output(uip_ipaddr_t *addr)
+{
+  unsigned char *buffer;
+  uip_ipaddr_t tmpaddr;
+
+  /* DAG Information Solicitation  - 2 bytes reserved      */
+  /*      0                   1                   2        */
+  /*      0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3  */
+  /*     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ */
+  /*     |     Flags     |   Reserved    |   Option(s)...  */
+  /*     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ */
+
+  buffer = UIP_ICMP_PAYLOAD;
+  buffer[0] = buffer[1] = 0;
+
+  if(addr == NULL) {
+    uip_create_linklocal_rplnodes_mcast(&tmpaddr);
+    addr = &tmpaddr;
+  }
+
+  PRINTF("RPL: Sending a DIS to ");
+  PRINT6ADDR(addr);
+  PRINTF("\n");
+
+  uip_icmp6_send(addr, ICMP6_RPL, RPL_CODE_DIS, 2);
+}
+/*---------------------------------------------------------------------------*/
+static void
+dio_input(void)
+{
+  unsigned char *buffer;
+  uint8_t buffer_length;
+  rpl_dio_t dio;
+  uint8_t subopt_type;
+  int i;
+  int len;
+  uip_ipaddr_t from;
+  uip_ds6_nbr_t *nbr;
+
+  memset(&dio, 0, sizeof(dio));
+
+  /* Set default values in case the DIO configuration option is missing. */
+  dio.dag_intdoubl = RPL_DIO_INTERVAL_DOUBLINGS;
+  dio.dag_intmin = RPL_DIO_INTERVAL_MIN;
+  dio.dag_redund = RPL_DIO_REDUNDANCY;
+  dio.dag_min_hoprankinc = RPL_MIN_HOPRANKINC;
+  dio.dag_max_rankinc = RPL_MAX_RANKINC;
+  dio.ocp = RPL_OF.ocp;
+  dio.default_lifetime = RPL_DEFAULT_LIFETIME;
+  dio.lifetime_unit = RPL_DEFAULT_LIFETIME_UNIT;
+
+  uip_ipaddr_copy(&from, &UIP_IP_BUF->srcipaddr);
+
+  /* DAG Information Object */
+  PRINTF("RPL: Received a DIO from ");
+  PRINT6ADDR(&from);
+  PRINTF("\n");
+
+  if((nbr = uip_ds6_nbr_lookup(&from)) == NULL) {
+    if((nbr = uip_ds6_nbr_add(&from, (uip_lladdr_t *)
+                              packetbuf_d_addr(PACKETBUF_D_ADDR_SENDER),
+                              0, NBR_REACHABLE)) != NULL) {
+      /* set reachable timer */
+      stimer_set(&nbr->reachable, UIP_ND6_REACHABLE_TIME / 1000);
+      PRINTF("RPL: Neighbor added to neighbor cache ");
+      PRINT6ADDR(&from);
+      PRINTF(", ");
+      PRINTLLADDR((uip_lladdr_t *)packetbuf_d_addr(PACKETBUF_D_ADDR_SENDER));
+      PRINTF("\n");
+    } else {
+      PRINTF("RPL: Out of Memory, dropping DIO from ");
+      PRINT6ADDR(&from);
+      PRINTF(", ");
+      PRINTLLADDR((uip_lladdr_t *)packetbuf_d_addr(PACKETBUF_D_ADDR_SENDER));
+      PRINTF("\n");
+      return;
+    }
+  } else {
+    PRINTF("RPL: Neighbor already in neighbor cache\n");
+  }
+
+  buffer_length = uip_len - uip_l3_icmp_hdr_len;
+
+  /* Process the DIO base option. */
+  i = 0;
+  buffer = UIP_ICMP_PAYLOAD;
+
+  dio.instance_id = buffer[i++];
+  dio.version = buffer[i++];
+  dio.rank = get16(buffer, i);
+  i += 2;
+
+  PRINTF("RPL: Incoming DIO (id, ver, rank) = (%u,%u,%u)\n",
+         (unsigned)dio.instance_id,
+         (unsigned)dio.version, 
+         (unsigned)dio.rank);
+
+  dio.grounded = buffer[i] & RPL_DIO_GROUNDED;
+  dio.mop = (buffer[i]& RPL_DIO_MOP_MASK) >> RPL_DIO_MOP_SHIFT;
+  dio.preference = buffer[i++] & RPL_DIO_PREFERENCE_MASK;
+
+  dio.dtsn = buffer[i++];
+  /* two reserved bytes */
+  i += 2;
+
+  memcpy(&dio.dag_id, buffer + i, sizeof(dio.dag_id));
+  i += sizeof(dio.dag_id);
+
+  PRINTF("RPL: Incoming DIO (dag_id, pref) = (");
+  PRINT6ADDR(&dio.dag_id);
+  PRINTF(", %u)\n", dio.preference);
+
+  /* Check if there are any DIO suboptions. */
+  for(; i < buffer_length; i += len) {
+    subopt_type = buffer[i];
+    if(subopt_type == RPL_OPTION_PAD1) {
+      len = 1;
+    } else {
+      /* Suboption with a two-byte header + payload */
+      len = 2 + buffer[i + 1];
+    }
+
+    if(len + i > buffer_length) {
+      PRINTF("RPL: Invalid DIO packet\n");
+      RPL_STAT(rpl_stats.malformed_msgs++);
+      return;
+    }
+
+    PRINTF("RPL: DIO option %u, length: %u\n", subopt_type, len - 2);
+
+    switch(subopt_type) {
+    case RPL_OPTION_DAG_METRIC_CONTAINER:
+      if(len < 6) {
+        PRINTF("RPL: Invalid DAG MC, len = %d\n", len);
+	RPL_STAT(rpl_stats.malformed_msgs++);
+        return;
+      }
+      dio.mc.type = buffer[i + 2];
+      dio.mc.flags = buffer[i + 3] << 1;
+      dio.mc.flags |= buffer[i + 4] >> 7;
+      dio.mc.aggr = (buffer[i + 4] >> 4) & 0x3;
+      dio.mc.prec = buffer[i + 4] & 0xf;
+      dio.mc.length = buffer[i + 5];
+
+      if(dio.mc.type == RPL_DAG_MC_NONE) {
+        /* No metric container: do nothing */
+      } else if(dio.mc.type == RPL_DAG_MC_ETX) {
+        dio.mc.obj.etx = get16(buffer, i + 6);
+
+        PRINTF("RPL: DAG MC: type %u, flags %u, aggr %u, prec %u, length %u, ETX %u\n",
+	       (unsigned)dio.mc.type,  
+	       (unsigned)dio.mc.flags, 
+	       (unsigned)dio.mc.aggr, 
+	       (unsigned)dio.mc.prec, 
+	       (unsigned)dio.mc.length, 
+	       (unsigned)dio.mc.obj.etx);
+      } else if(dio.mc.type == RPL_DAG_MC_ENERGY) {
+        dio.mc.obj.energy.flags = buffer[i + 6];
+        dio.mc.obj.energy.energy_est = buffer[i + 7];
+      } else {
+       PRINTF("RPL: Unhandled DAG MC type: %u\n", (unsigned)dio.mc.type);
+       return;
+      }
+      break;
+    case RPL_OPTION_ROUTE_INFO:
+      if(len < 9) {
+        PRINTF("RPL: Invalid destination prefix option, len = %d\n", len);
+	RPL_STAT(rpl_stats.malformed_msgs++);
+        return;
+      }
+
+      /* The flags field includes the preference value. */
+      dio.destination_prefix.length = buffer[i + 2];
+      dio.destination_prefix.flags = buffer[i + 3];
+      dio.destination_prefix.lifetime = get32(buffer, i + 4);
+
+      if(((dio.destination_prefix.length + 7) / 8) + 8 <= len &&
+         dio.destination_prefix.length <= 128) {
+        PRINTF("RPL: Copying destination prefix\n");
+        memcpy(&dio.destination_prefix.prefix, &buffer[i + 8],
+               (dio.destination_prefix.length + 7) / 8);
+      } else {
+        PRINTF("RPL: Invalid route info option, len = %d\n", len);
+	RPL_STAT(rpl_stats.malformed_msgs++);
+	return;
+      }
+
+      break;
+    case RPL_OPTION_DAG_CONF:
+      if(len != 16) {
+        PRINTF("RPL: Invalid DAG configuration option, len = %d\n", len);
+	RPL_STAT(rpl_stats.malformed_msgs++);
+        return;
+      }
+
+      /* Path control field not yet implemented - at i + 2 */
+      dio.dag_intdoubl = buffer[i + 3];
+      dio.dag_intmin = buffer[i + 4];
+      dio.dag_redund = buffer[i + 5];
+      dio.dag_max_rankinc = get16(buffer, i + 6);
+      dio.dag_min_hoprankinc = get16(buffer, i + 8);
+      dio.ocp = get16(buffer, i + 10);
+      /* buffer + 12 is reserved */
+      dio.default_lifetime = buffer[i + 13];
+      dio.lifetime_unit = get16(buffer, i + 14);
+      PRINTF("RPL: DAG conf:dbl=%d, min=%d red=%d maxinc=%d mininc=%d ocp=%d d_l=%u l_u=%u\n",
+             dio.dag_intdoubl, dio.dag_intmin, dio.dag_redund,
+             dio.dag_max_rankinc, dio.dag_min_hoprankinc, dio.ocp,
+             dio.default_lifetime, dio.lifetime_unit);
+      break;
+    case RPL_OPTION_PREFIX_INFO:
+      if(len != 32) {
+        PRINTF("RPL: DAG prefix info not ok, len != 32\n");
+	RPL_STAT(rpl_stats.malformed_msgs++);
+        return;
+      }
+      dio.prefix_info.length = buffer[i + 2];
+      dio.prefix_info.flags = buffer[i + 3];
+      /* valid lifetime is ingnored for now - at i + 4 */
+      /* preferred lifetime stored in lifetime */
+      dio.prefix_info.lifetime = get32(buffer, i + 8);
+      /* 32-bit reserved at i + 12 */
+      PRINTF("RPL: Copying prefix information\n");
+      memcpy(&dio.prefix_info.prefix, &buffer[i + 16], 16);
+      break;
+    default:
+      PRINTF("RPL: Unsupported suboption type in DIO: %u\n",
+	(unsigned)subopt_type);
+    }
+  }
+
+#ifdef RPL_DEBUG_DIO_INPUT
+  RPL_DEBUG_DIO_INPUT(&from, &dio);
+#endif
+
+  rpl_process_dio(&from, &dio);
+}
+/*---------------------------------------------------------------------------*/
+#pragma stackfunction 50    //TODO: CHSC find out, how much stack is really used
+void
+dio_output(rpl_instance_t *instance, uip_ipaddr_t *uc_addr)
+{
+  unsigned char *buffer;
+  int pos;
+  rpl_dag_t *dag = instance->current_dag;
+#if !RPL_LEAF_ONLY
+  uip_ipaddr_t addr;
+#endif /* !RPL_LEAF_ONLY */
+
+#if RPL_LEAF_ONLY
+  /* In leaf mode, we send DIO message only as unicasts in response to 
+     unicast DIS messages. */
+  if(uc_addr == NULL) {
+    PRINTF("RPL: LEAF ONLY have multicast addr: skip dio_output\n");
+    return;
+  }
+#endif /* RPL_LEAF_ONLY */
+
+  /* DAG Information Object */
+  pos = 0;
+
+  buffer = UIP_ICMP_PAYLOAD;
+  buffer[pos++] = instance->instance_id;
+  buffer[pos++] = dag->version;
+
+#if RPL_LEAF_ONLY
+  PRINTF("RPL: LEAF ONLY DIO rank set to INFINITE_RANK\n");
+  set16(buffer, pos, INFINITE_RANK);
+#else /* RPL_LEAF_ONLY */
+  set16(buffer, pos, dag->rank);
+#endif /* RPL_LEAF_ONLY */
+  pos += 2;
+
+  buffer[pos] = 0;
+  if(dag->grounded) {
+    buffer[pos] |= RPL_DIO_GROUNDED;
+  }
+
+  buffer[pos] |= instance->mop << RPL_DIO_MOP_SHIFT;
+  buffer[pos] |= dag->preference & RPL_DIO_PREFERENCE_MASK;
+  pos++;
+
+  buffer[pos++] = instance->dtsn_out;
+
+  /* always request new DAO to refresh route */
+  RPL_LOLLIPOP_INCREMENT(instance->dtsn_out);
+
+  /* reserved 2 bytes */
+  buffer[pos++] = 0; /* flags */
+  buffer[pos++] = 0; /* reserved */
+
+  memcpy(buffer + pos, &dag->dag_id, sizeof(dag->dag_id));
+  pos += 16;
+
+#if !RPL_LEAF_ONLY
+  if(instance->mc.type != RPL_DAG_MC_NONE) {
+    instance->of->update_metric_container(instance);
+
+    buffer[pos++] = RPL_OPTION_DAG_METRIC_CONTAINER;
+    buffer[pos++] = 6;
+    buffer[pos++] = instance->mc.type;
+    buffer[pos++] = instance->mc.flags >> 1;
+    buffer[pos] = (instance->mc.flags & 1) << 7;
+    buffer[pos++] |= (instance->mc.aggr << 4) | instance->mc.prec;
+    if(instance->mc.type == RPL_DAG_MC_ETX) {
+      buffer[pos++] = 2;
+      set16(buffer, pos, instance->mc.obj.etx);
+      pos += 2;
+    } else if(instance->mc.type == RPL_DAG_MC_ENERGY) {
+      buffer[pos++] = 2;
+      buffer[pos++] = instance->mc.obj.energy.flags;
+      buffer[pos++] = instance->mc.obj.energy.energy_est;
+    } else {
+      PRINTF("RPL: Unable to send DIO because of unhandled DAG MC type %u\n",
+	(unsigned)instance->mc.type);
+      return;
+    }
+  }
+#endif /* !RPL_LEAF_ONLY */
+
+  /* Always add a DAG configuration option. */
+  buffer[pos++] = RPL_OPTION_DAG_CONF;
+  buffer[pos++] = 14;
+  buffer[pos++] = 0; /* No Auth, PCS = 0 */
+  buffer[pos++] = instance->dio_intdoubl;
+  buffer[pos++] = instance->dio_intmin;
+  buffer[pos++] = instance->dio_redundancy;
+  set16(buffer, pos, instance->max_rankinc);
+  pos += 2;
+  set16(buffer, pos, instance->min_hoprankinc);
+  pos += 2;
+  /* OCP is in the DAG_CONF option */
+  set16(buffer, pos, instance->of->ocp);
+  pos += 2;
+  buffer[pos++] = 0; /* reserved */
+  buffer[pos++] = instance->default_lifetime;
+  set16(buffer, pos, instance->lifetime_unit);
+  pos += 2;
+
+  /* Check if we have a prefix to send also. */
+  if(dag->prefix_info.length > 0) {
+    buffer[pos++] = RPL_OPTION_PREFIX_INFO;
+    buffer[pos++] = 30; /* always 30 bytes + 2 long */
+    buffer[pos++] = dag->prefix_info.length;
+    buffer[pos++] = dag->prefix_info.flags;
+    set32(buffer, pos, dag->prefix_info.lifetime);
+    pos += 4;
+    set32(buffer, pos, dag->prefix_info.lifetime);
+    pos += 4;
+    memset(&buffer[pos], 0, 4);
+    pos += 4;
+    memcpy(&buffer[pos], &dag->prefix_info.prefix, 16);
+    pos += 16;
+    PRINTF("RPL: Sending prefix info in DIO for ");
+    PRINT6ADDR(&dag->prefix_info.prefix);
+    PRINTF("\n");
+  } else {
+    PRINTF("RPL: No prefix to announce (len %d)\n",
+           dag->prefix_info.length);
+  }
+
+#if RPL_LEAF_ONLY
+#if (DEBUG) & DEBUG_PRINT
+  if(uc_addr == NULL) {
+    PRINTF("RPL: LEAF ONLY sending unicast-DIO from multicast-DIO\n");
+  }
+#endif /* DEBUG_PRINT */
+  PRINTF("RPL: Sending unicast-DIO with rank %u to ",
+      (unsigned)dag->rank);
+  PRINT6ADDR(uc_addr);
+  PRINTF("\n");
+  uip_icmp6_send(uc_addr, ICMP6_RPL, RPL_CODE_DIO, pos);
+#else /* RPL_LEAF_ONLY */
+  /* Unicast requests get unicast replies! */
+  if(uc_addr == NULL) {
+    PRINTF("RPL: Sending a multicast-DIO with rank %u\n",
+        (unsigned)instance->current_dag->rank);
+    uip_create_linklocal_rplnodes_mcast(&addr);
+    uip_icmp6_send(&addr, ICMP6_RPL, RPL_CODE_DIO, pos);
+  } else {
+    PRINTF("RPL: Sending unicast-DIO with rank %u to ",
+        (unsigned)instance->current_dag->rank);
+    PRINT6ADDR(uc_addr);
+    PRINTF("\n");
+    uip_icmp6_send(uc_addr, ICMP6_RPL, RPL_CODE_DIO, pos);
+  }
+#endif /* RPL_LEAF_ONLY */
+}
+/*---------------------------------------------------------------------------*/
+static void
+dao_input(void)
+{
+  uip_ipaddr_t dao_sender_addr;
+  rpl_dag_t *dag;
+  rpl_instance_t *instance;
+  unsigned char *buffer;
+  uint16_t sequence;
+  uint8_t instance_id;
+  uint8_t lifetime;
+  uint8_t prefixlen;
+  uint8_t flags;
+  uint8_t subopt_type;
+  /*
+  uint8_t pathcontrol;
+  uint8_t pathsequence;
+  */
+  uip_ipaddr_t prefix;
+  uip_ds6_route_t *rep;
+  uint8_t buffer_length;
+  int pos;
+  int len;
+  int i;
+  int learned_from;
+  rpl_parent_t *p;
+
+  prefixlen = 0;
+
+  uip_ipaddr_copy(&dao_sender_addr, &UIP_IP_BUF->srcipaddr);
+
+  /* Destination Advertisement Object */
+  PRINTF("RPL: Received a DAO from ");
+  PRINT6ADDR(&dao_sender_addr);
+  PRINTF("\n");
+
+  buffer = UIP_ICMP_PAYLOAD;
+  buffer_length = uip_len - uip_l3_icmp_hdr_len;
+
+  pos = 0;
+  instance_id = buffer[pos++];
+
+  instance = rpl_get_instance(instance_id);
+  if(instance == NULL) {
+    PRINTF("RPL: Ignoring a DAO for an unknown RPL instance(%u)\n",
+           instance_id);
+    return;
+  }
+
+  lifetime = instance->default_lifetime;
+
+  flags = buffer[pos++];
+  /* reserved */
+  pos++;
+  sequence = buffer[pos++];
+
+  dag = instance->current_dag;
+  /* Is the DAGID present? */
+  if(flags & RPL_DAO_D_FLAG) {
+    if(memcmp(&dag->dag_id, &buffer[pos], sizeof(dag->dag_id))) {
+      PRINTF("RPL: Ignoring a DAO for a DAG different from ours\n");
+      return;
+    }
+    pos += 16;
+  } else {
+    /* Perhaps, there are verification to do but ... */
+  }
+
+  /* Check if there are any RPL options present. */
+  for(i = pos; i < buffer_length; i += len) {
+    subopt_type = buffer[i];
+    if(subopt_type == RPL_OPTION_PAD1) {
+      len = 1;
+    } else {
+      /* The option consists of a two-byte header and a payload. */
+      len = 2 + buffer[i + 1];
+    }
+
+    switch(subopt_type) {
+    case RPL_OPTION_TARGET:
+      /* Handle the target option. */
+      prefixlen = buffer[i + 3];
+      memset(&prefix, 0, sizeof(prefix));
+      memcpy(&prefix, buffer + i + 4, (prefixlen + 7) / CHAR_BIT);
+      break;
+    case RPL_OPTION_TRANSIT:
+      /* The path sequence and control are ignored. */
+      /*      pathcontrol = buffer[i + 3];
+              pathsequence = buffer[i + 4];*/
+      lifetime = buffer[i + 5];
+      /* The parent address is also ignored. */
+      break;
+    }
+  }
+
+  PRINTF("RPL: DAO lifetime: %u, prefix length: %u prefix: ",
+          (unsigned)lifetime, (unsigned)prefixlen);
+  PRINT6ADDR(&prefix);
+  PRINTF("\n");
+
+  rep = uip_ds6_route_lookup(&prefix);
+
+  if(lifetime == RPL_ZERO_LIFETIME) {
+    PRINTF("RPL: No-Path DAO received\n");
+    /* No-Path DAO received; invoke the route purging routine. */
+    if(rep != NULL &&
+       rep->state.nopath_received == 0 &&
+       rep->length == prefixlen &&
+       uip_ds6_route_nexthop(rep) != NULL &&
+       uip_ipaddr_cmp(uip_ds6_route_nexthop(rep), &dao_sender_addr)) {
+      PRINTF("RPL: Setting expiration timer for prefix ");
+      PRINT6ADDR(&prefix);
+      PRINTF("\n");
+      rep->state.nopath_received = 1;
+      rep->state.lifetime = DAO_EXPIRATION_TIMEOUT;
+    }
+    return;
+  }
+
+  learned_from = uip_is_addr_mcast(&dao_sender_addr) ?
+                 RPL_ROUTE_FROM_MULTICAST_DAO : RPL_ROUTE_FROM_UNICAST_DAO;
+
+  PRINTF("RPL: DAO from %s\n",
+         learned_from == RPL_ROUTE_FROM_UNICAST_DAO? "unicast": "multicast");
+  if(learned_from == RPL_ROUTE_FROM_UNICAST_DAO) {
+    /* Check whether this is a DAO forwarding loop. */
+    p = rpl_find_parent(dag, &dao_sender_addr);
+    /* check if this is a new DAO registration with an "illegal" rank */
+    /* if we already route to this node it is likely */
+    if(p != NULL &&
+       DAG_RANK(p->rank, instance) < DAG_RANK(dag->rank, instance)) {
+      PRINTF("RPL: Loop detected when receiving a unicast DAO from a node with a lower rank! (%u < %u)\n",
+          DAG_RANK(p->rank, instance), DAG_RANK(dag->rank, instance));
+      p->rank = INFINITE_RANK;
+      p->updated = 1;
+      return;
+    }
+
+    /* If we get the DAO from our parent, we also have a loop. */
+    if(p != NULL && p == dag->preferred_parent) {
+      PRINTF("RPL: Loop detected when receiving a unicast DAO from our parent\n");
+      p->rank = INFINITE_RANK;
+      p->updated = 1;
+      return;
+    }
+  }
+
+  PRINTF("RPL: adding DAO route\n");
+  rep = rpl_add_route(dag, &prefix, prefixlen, &dao_sender_addr);
+  if(rep == NULL) {
+    RPL_STAT(rpl_stats.mem_overflows++);
+    PRINTF("RPL: Could not add a route after receiving a DAO\n");
+    return;
+  }
+
+  rep->state.lifetime = RPL_LIFETIME(instance, lifetime);
+  rep->state.learned_from = learned_from;
+
+  if(learned_from == RPL_ROUTE_FROM_UNICAST_DAO) {
+    if(dag->preferred_parent != NULL &&
+       rpl_get_parent_ipaddr(dag->preferred_parent) != NULL) {
+      PRINTF("RPL: Forwarding DAO to parent ");
+      PRINT6ADDR(rpl_get_parent_ipaddr(dag->preferred_parent));
+      PRINTF("\n");
+      uip_icmp6_send(rpl_get_parent_ipaddr(dag->preferred_parent),
+                     ICMP6_RPL, RPL_CODE_DAO, buffer_length);
+    }
+    if(flags & RPL_DAO_K_FLAG) {
+      dao_ack_output(instance, &dao_sender_addr, sequence);
+    }
+  }
+}
+/*---------------------------------------------------------------------------*/
+void
+dao_output(rpl_parent_t *parent, uint8_t lifetime)
+{
+  /* Destination Advertisement Object */
+  uip_ipaddr_t prefix;
+
+  if(get_global_addr(&prefix) == 0) {
+    PRINTF("RPL: No global address set for this node - suppressing DAO\n");
+    return;
+  }
+
+  /* Sending a DAO with own prefix as target */
+  dao_output_target(parent, &prefix, lifetime);
+}
+/*---------------------------------------------------------------------------*/
+void
+dao_output_target(rpl_parent_t *parent, uip_ipaddr_t *prefix, uint8_t lifetime)
+{
+  rpl_dag_t *dag;
+  rpl_instance_t *instance;
+  unsigned char *buffer;
+  uint8_t prefixlen;
+  int pos;
+
+  /* Destination Advertisement Object */
+
+  if(parent == NULL) {
+    PRINTF("RPL dao_output_target error parent NULL\n");
+    return;
+  }
+
+  dag = parent->dag;
+  if(dag == NULL) {
+    PRINTF("RPL dao_output_target error dag NULL\n");
+    return;
+  }
+
+  instance = dag->instance;
+
+  if(instance == NULL) {
+    PRINTF("RPL dao_output_target error instance NULL\n");
+    return;
+  }
+  if(prefix == NULL) {
+    PRINTF("RPL dao_output_target error prefix NULL\n");
+    return;
+  }
+#ifdef RPL_DEBUG_DAO_OUTPUT
+  RPL_DEBUG_DAO_OUTPUT(parent);
+#endif
+
+  buffer = UIP_ICMP_PAYLOAD;
+
+  RPL_LOLLIPOP_INCREMENT(dao_sequence);
+  pos = 0;
+
+  buffer[pos++] = instance->instance_id;
+  buffer[pos] = 0;
+#if RPL_DAO_SPECIFY_DAG
+  buffer[pos] |= RPL_DAO_D_FLAG;
+#endif /* RPL_DAO_SPECIFY_DAG */
+#if RPL_CONF_DAO_ACK
+  buffer[pos] |= RPL_DAO_K_FLAG;
+#endif /* RPL_CONF_DAO_ACK */
+  ++pos;
+  buffer[pos++] = 0; /* reserved */
+  buffer[pos++] = dao_sequence;
+#if RPL_DAO_SPECIFY_DAG
+  memcpy(buffer + pos, &dag->dag_id, sizeof(dag->dag_id));
+  pos+=sizeof(dag->dag_id);
+#endif /* RPL_DAO_SPECIFY_DAG */
+
+  /* create target subopt */
+  prefixlen = sizeof(*prefix) * CHAR_BIT;
+  buffer[pos++] = RPL_OPTION_TARGET;
+  buffer[pos++] = 2 + ((prefixlen + 7) / CHAR_BIT);
+  buffer[pos++] = 0; /* reserved */
+  buffer[pos++] = prefixlen;
+  memcpy(buffer + pos, prefix, (prefixlen + 7) / CHAR_BIT);
+  pos += ((prefixlen + 7) / CHAR_BIT);
+
+  /* Create a transit information sub-option. */
+  buffer[pos++] = RPL_OPTION_TRANSIT;
+  buffer[pos++] = 4;
+  buffer[pos++] = 0; /* flags - ignored */
+  buffer[pos++] = 0; /* path control - ignored */
+  buffer[pos++] = 0; /* path seq - ignored */
+  buffer[pos++] = lifetime;
+
+  PRINTF("RPL: Sending DAO with prefix ");
+  PRINT6ADDR(prefix);
+  PRINTF(" to ");
+  PRINT6ADDR(rpl_get_parent_ipaddr(parent));
+  PRINTF("\n");
+
+  if(rpl_get_parent_ipaddr(parent) != NULL) {
+    uip_icmp6_send(rpl_get_parent_ipaddr(parent), ICMP6_RPL, RPL_CODE_DAO, pos);
+  }
+}
+/*---------------------------------------------------------------------------*/
+static void
+dao_ack_input(void)
+{
+#if DEBUG
+  unsigned char *buffer;
+  uint8_t buffer_length;
+  uint8_t instance_id;
+  uint8_t sequence;
+  uint8_t status;
+
+  buffer = UIP_ICMP_PAYLOAD;
+  buffer_length = uip_len - uip_l3_icmp_hdr_len;
+
+  instance_id = buffer[0];
+  sequence = buffer[2];
+  status = buffer[3];
+
+  PRINTF("RPL: Received a DAO ACK with sequence number %d and status %d from ",
+    sequence, status);
+  PRINT6ADDR(&UIP_IP_BUF->srcipaddr);
+  PRINTF("\n");
+#endif /* DEBUG */
+}
+/*---------------------------------------------------------------------------*/
+void
+dao_ack_output(rpl_instance_t *instance, uip_ipaddr_t *dest, uint8_t sequence)
+{
+  unsigned char *buffer;
+
+  PRINTF("RPL: Sending a DAO ACK with sequence number %d to ", sequence);
+  PRINT6ADDR(dest);
+  PRINTF("\n");
+
+  buffer = UIP_ICMP_PAYLOAD;
+
+  buffer[0] = instance->instance_id;
+  buffer[1] = 0;
+  buffer[2] = sequence;
+  buffer[3] = 0;
+
+  uip_icmp6_send(dest, ICMP6_RPL, RPL_CODE_DAO_ACK, 4);
+}
+/*---------------------------------------------------------------------------*/
+void
+uip_rpl_input(void)
+{
+  PRINTF("Received an RPL control message\n");
+  switch(UIP_ICMP_BUF->icode) {
+  case RPL_CODE_DIO:
+    dio_input();
+    break;
+  case RPL_CODE_DIS:
+    dis_input();
+    break;
+  case RPL_CODE_DAO:
+    dao_input();
+    break;
+  case RPL_CODE_DAO_ACK:
+    dao_ack_input();
+    break;
+  default:
+    PRINTF("RPL: received an unknown ICMP6 code (%u)\n", UIP_ICMP_BUF->icode);
+    break;
+  }
+
+  uip_len = 0;
+}
+#endif /* UIP_CONF_IPV6 */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/rpl/rpl-mrhof.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/rpl/rpl-mrhof.c
@@ -1,0 +1,267 @@
+/**
+ * \addtogroup uip6
+ * @{
+ */
+/*
+ * Copyright (c) 2010, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+/**
+ * \file
+ *         The Minimum Rank with Hysteresis Objective Function (MRHOF)
+ *
+ *         This implementation uses the estimated number of 
+ *         transmissions (ETX) as the additive routing metric,
+ *         and also provides stubs for the energy metric.
+ *
+ * \author Joakim Eriksson <joakime@sics.se>, Nicolas Tsiftes <nvt@sics.se>
+ */
+
+#include "net/rpl/rpl-private.h"
+#include "net/nbr-table.h"
+#include "mac.h"
+
+#define DEBUG DEBUG_NONE
+#include "net/uip-debug.h"
+
+static void reset(rpl_dag_t *);
+static void neighbor_link_callback(rpl_parent_t *, int, int);
+static rpl_parent_t *best_parent(rpl_parent_t *, rpl_parent_t *);
+static rpl_dag_t *best_dag(rpl_dag_t *, rpl_dag_t *);
+static rpl_rank_t calculate_rank(rpl_parent_t *, rpl_rank_t);
+static void update_metric_container(rpl_instance_t *);
+
+rpl_of_t rpl_mrhof = {
+  reset,
+  neighbor_link_callback,
+  best_parent,
+  best_dag,
+  calculate_rank,
+  update_metric_container,
+  1
+};
+
+/* Constants for the ETX moving average */
+#define ETX_SCALE   100
+#define ETX_ALPHA   90
+
+/* Reject parents that have a higher link metric than the following. */
+#define MAX_LINK_METRIC			10
+
+/* Reject parents that have a higher path cost than the following. */
+#define MAX_PATH_COST			100
+
+/*
+ * The rank must differ more than 1/PARENT_SWITCH_THRESHOLD_DIV in order
+ * to switch preferred parent.
+ */
+#define PARENT_SWITCH_THRESHOLD_DIV	2
+
+typedef uint16_t rpl_path_metric_t;
+
+static rpl_path_metric_t
+calculate_path_metric(rpl_parent_t *p)
+{
+  if(p == NULL) {
+    return MAX_PATH_COST * RPL_DAG_MC_ETX_DIVISOR;
+  }
+
+#if RPL_DAG_MC == RPL_DAG_MC_NONE
+  return p->rank + (uint16_t)p->link_metric;
+#elif RPL_DAG_MC == RPL_DAG_MC_ETX
+  return p->mc.obj.etx + (uint16_t)p->link_metric;
+#elif RPL_DAG_MC == RPL_DAG_MC_ENERGY
+  return p->mc.obj.energy.energy_est + (uint16_t)p->link_metric;
+#else
+#error "Unsupported RPL_DAG_MC configured. See rpl.h."
+#endif /* RPL_DAG_MC */
+}
+
+static void
+reset(rpl_dag_t *sag)
+{
+  PRINTF("RPL: Reset MRHOF\n");
+}
+
+static void
+neighbor_link_callback(rpl_parent_t *p, int status, int numtx)
+{
+  uint16_t recorded_etx = p->link_metric;
+  uint16_t packet_etx = numtx * RPL_DAG_MC_ETX_DIVISOR;
+  uint16_t new_etx;
+
+  /* Do not penalize the ETX when collisions or transmission errors occur. */
+  if(status == MAC_TX_OK || status == MAC_TX_NOACK) {
+    if(status == MAC_TX_NOACK) {
+      packet_etx = MAX_LINK_METRIC * RPL_DAG_MC_ETX_DIVISOR;
+    }
+
+    new_etx = ((uint32_t)recorded_etx * ETX_ALPHA +
+               (uint32_t)packet_etx * (ETX_SCALE - ETX_ALPHA)) / ETX_SCALE;
+
+    PRINTF("RPL: ETX changed from %u to %u (packet ETX = %u)\n",
+        (unsigned)(recorded_etx / RPL_DAG_MC_ETX_DIVISOR),
+        (unsigned)(new_etx  / RPL_DAG_MC_ETX_DIVISOR),
+        (unsigned)(packet_etx / RPL_DAG_MC_ETX_DIVISOR));
+    p->link_metric = new_etx;
+  }
+}
+
+static rpl_rank_t
+calculate_rank(rpl_parent_t *p, rpl_rank_t base_rank)
+{
+  rpl_rank_t new_rank;
+  rpl_rank_t rank_increase;
+
+  if(p == NULL) {
+    if(base_rank == 0) {
+      return INFINITE_RANK;
+    }
+    rank_increase = RPL_INIT_LINK_METRIC * RPL_DAG_MC_ETX_DIVISOR;
+  } else {
+    rank_increase = p->link_metric;
+    if(base_rank == 0) {
+      base_rank = p->rank;
+    }
+  }
+
+  if(INFINITE_RANK - base_rank < rank_increase) {
+    /* Reached the maximum rank. */
+    new_rank = INFINITE_RANK;
+  } else {
+   /* Calculate the rank based on the new rank information from DIO or
+      stored otherwise. */
+    new_rank = base_rank + rank_increase;
+  }
+
+  return new_rank;
+}
+
+static rpl_dag_t *
+best_dag(rpl_dag_t *d1, rpl_dag_t *d2)
+{
+  if(d1->grounded != d2->grounded) {
+    return d1->grounded ? d1 : d2;
+  }
+
+  if(d1->preference != d2->preference) {
+    return d1->preference > d2->preference ? d1 : d2;
+  }
+
+  return d1->rank < d2->rank ? d1 : d2;
+}
+
+static rpl_parent_t *
+best_parent(rpl_parent_t *p1, rpl_parent_t *p2)
+{
+  rpl_dag_t *dag;
+  rpl_path_metric_t min_diff;
+  rpl_path_metric_t p1_metric;
+  rpl_path_metric_t p2_metric;
+
+  dag = p1->dag; /* Both parents are in the same DAG. */
+
+  min_diff = RPL_DAG_MC_ETX_DIVISOR /
+             PARENT_SWITCH_THRESHOLD_DIV;
+
+  p1_metric = calculate_path_metric(p1);
+  p2_metric = calculate_path_metric(p2);
+
+  /* Maintain stability of the preferred parent in case of similar ranks. */
+  if(p1 == dag->preferred_parent || p2 == dag->preferred_parent) {
+    if(p1_metric < p2_metric + min_diff &&
+       p1_metric > p2_metric - min_diff) {
+      PRINTF("RPL: MRHOF hysteresis: %u <= %u <= %u\n",
+             p2_metric - min_diff,
+             p1_metric,
+             p2_metric + min_diff);
+      return dag->preferred_parent;
+    }
+  }
+
+  return p1_metric < p2_metric ? p1 : p2;
+}
+
+#if RPL_DAG_MC == RPL_DAG_MC_NONE
+static void
+update_metric_container(rpl_instance_t *instance)
+{
+  instance->mc.type = RPL_DAG_MC;
+}
+#else
+static void
+update_metric_container(rpl_instance_t *instance)
+{
+  rpl_path_metric_t path_metric;
+  rpl_dag_t *dag;
+#if RPL_DAG_MC == RPL_DAG_MC_ENERGY
+  uint8_t type;
+#endif
+
+  instance->mc.type = RPL_DAG_MC;
+  instance->mc.flags = RPL_DAG_MC_FLAG_P;
+  instance->mc.aggr = RPL_DAG_MC_AGGR_ADDITIVE;
+  instance->mc.prec = 0;
+
+  dag = instance->current_dag;
+
+  if (!dag->joined) {
+    PRINTF("RPL: Cannot update the metric container when not joined\n");
+    return;
+  }
+
+  if(dag->rank == ROOT_RANK(instance)) {
+    path_metric = 0;
+  } else {
+    path_metric = calculate_path_metric(dag->preferred_parent);
+  }
+
+#if RPL_DAG_MC == RPL_DAG_MC_ETX
+  instance->mc.length = sizeof(instance->mc.obj.etx);
+  instance->mc.obj.etx = path_metric;
+
+  PRINTF("RPL: My path ETX to the root is %u.%u\n",
+	instance->mc.obj.etx / RPL_DAG_MC_ETX_DIVISOR,
+	(instance->mc.obj.etx % RPL_DAG_MC_ETX_DIVISOR * 100) /
+	 RPL_DAG_MC_ETX_DIVISOR);
+#elif RPL_DAG_MC == RPL_DAG_MC_ENERGY
+  instance->mc.length = sizeof(instance->mc.obj.energy);
+
+  if(dag->rank == ROOT_RANK(instance)) {
+    type = RPL_DAG_MC_ENERGY_TYPE_MAINS;
+  } else {
+    type = RPL_DAG_MC_ENERGY_TYPE_BATTERY;
+  }
+
+  instance->mc.obj.energy.flags = type << RPL_DAG_MC_ENERGY_TYPE;
+  instance->mc.obj.energy.energy_est = path_metric;
+#endif /* RPL_DAG_MC == RPL_DAG_MC_ETX */
+}
+#endif /* RPL_DAG_MC == RPL_DAG_MC_NONE */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/rpl/rpl-of0.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/rpl/rpl-of0.c
@@ -1,0 +1,161 @@
+/**
+ * \addtogroup uip6
+ * @{
+ */
+/*
+ * Copyright (c) 2010, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+/**
+ * \file
+ *         An implementation of RPL's objective function 0.
+ *
+ * \author Joakim Eriksson <joakime@sics.se>, Nicolas Tsiftes <nvt@sics.se>
+ */
+
+#include "net/rpl/rpl-private.h"
+
+#define DEBUG DEBUG_NONE
+#include "net/uip-debug.h"
+
+static void reset(rpl_dag_t *);
+static rpl_parent_t *best_parent(rpl_parent_t *, rpl_parent_t *);
+static rpl_dag_t *best_dag(rpl_dag_t *, rpl_dag_t *);
+static rpl_rank_t calculate_rank(rpl_parent_t *, rpl_rank_t);
+static void update_metric_container(rpl_instance_t *);
+
+rpl_of_t rpl_of0 = {
+  reset,
+  NULL,
+  best_parent,
+  best_dag,
+  calculate_rank,
+  update_metric_container,
+  0
+};
+
+#define DEFAULT_RANK_INCREMENT  RPL_MIN_HOPRANKINC
+
+#define MIN_DIFFERENCE (RPL_MIN_HOPRANKINC + RPL_MIN_HOPRANKINC / 2)
+
+static void
+reset(rpl_dag_t *dag)
+{
+  PRINTF("RPL: Resetting OF0\n");
+}
+
+static rpl_rank_t
+calculate_rank(rpl_parent_t *p, rpl_rank_t base_rank)
+{
+  rpl_rank_t increment;
+  if(base_rank == 0) {
+    if(p == NULL) {
+      return INFINITE_RANK;
+    }
+    base_rank = p->rank;
+  }
+
+  increment = p != NULL ?
+                p->dag->instance->min_hoprankinc :
+                DEFAULT_RANK_INCREMENT;
+
+  if((rpl_rank_t)(base_rank + increment) < base_rank) {
+    PRINTF("RPL: OF0 rank %d incremented to infinite rank due to wrapping\n",
+        base_rank);
+    return INFINITE_RANK;
+  }
+  return base_rank + increment;
+
+}
+
+static rpl_dag_t *
+best_dag(rpl_dag_t *d1, rpl_dag_t *d2)
+{
+  if(d1->grounded) {
+    if (!d2->grounded) {
+      return d1;
+    }
+  } else if(d2->grounded) {
+    return d2;
+  }
+
+  if(d1->preference < d2->preference) {
+    return d2;
+  } else {
+    if(d1->preference > d2->preference) {
+      return d1;
+    }
+  }
+
+  if(d2->rank < d1->rank) {
+    return d2;
+  } else {
+    return d1;
+  }
+}
+
+static rpl_parent_t *
+best_parent(rpl_parent_t *p1, rpl_parent_t *p2)
+{
+  rpl_rank_t r1, r2;
+  rpl_dag_t *dag;
+  
+  PRINTF("RPL: Comparing parent ");
+  PRINT6ADDR(rpl_get_parent_ipaddr(p1));
+  PRINTF(" (confidence %d, rank %d) with parent ",
+        p1->link_metric, p1->rank);
+  PRINT6ADDR(rpl_get_parent_ipaddr(p2));
+  PRINTF(" (confidence %d, rank %d)\n",
+        p2->link_metric, p2->rank);
+
+
+  r1 = DAG_RANK(p1->rank, p1->dag->instance) * RPL_MIN_HOPRANKINC  +
+         p1->link_metric;
+  r2 = DAG_RANK(p2->rank, p1->dag->instance) * RPL_MIN_HOPRANKINC  +
+         p2->link_metric;
+  /* Compare two parents by looking both and their rank and at the ETX
+     for that parent. We choose the parent that has the most
+     favourable combination. */
+
+  dag = (rpl_dag_t *)p1->dag; /* Both parents must be in the same DAG. */
+  if(r1 < r2 + MIN_DIFFERENCE &&
+     r1 > r2 - MIN_DIFFERENCE) {
+    return dag->preferred_parent;
+  } else if(r1 < r2) {
+    return p1;
+  } else {
+    return p2;
+  }
+}
+
+static void
+update_metric_container(rpl_instance_t *instance)
+{
+  instance->mc.type = RPL_DAG_MC_NONE;
+}

--- a/module_xtcp/src/xtcp_uip6/contiki/net/rpl/rpl-private.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/rpl/rpl-private.h
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c) 2010, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ * \file
+ *   Private declarations for ContikiRPL.
+ * \author
+ *   Joakim Eriksson <joakime@sics.se>, Nicolas Tsiftes <nvt@sics.se>
+ */
+
+#ifndef RPL_PRIVATE_H
+#define RPL_PRIVATE_H
+
+#include "net/rpl/rpl.h"
+
+#include "lib/list.h"
+#include "net/uip.h"
+#include "sys/clock.h"
+#include "sys/ctimer.h"
+#include "net/uip-ds6.h"
+
+/*---------------------------------------------------------------------------*/
+/** \brief Is IPv6 address addr the link-local, all-RPL-nodes
+    multicast address? */
+#define uip_is_addr_linklocal_rplnodes_mcast(addr)	    \
+  ((addr)->u8[0] == 0xff) &&				    \
+  ((addr)->u8[1] == 0x02) &&				    \
+  ((addr)->u16[1] == 0) &&				    \
+  ((addr)->u16[2] == 0) &&				    \
+  ((addr)->u16[3] == 0) &&				    \
+  ((addr)->u16[4] == 0) &&				    \
+  ((addr)->u16[5] == 0) &&				    \
+  ((addr)->u16[6] == 0) &&				    \
+  ((addr)->u8[14] == 0) &&				    \
+  ((addr)->u8[15] == 0x1a))
+
+/** \brief Set IP address addr to the link-local, all-rpl-nodes
+    multicast address. */
+#define uip_create_linklocal_rplnodes_mcast(addr)	\
+  uip_ip6addr((addr), 0xff02, 0, 0, 0, 0, 0, 0, 0x001a)
+/*---------------------------------------------------------------------------*/
+/* RPL message types */
+#define RPL_CODE_DIS                   0x00   /* DAG Information Solicitation */
+#define RPL_CODE_DIO                   0x01   /* DAG Information Option */
+#define RPL_CODE_DAO                   0x02   /* Destination Advertisement Option */
+#define RPL_CODE_DAO_ACK               0x03   /* DAO acknowledgment */
+#define RPL_CODE_SEC_DIS               0x80   /* Secure DIS */
+#define RPL_CODE_SEC_DIO               0x81   /* Secure DIO */
+#define RPL_CODE_SEC_DAO               0x82   /* Secure DAO */
+#define RPL_CODE_SEC_DAO_ACK           0x83   /* Secure DAO ACK */
+
+/* RPL control message options. */
+#define RPL_OPTION_PAD1                  0
+#define RPL_OPTION_PADN                  1
+#define RPL_OPTION_DAG_METRIC_CONTAINER  2
+#define RPL_OPTION_ROUTE_INFO            3
+#define RPL_OPTION_DAG_CONF              4
+#define RPL_OPTION_TARGET                5
+#define RPL_OPTION_TRANSIT               6
+#define RPL_OPTION_SOLICITED_INFO        7
+#define RPL_OPTION_PREFIX_INFO           8
+#define RPL_OPTION_TARGET_DESC           9
+
+#define RPL_DAO_K_FLAG                   0x80 /* DAO ACK requested */
+#define RPL_DAO_D_FLAG                   0x40 /* DODAG ID present */
+/*---------------------------------------------------------------------------*/
+/* RPL IPv6 extension header option. */
+#define RPL_HDR_OPT_LEN                  4
+#define RPL_HOP_BY_HOP_LEN               (RPL_HDR_OPT_LEN + 2 + 2)
+#define RPL_HDR_OPT_DOWN                 0x80
+#define RPL_HDR_OPT_DOWN_SHIFT           7
+#define RPL_HDR_OPT_RANK_ERR             0x40
+#define RPL_HDR_OPT_RANK_ERR_SHIFT       6
+#define RPL_HDR_OPT_FWD_ERR              0x20
+#define RPL_HDR_OPT_FWD_ERR_SHIFT        5
+/*---------------------------------------------------------------------------*/
+/* Default values for RPL constants and variables. */
+
+/* The default value for the DAO timer. */
+#ifdef RPL_CONF_DAO_LATENCY
+#define RPL_DAO_LATENCY                 RPL_CONF_DAO_LATENCY
+#else /* RPL_CONF_DAO_LATENCY */
+#define RPL_DAO_LATENCY                 (CLOCK_SECOND * 4)
+#endif /* RPL_DAO_LATENCY */
+
+/* Special value indicating immediate removal. */
+#define RPL_ZERO_LIFETIME               0
+
+#define RPL_LIFETIME(instance, lifetime) \
+          ((unsigned long)(instance)->lifetime_unit * (lifetime))
+
+#ifndef RPL_CONF_MIN_HOPRANKINC
+#define RPL_MIN_HOPRANKINC          256
+#else
+#define RPL_MIN_HOPRANKINC          RPL_CONF_MIN_HOPRANKINC
+#endif
+#define RPL_MAX_RANKINC             (7 * RPL_MIN_HOPRANKINC)
+
+#define DAG_RANK(fixpt_rank, instance) \
+  ((fixpt_rank) / (instance)->min_hoprankinc)
+
+/* Rank of a virtual root node that coordinates DAG root nodes. */
+#define BASE_RANK                       0
+
+/* Rank of a root node. */
+#define ROOT_RANK(instance)             (instance)->min_hoprankinc
+
+#define INFINITE_RANK                   0xffff
+
+/* Represents 2^n ms. */
+/* Default value according to the specification is 3 which
+   means 8 milliseconds, but that is an unreasonable value if
+   using power-saving / duty-cycling    */
+#ifdef RPL_CONF_DIO_INTERVAL_MIN
+#define RPL_DIO_INTERVAL_MIN        RPL_CONF_DIO_INTERVAL_MIN
+#else
+#define RPL_DIO_INTERVAL_MIN        12
+#endif
+
+/* Maximum amount of timer doublings. */
+#ifdef RPL_CONF_DIO_INTERVAL_DOUBLINGS
+#define RPL_DIO_INTERVAL_DOUBLINGS  RPL_CONF_DIO_INTERVAL_DOUBLINGS
+#else
+#define RPL_DIO_INTERVAL_DOUBLINGS  8
+#endif
+
+/* Default DIO redundancy. */
+#ifdef RPL_CONF_DIO_REDUNDANCY
+#define RPL_DIO_REDUNDANCY          RPL_CONF_DIO_REDUNDANCY
+#else
+#define RPL_DIO_REDUNDANCY          10
+#endif
+
+/* Expire DAOs from neighbors that do not respond in this time. (seconds) */
+#define DAO_EXPIRATION_TIMEOUT          60
+/*---------------------------------------------------------------------------*/
+#define RPL_INSTANCE_LOCAL_FLAG         0x80
+#define RPL_INSTANCE_D_FLAG             0x40
+
+/* Values that tell where a route came from. */
+#define RPL_ROUTE_FROM_INTERNAL         0
+#define RPL_ROUTE_FROM_UNICAST_DAO      1
+#define RPL_ROUTE_FROM_MULTICAST_DAO    2
+#define RPL_ROUTE_FROM_DIO              3
+
+/* DAG Mode of Operation */
+#define RPL_MOP_NO_DOWNWARD_ROUTES      0
+#define RPL_MOP_NON_STORING             1
+#define RPL_MOP_STORING_NO_MULTICAST    2
+#define RPL_MOP_STORING_MULTICAST       3
+
+#ifdef  RPL_CONF_MOP
+#define RPL_MOP_DEFAULT                 RPL_CONF_MOP
+#else
+#define RPL_MOP_DEFAULT                 RPL_MOP_STORING_NO_MULTICAST
+#endif
+
+/*
+ * The ETX in the metric container is expressed as a fixed-point value 
+ * whose integer part can be obtained by dividing the value by 
+ * RPL_DAG_MC_ETX_DIVISOR.
+ */
+#define RPL_DAG_MC_ETX_DIVISOR		128
+
+/* DIS related */
+#define RPL_DIS_SEND                    1
+#ifdef  RPL_DIS_INTERVAL_CONF
+#define RPL_DIS_INTERVAL                RPL_DIS_INTERVAL_CONF
+#else
+#define RPL_DIS_INTERVAL                60
+#endif
+#define RPL_DIS_START_DELAY             5
+/*---------------------------------------------------------------------------*/
+/* Lollipop counters */
+
+#define RPL_LOLLIPOP_MAX_VALUE           255
+#define RPL_LOLLIPOP_CIRCULAR_REGION     127
+#define RPL_LOLLIPOP_SEQUENCE_WINDOWS    16
+#define RPL_LOLLIPOP_INIT                (RPL_LOLLIPOP_MAX_VALUE - RPL_LOLLIPOP_SEQUENCE_WINDOWS + 1)
+#define RPL_LOLLIPOP_INCREMENT(counter)                                 \
+  do {                                                                  \
+    if((counter) > RPL_LOLLIPOP_CIRCULAR_REGION) {                      \
+      (counter) = ((counter) + 1) & RPL_LOLLIPOP_MAX_VALUE;             \
+    } else {                                                            \
+      (counter) = ((counter) + 1) & RPL_LOLLIPOP_CIRCULAR_REGION;       \
+    }                                                                   \
+  } while(0)
+
+#define RPL_LOLLIPOP_IS_INIT(counter)		\
+  ((counter) > RPL_LOLLIPOP_CIRCULAR_REGION)
+/*---------------------------------------------------------------------------*/
+/* Logical representation of a DAG Information Object (DIO.) */
+struct rpl_dio {
+  uip_ipaddr_t dag_id;
+  rpl_ocp_t ocp;
+  rpl_rank_t rank;
+  uint8_t grounded;
+  uint8_t mop;
+  uint8_t preference;
+  uint8_t version;
+  uint8_t instance_id;
+  uint8_t dtsn;
+  uint8_t dag_intdoubl;
+  uint8_t dag_intmin;
+  uint8_t dag_redund;
+  uint8_t default_lifetime;
+  uint16_t lifetime_unit;
+  rpl_rank_t dag_max_rankinc;
+  rpl_rank_t dag_min_hoprankinc;
+  rpl_prefix_t destination_prefix;
+  rpl_prefix_t prefix_info;
+  struct rpl_metric_container mc;
+};
+typedef struct rpl_dio rpl_dio_t;
+
+#if RPL_CONF_STATS
+/* Statistics for fault management. */
+struct rpl_stats {
+  uint16_t mem_overflows;
+  uint16_t local_repairs;
+  uint16_t global_repairs;
+  uint16_t malformed_msgs;
+  uint16_t resets;
+  uint16_t parent_switch;
+};
+typedef struct rpl_stats rpl_stats_t;
+
+extern rpl_stats_t rpl_stats;
+#endif
+/*---------------------------------------------------------------------------*/
+/* RPL macros. */
+
+#if RPL_CONF_STATS
+#define RPL_STAT(code)	(code) 
+#else
+#define RPL_STAT(code)
+#endif /* RPL_CONF_STATS */
+/*---------------------------------------------------------------------------*/
+/* Instances */
+extern rpl_instance_t instance_table[];
+extern rpl_instance_t *default_instance;
+
+/* ICMPv6 functions for RPL. */
+void dis_output(uip_ipaddr_t *addr);
+void dio_output(rpl_instance_t *, uip_ipaddr_t *uc_addr);
+void dao_output(rpl_parent_t *, uint8_t lifetime);
+void dao_output_target(rpl_parent_t *, uip_ipaddr_t *, uint8_t lifetime);
+void dao_ack_output(rpl_instance_t *, uip_ipaddr_t *, uint8_t);
+
+/* RPL logic functions. */
+void rpl_join_dag(uip_ipaddr_t *from, rpl_dio_t *dio);
+void rpl_join_instance(uip_ipaddr_t *from, rpl_dio_t *dio);
+void rpl_local_repair(rpl_instance_t *instance);
+void rpl_process_dio(uip_ipaddr_t *, rpl_dio_t *);
+int rpl_process_parent_event(rpl_instance_t *, rpl_parent_t *);
+
+/* DAG object management. */
+rpl_dag_t *rpl_alloc_dag(uint8_t, uip_ipaddr_t *);
+rpl_instance_t *rpl_alloc_instance(uint8_t);
+void rpl_free_dag(rpl_dag_t *);
+void rpl_free_instance(rpl_instance_t *);
+
+/* DAG parent management function. */
+rpl_parent_t *rpl_add_parent(rpl_dag_t *, rpl_dio_t *dio, uip_ipaddr_t *);
+rpl_parent_t *rpl_find_parent(rpl_dag_t *, uip_ipaddr_t *);
+rpl_parent_t *rpl_find_parent_any_dag(rpl_instance_t *instance, uip_ipaddr_t *addr);
+void rpl_nullify_parent(rpl_parent_t *);
+void rpl_remove_parent(rpl_parent_t *);
+void rpl_move_parent(rpl_dag_t *dag_src, rpl_dag_t *dag_dst, rpl_parent_t *parent);
+rpl_parent_t *rpl_select_parent(rpl_dag_t *dag);
+rpl_dag_t *rpl_select_dag(rpl_instance_t *instance,rpl_parent_t *parent);
+void rpl_recalculate_ranks(void);
+
+/* RPL routing table functions. */
+void rpl_remove_routes(rpl_dag_t *dag);
+void rpl_remove_routes_by_nexthop(uip_ipaddr_t *nexthop, rpl_dag_t *dag);
+uip_ds6_route_t *rpl_add_route(rpl_dag_t *dag, uip_ipaddr_t *prefix,
+                               int prefix_len, uip_ipaddr_t *next_hop);
+void rpl_purge_routes(void);
+
+/* Objective function. */
+rpl_of_t *rpl_find_of(rpl_ocp_t);
+
+/* Timer functions. */
+void rpl_schedule_dao(rpl_instance_t *);
+void rpl_reset_dio_timer(rpl_instance_t *);
+void rpl_reset_periodic_timer(void);
+
+/* Route poisoning. */
+void rpl_poison_routes(rpl_dag_t *, rpl_parent_t *);
+
+#endif /* RPL_PRIVATE_H */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/rpl/rpl-timers.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/rpl/rpl-timers.c
@@ -1,0 +1,240 @@
+/**
+ * \addtogroup uip6
+ * @{
+ */
+/*
+ * Copyright (c) 2010, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+/**
+ * \file
+ *         RPL timer management.
+ *
+ * \author Joakim Eriksson <joakime@sics.se>, Nicolas Tsiftes <nvt@sics.se>
+ */
+
+#include "uip-conf.h"
+#include "net/rpl/rpl-private.h"
+#include "lib/random.h"
+#include "sys/ctimer.h"
+
+#if UIP_CONF_IPV6
+
+#define DEBUG DEBUG_NONE
+#include "net/uip-debug.h"
+
+/*---------------------------------------------------------------------------*/
+static struct ctimer periodic_timer;
+
+static void handle_periodic_timer(void *ptr);
+static void new_dio_interval(rpl_instance_t *instance);
+static void handle_dio_timer(void *ptr);
+
+static uint16_t next_dis;
+
+/* dio_send_ok is true if the node is ready to send DIOs */
+static uint8_t dio_send_ok;
+
+/*---------------------------------------------------------------------------*/
+static void
+handle_periodic_timer(void *ptr)
+{
+  rpl_purge_routes();
+  rpl_recalculate_ranks();
+
+  /* handle DIS */
+#ifdef RPL_DIS_SEND
+  next_dis++;
+  if(rpl_get_any_dag() == NULL && next_dis >= RPL_DIS_INTERVAL) {
+    next_dis = 0;
+    dis_output(NULL);
+  }
+#endif
+  ctimer_reset(&periodic_timer);
+}
+/*---------------------------------------------------------------------------*/
+static void
+new_dio_interval(rpl_instance_t *instance)
+{
+  uint32_t time;
+  clock_time_t ticks;
+
+  /* TODO: too small timer intervals for many cases */
+  time = 1UL << instance->dio_intcurrent;
+
+  /* Convert from milliseconds to CLOCK_TICKS. */
+  ticks = (time * CLOCK_SECOND) / 1000;
+  instance->dio_next_delay = ticks;
+
+  /* random number between I/2 and I */
+  ticks = ticks / 2 + (ticks / 2 * (uint32_t)random_rand()) / RANDOM_RAND_MAX;
+
+  /*
+   * The intervals must be equally long among the nodes for Trickle to
+   * operate efficiently. Therefore we need to calculate the delay between
+   * the randomized time and the start time of the next interval.
+   */
+  instance->dio_next_delay -= ticks;
+  instance->dio_send = 1;
+
+#if RPL_CONF_STATS
+  /* keep some stats */
+  instance->dio_totint++;
+  instance->dio_totrecv += instance->dio_counter;
+  ANNOTATE("#A rank=%u.%u(%u),stats=%d %d %d %d,color=%s\n",
+	   DAG_RANK(instance->current_dag->rank, instance),
+           (10 * (instance->current_dag->rank % instance->min_hoprankinc)) / instance->min_hoprankinc,
+           instance->current_dag->version,
+           instance->dio_totint, instance->dio_totsend,
+           instance->dio_totrecv,instance->dio_intcurrent,
+	   instance->current_dag->rank == ROOT_RANK(instance) ? "BLUE" : "ORANGE");
+#endif /* RPL_CONF_STATS */
+
+  /* reset the redundancy counter */
+  instance->dio_counter = 0;
+
+  /* schedule the timer */
+  PRINTF("RPL: Scheduling DIO timer %lu ticks in future (Interval)\n", ticks);
+  ctimer_set(&instance->dio_timer, ticks, &handle_dio_timer, instance);
+}
+/*---------------------------------------------------------------------------*/
+static void
+handle_dio_timer(void *ptr)
+{
+  rpl_instance_t *instance;
+
+  instance = (rpl_instance_t *)ptr;
+
+  PRINTF("RPL: DIO Timer triggered\n");
+  if(!dio_send_ok) {
+    if(uip_ds6_get_link_local(ADDR_PREFERRED) != NULL) {
+      dio_send_ok = 1;
+    } else {
+      PRINTF("RPL: Postponing DIO transmission since link local address is not ok\n");
+      ctimer_set(&instance->dio_timer, CLOCK_SECOND, &handle_dio_timer, instance);
+      return;
+    }
+  }
+
+  if(instance->dio_send) {
+    /* send DIO if counter is less than desired redundancy */
+    if(instance->dio_counter < instance->dio_redundancy) {
+#if RPL_CONF_STATS
+      instance->dio_totsend++;
+#endif /* RPL_CONF_STATS */
+      dio_output(instance, NULL);
+    } else {
+      PRINTF("RPL: Supressing DIO transmission (%d >= %d)\n",
+             instance->dio_counter, instance->dio_redundancy);
+    }
+    instance->dio_send = 0;
+    PRINTF("RPL: Scheduling DIO timer %lu ticks in future (sent)\n",
+           instance->dio_next_delay);
+    ctimer_set(&instance->dio_timer, instance->dio_next_delay, handle_dio_timer, instance);
+  } else {
+    /* check if we need to double interval */
+    if(instance->dio_intcurrent < instance->dio_intmin + instance->dio_intdoubl) {
+      instance->dio_intcurrent++;
+      PRINTF("RPL: DIO Timer interval doubled %d\n", instance->dio_intcurrent);
+    }
+    new_dio_interval(instance);
+  }
+}
+/*---------------------------------------------------------------------------*/
+void
+rpl_reset_periodic_timer(void)
+{
+  next_dis = RPL_DIS_INTERVAL / 2 +
+    ((uint32_t)RPL_DIS_INTERVAL * (uint32_t)random_rand()) / RANDOM_RAND_MAX -
+    RPL_DIS_START_DELAY;
+  ctimer_set(&periodic_timer, CLOCK_SECOND, handle_periodic_timer, NULL);
+}
+/*---------------------------------------------------------------------------*/
+/* Resets the DIO timer in the instance to its minimal interval. */
+void
+rpl_reset_dio_timer(rpl_instance_t *instance)
+{
+#if !RPL_LEAF_ONLY
+  /* Do not reset if we are already on the minimum interval,
+     unless forced to do so. */
+  if(instance->dio_intcurrent > instance->dio_intmin) {
+    instance->dio_counter = 0;
+    instance->dio_intcurrent = instance->dio_intmin;
+    new_dio_interval(instance);
+  }
+#if RPL_CONF_STATS
+  rpl_stats.resets++;
+#endif /* RPL_CONF_STATS */
+#endif /* RPL_LEAF_ONLY */
+}
+/*---------------------------------------------------------------------------*/
+static void
+handle_dao_timer(void *ptr)
+{
+  rpl_instance_t *instance;
+
+  instance = (rpl_instance_t *)ptr;
+
+  if(!dio_send_ok && uip_ds6_get_link_local(ADDR_PREFERRED) == NULL) {
+    PRINTF("RPL: Postpone DAO transmission\n");
+    ctimer_set(&instance->dao_timer, CLOCK_SECOND, handle_dao_timer, instance);
+    return;
+  }
+
+  /* Send the DAO to the DAO parent set -- the preferred parent in our case. */
+  if(instance->current_dag->preferred_parent != NULL) {
+    PRINTF("RPL: handle_dao_timer - sending DAO\n");
+    /* Set the route lifetime to the default value. */
+    dao_output(instance->current_dag->preferred_parent, instance->default_lifetime);
+  } else {
+    PRINTF("RPL: No suitable DAO parent\n");
+  }
+  ctimer_stop(&instance->dao_timer);
+}
+/*---------------------------------------------------------------------------*/
+void
+rpl_schedule_dao(rpl_instance_t *instance)
+{
+  clock_time_t expiration_time;
+
+  expiration_time = etimer_expiration_time(&instance->dao_timer.etimer);
+
+  if(!etimer_expired(&instance->dao_timer.etimer)) {
+    PRINTF("RPL: DAO timer already scheduled\n");
+  } else {
+    expiration_time = RPL_DAO_LATENCY / 2 +
+      (random_rand() % (RPL_DAO_LATENCY));
+    PRINTF("RPL: Scheduling DAO timer %u ticks in the future\n",
+           (unsigned)expiration_time);
+    ctimer_set(&instance->dao_timer, expiration_time,
+               handle_dao_timer, instance);
+  }
+}
+/*---------------------------------------------------------------------------*/
+#endif /* UIP_CONF_IPV6 */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/rpl/rpl.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/rpl/rpl.c
@@ -1,0 +1,238 @@
+/**
+ * \addtogroup uip6
+ * @{
+ */
+/*
+ * Copyright (c) 2009, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+/**
+ * \file
+ *         ContikiRPL, an implementation of RPL: IPv6 Routing Protocol
+ *         for Low-Power and Lossy Networks (IETF RFC 6550)
+ *
+ * \author Joakim Eriksson <joakime@sics.se>, Nicolas Tsiftes <nvt@sics.se>
+ */
+
+#include "net/uip.h"
+#include "net/tcpip.h"
+#include "net/uip-ds6.h"
+#include "net/rpl/rpl-private.h"
+
+#define DEBUG DEBUG_NONE
+#include "net/uip-debug.h"
+
+#include <limits.h>
+#include <string.h>
+
+#if UIP_CONF_IPV6
+
+#if RPL_CONF_STATS
+rpl_stats_t rpl_stats;
+#endif
+
+/*---------------------------------------------------------------------------*/
+void
+rpl_purge_routes(void)
+{
+  uip_ds6_route_t *r;
+  uip_ipaddr_t prefix;
+  rpl_dag_t *dag;
+
+  /* First pass, decrement lifetime */
+  r = uip_ds6_route_head();
+
+  while(r != NULL) {
+    if(r->state.lifetime >= 1) {
+      /*
+       * If a route is at lifetime == 1, set it to 0, scheduling it for
+       * immediate removal below. This achieves the same as the original code,
+       * which would delete lifetime <= 1
+       */
+      r->state.lifetime--;
+    }
+    r = uip_ds6_route_next(r);
+  }
+
+  /* Second pass, remove dead routes */
+  r = uip_ds6_route_head();
+
+  while(r != NULL) {
+    if(r->state.lifetime < 1) {
+      /* Routes with lifetime == 1 have only just been decremented from 2 to 1,
+       * thus we want to keep them. Hence < and not <= */
+      uip_ipaddr_copy(&prefix, &r->ipaddr);
+      uip_ds6_route_rm(r);
+      r = uip_ds6_route_head();
+      PRINTF("No more routes to ");
+      PRINT6ADDR(&prefix);
+      dag = default_instance->current_dag;
+      /* Propagate this information with a No-Path DAO to preferred parent if we are not a RPL Root */
+      if(dag->rank != ROOT_RANK(default_instance)) {
+        PRINTF(" -> generate No-Path DAO\n");
+        dao_output_target(dag->preferred_parent, &prefix, RPL_ZERO_LIFETIME);
+        /* Don't schedule more than 1 No-Path DAO, let next iteration handle that */
+        return;
+      }
+      PRINTF("\n");
+    } else {
+      r = uip_ds6_route_next(r);
+    }
+  }
+}
+/*---------------------------------------------------------------------------*/
+void
+rpl_remove_routes(rpl_dag_t *dag)
+{
+  uip_ds6_route_t *r;
+
+  r = uip_ds6_route_head();
+
+  while(r != NULL) {
+    if(r->state.dag == dag) {
+      uip_ds6_route_rm(r);
+      r = uip_ds6_route_head();
+    } else {
+      r = uip_ds6_route_next(r);
+    }
+  }
+}
+/*---------------------------------------------------------------------------*/
+void
+rpl_remove_routes_by_nexthop(uip_ipaddr_t *nexthop, rpl_dag_t *dag)
+{
+  uip_ds6_route_t *r;
+
+  r = uip_ds6_route_head();
+
+  while(r != NULL) {
+    if(uip_ipaddr_cmp(uip_ds6_route_nexthop(r), nexthop) &&
+       r->state.dag == dag) {
+      uip_ds6_route_rm(r);
+      r = uip_ds6_route_head();
+    } else {
+      r = uip_ds6_route_next(r);
+    }
+  }
+  ANNOTATE("#L %u 0\n", nexthop->u8[sizeof(uip_ipaddr_t) - 1]);
+}
+/*---------------------------------------------------------------------------*/
+uip_ds6_route_t *
+rpl_add_route(rpl_dag_t *dag, uip_ipaddr_t *prefix, int prefix_len,
+              uip_ipaddr_t *next_hop)
+{
+  uip_ds6_route_t *rep;
+
+  if((rep = uip_ds6_route_add(prefix, prefix_len, next_hop)) == NULL) {
+    PRINTF("RPL: No space for more route entries\n");
+    return NULL;
+  }
+
+  rep->state.dag = dag;
+  rep->state.lifetime = RPL_LIFETIME(dag->instance, dag->instance->default_lifetime);
+  rep->state.learned_from = RPL_ROUTE_FROM_INTERNAL;
+
+  PRINTF("RPL: Added a route to ");
+  PRINT6ADDR(prefix);
+  PRINTF("/%d via ", prefix_len);
+  PRINT6ADDR(next_hop);
+  PRINTF("\n");
+
+  return rep;
+}
+/*---------------------------------------------------------------------------*/
+void
+rpl_link_neighbor_callback(const rimeaddr_t *addr, int status, int numtx)
+{
+  uip_ipaddr_t ipaddr;
+  rpl_parent_t *parent;
+  rpl_instance_t *instance;
+  rpl_instance_t *end;
+
+  uip_ip6addr(&ipaddr, 0xfe80, 0, 0, 0, 0, 0, 0, 0);
+  uip_ds6_set_addr_iid(&ipaddr, (uip_lladdr_t *)addr);
+
+  for(instance = &instance_table[0], end = instance + RPL_MAX_INSTANCES; instance < end; ++instance) {
+    if(instance->used == 1 ) {
+      parent = rpl_find_parent_any_dag(instance, &ipaddr);
+      if(parent != NULL) {
+        /* Trigger DAG rank recalculation. */
+        PRINTF("RPL: rpl_link_neighbor_callback triggering update\n");
+        parent->updated = 1;
+        if(instance->of->neighbor_link_callback != NULL) {
+          instance->of->neighbor_link_callback(parent, status, numtx);
+        }
+      }
+    }
+  }
+}
+/*---------------------------------------------------------------------------*/
+void
+rpl_ipv6_neighbor_callback(uip_ds6_nbr_t *nbr)
+{
+  rpl_parent_t *p;
+  rpl_instance_t *instance;
+  rpl_instance_t *end;
+
+  PRINTF("RPL: Removing neighbor ");
+  PRINT6ADDR(&nbr->ipaddr);
+  PRINTF("\n");
+  for(instance = &instance_table[0], end = instance + RPL_MAX_INSTANCES; instance < end; ++instance) {
+    if(instance->used == 1 ) {
+      p = rpl_find_parent_any_dag(instance, &nbr->ipaddr);
+      if(p != NULL) {
+        p->rank = INFINITE_RANK;
+        /* Trigger DAG rank recalculation. */
+        PRINTF("RPL: rpl_ipv6_neighbor_callback infinite rank\n");
+        p->updated = 1;
+      }
+    }
+  }
+}
+/*---------------------------------------------------------------------------*/
+void
+rpl_init(void)
+{
+  uip_ipaddr_t rplmaddr;
+  PRINTF("RPL started\n");
+  default_instance = NULL;
+
+  rpl_dag_init();
+  rpl_reset_periodic_timer();
+
+  /* add rpl multicast address */
+  uip_create_linklocal_rplnodes_mcast(&rplmaddr);
+  uip_ds6_maddr_add(&rplmaddr);
+
+#if RPL_CONF_STATS
+  memset(&rpl_stats, 0, sizeof(rpl_stats));
+#endif
+}
+/*---------------------------------------------------------------------------*/
+#endif /* UIP_CONF_IPV6 */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/rpl/rpl.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/rpl/rpl.h
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2010, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ * \file
+ *	Public API declarations for ContikiRPL.
+ * \author
+ *	Joakim Eriksson <joakime@sics.se> & Nicolas Tsiftes <nvt@sics.se>
+ *
+ */
+
+#ifndef RPL_H
+#define RPL_H
+
+#include "rpl-conf.h"
+
+#include "lib/list.h"
+#include "net/uip.h"
+#include "net/uip-ds6.h"
+#include "sys/ctimer.h"
+
+/*---------------------------------------------------------------------------*/
+/* The amount of parents that this node has in a particular DAG. */
+#define RPL_PARENT_COUNT(dag)   list_length((dag)->parents)
+/*---------------------------------------------------------------------------*/
+typedef uint16_t rpl_rank_t;
+typedef uint16_t rpl_ocp_t;
+/*---------------------------------------------------------------------------*/
+/* DAG Metric Container Object Types, to be confirmed by IANA. */
+#define RPL_DAG_MC_NONE                 0 /* Local identifier for empty MC */
+#define RPL_DAG_MC_NSA                  1 /* Node State and Attributes */
+#define RPL_DAG_MC_ENERGY               2 /* Node Energy */
+#define RPL_DAG_MC_HOPCOUNT             3 /* Hop Count */
+#define RPL_DAG_MC_THROUGHPUT           4 /* Throughput */
+#define RPL_DAG_MC_LATENCY              5 /* Latency */
+#define RPL_DAG_MC_LQL                  6 /* Link Quality Level */
+#define RPL_DAG_MC_ETX                  7 /* Expected Transmission Count */
+#define RPL_DAG_MC_LC                   8 /* Link Color */
+
+/* DAG Metric Container flags. */
+#define RPL_DAG_MC_FLAG_P               0x8
+#define RPL_DAG_MC_FLAG_C               0x4
+#define RPL_DAG_MC_FLAG_O               0x2
+#define RPL_DAG_MC_FLAG_R               0x1
+
+/* DAG Metric Container aggregation mode. */
+#define RPL_DAG_MC_AGGR_ADDITIVE        0
+#define RPL_DAG_MC_AGGR_MAXIMUM         1
+#define RPL_DAG_MC_AGGR_MINIMUM         2
+#define RPL_DAG_MC_AGGR_MULTIPLICATIVE  3
+
+/* The bit index within the flags field of
+   the rpl_metric_object_energy structure. */
+#define RPL_DAG_MC_ENERGY_INCLUDED      3
+#define RPL_DAG_MC_ENERGY_TYPE          1
+#define RPL_DAG_MC_ENERGY_ESTIMATION    0
+
+#define RPL_DAG_MC_ENERGY_TYPE_MAINS        0
+#define RPL_DAG_MC_ENERGY_TYPE_BATTERY      1
+#define RPL_DAG_MC_ENERGY_TYPE_SCAVENGING   2
+
+struct rpl_metric_object_energy {
+  uint8_t flags;
+  uint8_t energy_est;
+};
+
+/* Logical representation of a DAG Metric Container. */
+struct rpl_metric_container {
+  uint8_t type;
+  uint8_t flags;
+  uint8_t aggr;
+  uint8_t prec;
+  uint8_t length;
+  union metric_object {
+    struct rpl_metric_object_energy energy;
+    uint16_t etx;
+  } obj;
+};
+typedef struct rpl_metric_container rpl_metric_container_t;
+/*---------------------------------------------------------------------------*/
+struct rpl_instance;
+struct rpl_dag;
+/*---------------------------------------------------------------------------*/
+struct rpl_parent {
+  struct rpl_parent *next;
+  struct rpl_dag *dag;
+#if RPL_DAG_MC != RPL_DAG_MC_NONE
+  rpl_metric_container_t mc;
+#endif /* RPL_DAG_MC != RPL_DAG_MC_NONE */
+  rpl_rank_t rank;
+  uint16_t link_metric;
+  uint8_t dtsn;
+  uint8_t updated;
+};
+typedef struct rpl_parent rpl_parent_t;
+/*---------------------------------------------------------------------------*/
+/* RPL DIO prefix suboption */
+struct rpl_prefix {
+  uip_ipaddr_t prefix;
+  uint32_t lifetime;
+  uint8_t length;
+  uint8_t flags;
+};
+typedef struct rpl_prefix rpl_prefix_t;
+/*---------------------------------------------------------------------------*/
+/* Directed Acyclic Graph */
+struct rpl_dag {
+  uip_ipaddr_t dag_id;
+  rpl_rank_t min_rank; /* should be reset per DAG iteration! */
+  uint8_t version;
+  uint8_t grounded;
+  uint8_t preference;
+  uint8_t used;
+  /* live data for the DAG */
+  uint8_t joined;
+  rpl_parent_t *preferred_parent;
+  rpl_rank_t rank;
+  struct rpl_instance *instance;
+  LIST_STRUCT(parents);
+  rpl_prefix_t prefix_info;
+};
+typedef struct rpl_dag rpl_dag_t;
+typedef struct rpl_instance rpl_instance_t;
+/*---------------------------------------------------------------------------*/
+/*
+ * API for RPL objective functions (OF)
+ *
+ * reset(dag)
+ *
+ *  Resets the objective function state for a specific DAG. This function is
+ *  called when doing a global repair on the DAG.
+ *
+ * neighbor_link_callback(parent, known, etx)
+ *
+ *  Receives link-layer neighbor information. The parameter "known" is set
+ *  either to 0 or 1. The "etx" parameter specifies the current
+ *  ETX(estimated transmissions) for the neighbor.
+ *
+ * best_parent(parent1, parent2)
+ *
+ *  Compares two parents and returns the best one, according to the OF.
+ *
+ * best_dag(dag1, dag2)
+ *
+ *  Compares two DAGs and returns the best one, according to the OF.
+ *
+ * calculate_rank(parent, base_rank)
+ *
+ *  Calculates a rank value using the parent rank and a base rank.
+ *  If "parent" is NULL, the objective function selects a default increment
+ *  that is adds to the "base_rank". Otherwise, the OF uses information known
+ *  about "parent" to select an increment to the "base_rank".
+ *
+ * update_metric_container(dag)
+ *
+ *  Updates the metric container for outgoing DIOs in a certain DAG.
+ *  If the objective function of the DAG does not use metric containers, 
+ *  the function should set the object type to RPL_DAG_MC_NONE.
+ */
+struct rpl_of {
+  void (*reset)(struct rpl_dag *);
+  void (*neighbor_link_callback)(rpl_parent_t *, int, int);
+  rpl_parent_t *(*best_parent)(rpl_parent_t *, rpl_parent_t *);
+  rpl_dag_t *(*best_dag)(rpl_dag_t *, rpl_dag_t *);
+  rpl_rank_t (*calculate_rank)(rpl_parent_t *, rpl_rank_t);
+  void (*update_metric_container)( rpl_instance_t *);
+  rpl_ocp_t ocp;
+};
+typedef struct rpl_of rpl_of_t;
+/*---------------------------------------------------------------------------*/
+/* Instance */
+struct rpl_instance {
+  /* DAG configuration */
+  rpl_metric_container_t mc;
+  rpl_of_t *of;
+  rpl_dag_t *current_dag;
+  rpl_dag_t dag_table[RPL_MAX_DAG_PER_INSTANCE];
+  /* The current default router - used for routing "upwards" */
+  uip_ds6_defrt_t *def_route;
+  uint8_t instance_id;
+  uint8_t used;
+  uint8_t dtsn_out;
+  uint8_t mop;
+  uint8_t dio_intdoubl;
+  uint8_t dio_intmin;
+  uint8_t dio_redundancy;
+  uint8_t default_lifetime;
+  uint8_t dio_intcurrent;
+  uint8_t dio_send; /* for keeping track of which mode the timer is in */
+  uint8_t dio_counter;
+  rpl_rank_t max_rankinc;
+  rpl_rank_t min_hoprankinc;
+  uint16_t lifetime_unit; /* lifetime in seconds = l_u * d_l */
+#if RPL_CONF_STATS
+  uint16_t dio_totint;
+  uint16_t dio_totsend;
+  uint16_t dio_totrecv;
+#endif /* RPL_CONF_STATS */
+  clock_time_t dio_next_delay; /* delay for completion of dio interval */
+  struct ctimer dio_timer;
+  struct ctimer dao_timer;
+};
+
+/*---------------------------------------------------------------------------*/
+/* Public RPL functions. */
+void rpl_init(void);
+void uip_rpl_input(void);
+rpl_dag_t *rpl_set_root(uint8_t instance_id, uip_ipaddr_t * dag_id);
+int rpl_set_prefix(rpl_dag_t *dag, uip_ipaddr_t *prefix, unsigned len);
+int rpl_repair_root(uint8_t instance_id);
+int rpl_set_default_route(rpl_instance_t *instance, uip_ipaddr_t *from);
+rpl_dag_t *rpl_get_any_dag(void);
+rpl_instance_t *rpl_get_instance(uint8_t instance_id);
+void rpl_update_header_empty(void);
+int rpl_update_header_final(uip_ipaddr_t *addr);
+int rpl_verify_header(int);
+void rpl_insert_header(void);
+void rpl_remove_header(void);
+uint8_t rpl_invert_header(void);
+uip_ipaddr_t *rpl_get_parent_ipaddr(rpl_parent_t *nbr);
+rpl_rank_t rpl_get_parent_rank(uip_lladdr_t *addr);
+uint16_t rpl_get_parent_link_metric(uip_lladdr_t *addr);
+void rpl_dag_init(void);
+/*---------------------------------------------------------------------------*/
+#endif /* RPL_H */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/tcpip.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/tcpip.c
@@ -1,0 +1,865 @@
+/*
+ * Copyright (c) 2004, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+
+/**
+ * \file
+ *         Code for tunnelling uIP packets over the Rime mesh routing module
+ *
+ * \author  Adam Dunkels <adam@sics.se>\author
+ * \author  Mathilde Durvy <mdurvy@cisco.com> (IPv6 related code)
+ * \author  Julien Abeille <jabeille@cisco.com> (IPv6 related code)
+ */
+#include "contiki-net.h"
+#include "net/uip-split.h"
+#include "net/uip-packetqueue.h"
+
+#if UIP_CONF_IPV6
+#include "net/uip-nd6.h"
+#include "net/uip-ds6.h"
+#endif
+
+#include <string.h>
+
+#define DEBUG DEBUG_NONE
+#include "net/uip-debug.h"
+
+
+#if UIP_LOGGING == 0
+#include <stdio.h>
+void uip_log(char *msg);
+#define UIP_LOG(m) uip_log(m)
+#else
+#define UIP_LOG(m)
+#endif
+
+#if !BUF_32BIT_ALIGN //ORIGINAL
+#define UIP_ICMP_BUF ((struct uip_icmp_hdr *)&uip_buf[UIP_LLIPH_LEN + uip_ext_len])
+#define UIP_IP_BUF ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN])
+#define UIP_TCP_BUF ((struct uip_tcpip_hdr *)&uip_buf[UIP_LLH_LEN])
+#else
+#define UIP_ICMP_BUF ((struct uip_icmp_hdr *)&uip_buf32(UIP_LLIPH_LEN + uip_ext_len))
+#define UIP_IP_BUF ((struct uip_ip_hdr *)&uip_buf32(UIP_LLH_LEN))
+#define UIP_TCP_BUF ((struct uip_tcpip_hdr *)&uip_buf32(UIP_LLH_LEN))
+#endif
+
+#ifdef UIP_FALLBACK_INTERFACE
+extern struct uip_fallback_interface UIP_FALLBACK_INTERFACE;
+#endif
+
+#if UIP_CONF_IPV6_RPL
+#include "rpl/rpl.h"
+#endif
+
+process_event_t tcpip_event;
+#if UIP_CONF_ICMP6
+process_event_t tcpip_icmp6_event;
+#endif /* UIP_CONF_ICMP6 */
+
+/* Periodic check of active connections. */
+//static struct etimer periodic;
+
+#if UIP_CONF_IPV6 && UIP_CONF_IPV6_REASSEMBLY
+/* Timer for reassembly. */
+extern struct etimer uip_reass_timer;
+#endif
+
+#if UIP_TCP
+/**
+ * \internal Structure for holding a TCP port and a process ID.
+ */
+struct listenport {
+  uint16_t port;
+  struct process *p;
+};
+
+/*
+static struct internal_state {
+  struct listenport listenports[UIP_LISTENPORTS];
+  struct process *p;
+} s;
+*/
+#endif
+
+enum {
+  TCP_POLL,
+  UDP_POLL,
+  PACKET_INPUT
+};
+
+/* Called on IP packet output. */
+#if UIP_CONF_IPV6
+
+static uint8_t (* outputfunc)(uip_lladdr_t *a);
+
+#pragma stackfunction 50 //TODO: CHSC find out, how mutch stack is realy used
+uint8_t
+tcpip_output(uip_lladdr_t *a)
+{
+  int ret;
+  if(outputfunc != NULL) {
+    ret = outputfunc(a);
+    return ret;
+  }
+  UIP_LOG("tcpip_output: Use tcpip_set_outputfunc() to set an output function");
+  return 0;
+}
+
+void
+tcpip_set_outputfunc(uint8_t (*f)(uip_lladdr_t *))
+{
+  outputfunc = f;
+}
+#else
+
+static uint8_t (* outputfunc)(void);
+uint8_t
+tcpip_output(void)
+{
+  if(outputfunc != NULL) {
+    return outputfunc();
+  }
+  UIP_LOG("tcpip_output: Use tcpip_set_outputfunc() to set an output function");
+  return 0;
+}
+
+void
+tcpip_set_outputfunc(uint8_t (*f)(void))
+{
+  outputfunc = f;
+}
+#endif
+
+#if UIP_CONF_IP_FORWARD
+unsigned char tcpip_is_forwarding; /* Forwarding right now? */
+#endif /* UIP_CONF_IP_FORWARD */
+
+#if NO_XMOS_PROJECT		// This functions are completely different with the
+						// XMOS implementation. You can find them in uip_xtcp.c
+
+PROCESS(tcpip_process, "TCP/IP stack");
+
+/*---------------------------------------------------------------------------*/
+static void
+start_periodic_tcp_timer(void)
+{
+  if(etimer_expired(&periodic)) {
+    etimer_restart(&periodic);
+  }
+}
+/*---------------------------------------------------------------------------*/
+static void
+check_for_tcp_syn(void)
+{
+#if UIP_TCP || UIP_CONF_IP_FORWARD
+  /* This is a hack that is needed to start the periodic TCP timer if
+     an incoming packet contains a SYN: since uIP does not inform the
+     application if a SYN arrives, we have no other way of starting
+     this timer.  This function is called for every incoming IP packet
+     to check for such SYNs. */
+#define TCP_SYN 0x02
+  if(UIP_IP_BUF->proto == UIP_PROTO_TCP &&
+     (UIP_TCP_BUF->flags & TCP_SYN) == TCP_SYN) {
+    start_periodic_tcp_timer();
+  }
+#endif /* UIP_TCP || UIP_CONF_IP_FORWARD */
+}
+/*---------------------------------------------------------------------------*/
+static void
+packet_input(void)
+{
+#if UIP_CONF_IP_FORWARD
+  if(uip_len > 0) {
+    tcpip_is_forwarding = 1;
+    if(uip_fw_forward() == UIP_FW_LOCAL) {
+      tcpip_is_forwarding = 0;
+      check_for_tcp_syn();
+      uip_input();
+      if(uip_len > 0) {
+#if UIP_CONF_TCP_SPLIT
+        uip_split_output();
+#else /* UIP_CONF_TCP_SPLIT */
+#if UIP_CONF_IPV6
+        tcpip_ipv6_output();
+#else
+	PRINTF("tcpip packet_input forward output len %d\n", uip_len);
+        tcpip_output();
+#endif
+#endif /* UIP_CONF_TCP_SPLIT */
+      }
+    }
+    tcpip_is_forwarding = 0;
+  }
+#else /* UIP_CONF_IP_FORWARD */
+  if(uip_len > 0) {
+    check_for_tcp_syn();
+    uip_input();
+    if(uip_len > 0) {
+#if UIP_CONF_TCP_SPLIT
+      uip_split_output();
+#else /* UIP_CONF_TCP_SPLIT */
+#if UIP_CONF_IPV6
+      tcpip_ipv6_output();
+#else
+      PRINTF("tcpip packet_input output len %d\n", uip_len);
+      tcpip_output();
+#endif
+#endif /* UIP_CONF_TCP_SPLIT */
+    }
+  }
+#endif /* UIP_CONF_IP_FORWARD */
+}
+/*---------------------------------------------------------------------------*/
+#if UIP_TCP
+#if UIP_ACTIVE_OPEN
+struct uip_conn *
+tcp_connect(uip_ipaddr_t *ripaddr, uint16_t port, void *appstate)
+{
+  struct uip_conn *c;
+  
+  c = uip_connect(ripaddr, port);
+  if(c == NULL) {
+    return NULL;
+  }
+  c->appstate.p = PROCESS_CURRENT();
+  c->appstate.state = appstate;
+  
+  tcpip_poll_tcp(c);
+  return c;
+}
+#endif /* UIP_ACTIVE_OPEN */
+/*---------------------------------------------------------------------------*/
+void
+tcp_unlisten(uint16_t port)
+{
+  static unsigned char i;
+  struct listenport *l;
+
+  l = s.listenports;
+  for(i = 0; i < UIP_LISTENPORTS; ++i) {
+    if(l->port == port &&
+       l->p == PROCESS_CURRENT()) {
+      l->port = 0;
+      uip_unlisten(port);
+      break;
+    }
+    ++l;
+  }
+}
+/*---------------------------------------------------------------------------*/
+void
+tcp_listen(uint16_t port)
+{
+  static unsigned char i;
+  struct listenport *l;
+
+  l = s.listenports;
+  for(i = 0; i < UIP_LISTENPORTS; ++i) {
+    if(l->port == 0) {
+      l->port = port;
+      l->p = PROCESS_CURRENT();
+      uip_listen(port);
+      break;
+    }
+    ++l;
+  }
+}
+/*---------------------------------------------------------------------------*/
+
+void
+tcp_attach(struct uip_conn *conn,
+	   void *appstate)
+{
+  uip_tcp_appstate_t *s;
+  s = &conn->appstate;
+  s->p = PROCESS_CURRENT();
+  s->state = appstate;
+}
+
+#endif /* UIP_TCP */
+/*---------------------------------------------------------------------------*/
+#if UIP_UDP
+void
+udp_attach(struct uip_udp_conn *conn,
+	   void *appstate)
+{
+  uip_udp_appstate_t *s;
+
+  s = &conn->appstate;
+  s->p = PROCESS_CURRENT();
+  s->state = appstate;
+}
+
+/*---------------------------------------------------------------------------*/
+struct uip_udp_conn *
+udp_new(const uip_ipaddr_t *ripaddr, uint16_t port, void *appstate)
+{
+  struct uip_udp_conn *c;
+  uip_udp_appstate_t *s;
+  
+  c = uip_udp_new(ripaddr, port);
+  if(c == NULL) {
+    return NULL;
+  }
+  s = &c->appstate;
+  s->p = PROCESS_CURRENT();
+  s->state = appstate;
+  return c;
+}
+/*---------------------------------------------------------------------------*/
+struct uip_udp_conn *
+udp_broadcast_new(uint16_t port, void *appstate)
+{
+  uip_ipaddr_t addr;
+  struct uip_udp_conn *conn;
+
+#if UIP_CONF_IPV6
+  uip_create_linklocal_allnodes_mcast(&addr);
+#else
+  uip_ipaddr(&addr, 255,255,255,255);
+#endif /* UIP_CONF_IPV6 */
+  conn = udp_new(&addr, port, appstate);
+  if(conn != NULL) {
+    udp_bind(conn, port);
+  }
+  return conn;
+}
+#endif /* UIP_UDP */
+
+/*---------------------------------------------------------------------------*/
+#if UIP_CONF_ICMP6
+uint8_t
+icmp6_new(void *appstate) {
+  if(uip_icmp6_conns.appstate.p == PROCESS_NONE) {
+    uip_icmp6_conns.appstate.p = PROCESS_CURRENT();
+    uip_icmp6_conns.appstate.state = appstate;
+    return 0;
+  }
+  return 1;
+}
+
+void
+tcpip_icmp6_call(uint8_t type)
+{
+  if(uip_icmp6_conns.appstate.p != PROCESS_NONE) {
+    /* XXX: This is a hack that needs to be updated. Passing a pointer (&type)
+       like this only works with process_post_synch. */
+    process_post_synch(uip_icmp6_conns.appstate.p, tcpip_icmp6_event, &type);
+  }
+  return;
+}
+#endif /* UIP_CONF_ICMP6 */
+/*---------------------------------------------------------------------------*/
+static void
+eventhandler(process_event_t ev, process_data_t data)
+{
+#if UIP_TCP
+  static unsigned char i;
+  register struct listenport *l;
+#endif /*UIP_TCP*/
+  struct process *p;
+
+  switch(ev) {
+    case PROCESS_EVENT_EXITED:
+/* ========================================================================== */
+    	/* This is the event we get if a process has exited. We go through
+         the TCP/IP tables to see if this process had any open
+         connections or listening TCP ports. If so, we'll close those
+         connections. */
+
+      p = (struct process *)data;
+#if UIP_TCP
+      l = s.listenports;
+      for(i = 0; i < UIP_LISTENPORTS; ++i) {
+        if(l->p == p) {
+          uip_unlisten(l->port);
+          l->port = 0;
+          l->p = PROCESS_NONE;
+        }
+        ++l;
+      }
+
+      {
+        struct uip_conn *cptr;
+
+        for(cptr = &uip_conns[0]; cptr < &uip_conns[UIP_CONNS]; ++cptr) {
+#if NO_XMOS_PROJECT
+          if(cptr->appstate.p == p) {
+            cptr->appstate.p = PROCESS_NONE;
+            cptr->tcpstateflags = UIP_CLOSED;
+          }
+#else
+          printf("### %s: Here the process should be called.\n", __func__);
+#endif
+        }
+      }
+#endif /* UIP_TCP */
+#if UIP_UDP
+      {
+        struct uip_udp_conn *cptr;
+
+        for(cptr = &uip_udp_conns[0];
+            cptr < &uip_udp_conns[UIP_UDP_CONNS]; ++cptr) {
+#if NO_XMOS_PROJECT
+        	if(cptr->appstate.p == p) {
+            cptr->lport = 0;
+          }
+#else
+          printf("### %s: Here the process should be called.\n", __func__);
+#endif
+        }
+      }
+#endif /* UIP_UDP */
+      break;
+/* ========== END OF "PROCESS_EVENT_EXITED" ================================= */
+
+    case PROCESS_EVENT_TIMER:
+      /* We get this event if one of our timers have expired. */
+      {
+        /* Check the clock so see if we should call the periodic uIP
+           processing. */
+        if(data == &periodic &&
+           etimer_expired(&periodic)) {
+#if UIP_TCP
+          for(int i = 0; i < UIP_CONNS; ++i) {
+            if(uip_conn_active(i)) {
+              /* Only restart the timer if there are active
+                 connections. */
+              etimer_restart(&periodic);
+              uip_periodic(i);
+#if UIP_CONF_IPV6
+              tcpip_ipv6_output();
+#else
+              if(uip_len > 0) {
+                PRINTF("tcpip_output from periodic len %d\n", uip_len);
+                tcpip_output();
+                PRINTF("tcpip_output after periodic len %d\n", uip_len);
+              }
+#endif /* UIP_CONF_IPV6 */
+            }
+          }
+#endif /* UIP_TCP */
+#if UIP_CONF_IP_FORWARD
+          uip_fw_periodic();
+#endif /* UIP_CONF_IP_FORWARD */
+        }
+        
+#if UIP_CONF_IPV6
+#if UIP_CONF_IPV6_REASSEMBLY
+        /*
+         * check the timer for reassembly
+         */
+        if(data == &uip_reass_timer &&
+           etimer_expired(&uip_reass_timer)) {
+          uip_reass_over();
+          tcpip_ipv6_output();
+        }
+#endif /* UIP_CONF_IPV6_REASSEMBLY */
+        /*
+         * check the different timers for neighbor discovery and
+         * stateless autoconfiguration
+         */
+        /*if(data == &uip_ds6_timer_periodic &&
+           etimer_expired(&uip_ds6_timer_periodic)) {
+          uip_ds6_periodic();
+          tcpip_ipv6_output();
+        }*/
+#if !UIP_CONF_ROUTER
+        if(data == &uip_ds6_timer_rs &&
+           etimer_expired(&uip_ds6_timer_rs)) {
+          uip_ds6_send_rs();
+          tcpip_ipv6_output();
+        }
+#endif /* !UIP_CONF_ROUTER */
+        if(data == &uip_ds6_timer_periodic &&
+           etimer_expired(&uip_ds6_timer_periodic)) {
+          uip_ds6_periodic();
+          tcpip_ipv6_output();
+        }
+#endif /* UIP_CONF_IPV6 */
+      }
+      break;
+/* ========== END OF "PROCESS_EVENT_TIMER" ================================= */
+
+#if UIP_TCP
+    case TCP_POLL:
+      if(data != NULL) {
+        uip_poll_conn(data);
+#if UIP_CONF_IPV6
+        tcpip_ipv6_output();
+#else /* UIP_CONF_IPV6 */
+        if(uip_len > 0) {
+	  PRINTF("tcpip_output from tcp poll len %d\n", uip_len);
+          tcpip_output();
+        }
+#endif /* UIP_CONF_IPV6 */
+        /* Start the periodic polling, if it isn't already active. */
+        start_periodic_tcp_timer();
+      }
+      break;
+#endif /* UIP_TCP */
+#if UIP_UDP
+    case UDP_POLL:
+      if(data != NULL) {
+        uip_udp_periodic_conn(data);
+#if UIP_CONF_IPV6
+        tcpip_ipv6_output();
+#else
+        if(uip_len > 0) {
+          tcpip_output();
+        }
+#endif /* UIP_UDP */
+      }
+      break;
+#endif /* UIP_UDP */
+
+    case PACKET_INPUT:
+      packet_input();
+      break;
+
+    default:
+    	PRINTF("%s: Unknown event type: %i", __func__, ev);
+    	break;
+  };
+}
+#endif /* NO_XMOS_PROJECT */
+/*---------------------------------------------------------------------------*/
+#if NO_XMOS_PROJECT
+void
+tcpip_input(void)
+{
+  process_post_synch(&tcpip_process, PACKET_INPUT, NULL);
+  uip_len = 0;
+#if UIP_CONF_IPV6
+  uip_ext_len = 0;
+#endif /*UIP_CONF_IPV6*/
+}
+#endif /* NO_XMOS_PROJECT */
+/*---------------------------------------------------------------------------*/
+#if NO_XMOS_PROJECT
+#if UIP_CONF_IPV6
+void
+tcpip_ipv6_output(void)
+{
+	uip_ds6_nbr_t *nbr = NULL;
+	uip_ipaddr_t *nexthop;
+
+	if(uip_len == 0) {
+		return;
+	}
+
+	if(uip_len > UIP_LINK_MTU) {
+		UIP_LOG("tcpip_ipv6_output: Packet to big");
+		uip_len = 0;
+		return;
+	}
+
+	if(uip_is_addr_unspecified(&UIP_IP_BUF->destipaddr)){
+			UIP_LOG("tcpip_ipv6_output: Destination address unspecified");
+		uip_len = 0;
+		return;
+	}
+
+	if(!uip_is_addr_mcast(&UIP_IP_BUF->destipaddr)) {
+		/* Next hop determination */
+		nbr = NULL;
+
+		/* We first check if the destination address is on our immediate
+			link. If so, we simply use the destination address as our
+			nexthop address. */
+		if(uip_ds6_is_addr_onlink(&UIP_IP_BUF->destipaddr)){
+			nexthop = &UIP_IP_BUF->destipaddr;
+		} else {
+			uip_ds6_route_t *route;
+			/* Check if we have a route to the destination address. */
+			route = uip_ds6_route_lookup(&UIP_IP_BUF->destipaddr);
+
+			/* No route was found - we send to the default route instead. */
+			if(route == NULL) {
+				PRINTF("tcpip_ipv6_output: no route found, using default route\n");
+				nexthop = uip_ds6_defrt_choose();
+				if(nexthop == NULL) {
+#ifdef UIP_FALLBACK_INTERFACE
+					PRINTF("FALLBACK: removing ext hdrs & setting proto %d %d\n",
+							uip_ext_len, *((uint8_t *)UIP_IP_BUF + 40));
+					if(uip_ext_len > 0) {
+						extern void remove_ext_hdr(void);
+						uint8_t proto = *((uint8_t *)UIP_IP_BUF + 40);
+						remove_ext_hdr();
+						/* This should be copied from the ext header... */
+						UIP_IP_BUF->proto = proto;
+					}
+					UIP_FALLBACK_INTERFACE.output();
+#else
+					PRINTF("tcpip_ipv6_output: Destination off-link but no route\n");
+#endif /* !UIP_FALLBACK_INTERFACE */
+					uip_len = 0;
+					return;
+				}
+
+			} else {
+				/* A route was found, so we look up the nexthop neighbor for
+				   the route. */
+				nexthop = uip_ds6_route_nexthop(route);
+
+				/* If the nexthop is dead, for example because the neighbor
+				   never responded to link-layer acks, we drop its route. */
+				if(nexthop == NULL) {
+#if UIP_CONF_IPV6_RPL
+					/* If we are running RPL, and if we are the root of the
+					* network, we'll trigger a global repair berfore we remove
+					* the route. */
+					rpl_dag_t *dag;
+					rpl_instance_t *instance;
+
+					dag = (rpl_dag_t *)route->state.dag;
+					if(dag != NULL) {
+						instance = dag->instance;
+
+						rpl_repair_root(instance->instance_id);
+					}
+#endif /* UIP_CONF_RPL */
+					uip_ds6_route_rm(route);
+
+					/* We don't have a nexthop to send the packet to, so we drop
+					* it. */
+					return;
+				}
+			}
+#if TCPIP_CONF_ANNOTATE_TRANSMISSIONS
+			if(nexthop != NULL) {
+				static uint8_t annotate_last;
+				static uint8_t annotate_has_last = 0;
+
+				if(annotate_has_last) {
+					printf("#L %u 0; red\n", annotate_last);
+				}
+				printf("#L %u 1; red\n", nexthop->u8[sizeof(uip_ipaddr_t) - 1]);
+				annotate_last = nexthop->u8[sizeof(uip_ipaddr_t) - 1];
+				annotate_has_last = 1;
+			}
+#endif /* TCPIP_CONF_ANNOTATE_TRANSMISSIONS */
+		}
+
+		/* End of next hop determination */
+
+#if UIP_CONF_IPV6_RPL
+		if(rpl_update_header_final(nexthop)) {
+			uip_len = 0;
+			return;
+		}
+#endif /* UIP_CONF_IPV6_RPL */
+		nbr = uip_ds6_nbr_lookup(nexthop);
+		if(nbr == NULL) {
+#if UIP_ND6_SEND_NA
+			if((nbr = uip_ds6_nbr_add(nexthop, NULL, 0, NBR_INCOMPLETE)) == NULL) {
+				uip_len = 0;
+				return;
+			} else {
+#if UIP_CONF_IPV6_QUEUE_PKT
+				/* Copy outgoing pkt in the queuing buffer for later transmit. */
+				if(uip_packetqueue_alloc(&nbr->packethandle, UIP_DS6_NBR_PACKET_LIFETIME) != NULL) {
+					memcpy(uip_packetqueue_buf(&nbr->packethandle), UIP_IP_BUF, uip_len);
+					uip_packetqueue_set_buflen(&nbr->packethandle, uip_len);
+				}
+#endif
+				/* RFC4861, 7.2.2:
+				* "If the source address of the packet prompting the solicitation is the
+				* same as one of the addresses assigned to the outgoing interface, that
+				* address SHOULD be placed in the IP Source Address of the outgoing
+				* solicitation.  Otherwise, any one of the addresses assigned to the
+				* interface should be used."*/
+				if(uip_ds6_is_my_addr(&UIP_IP_BUF->srcipaddr)){
+					uip_nd6_ns_output(&UIP_IP_BUF->srcipaddr, NULL, &nbr->ipaddr);
+				} else {
+					uip_nd6_ns_output(NULL, NULL, &nbr->ipaddr);
+				}
+
+				stimer_set(&nbr->sendns, uip_ds6_if.retrans_timer / 1000);
+				nbr->nscount = 1;
+			}
+#endif /* UIP_ND6_SEND_NA */
+		} else {
+#if UIP_ND6_SEND_NA
+			if(nbr->state == NBR_INCOMPLETE) {
+				PRINTF("tcpip_ipv6_output: nbr cache entry incomplete\n");
+#if UIP_CONF_IPV6_QUEUE_PKT
+				/* Copy outgoing pkt in the queuing buffer for later transmit and set
+				*  the destination nbr to nbr. */
+				if(uip_packetqueue_alloc(&nbr->packethandle, UIP_DS6_NBR_PACKET_LIFETIME) != NULL) {
+					memcpy(uip_packetqueue_buf(&nbr->packethandle), UIP_IP_BUF, uip_len);
+					uip_packetqueue_set_buflen(&nbr->packethandle, uip_len);
+				}
+#endif /*UIP_CONF_IPV6_QUEUE_PKT*/
+				uip_len = 0;
+				return;
+			}
+			/* Send in parallel if we are running NUD (nbc state is either STALE,
+			*   DELAY, or PROBE). See RFC 4861, section 7.7.3 on node behavior. */
+			if(nbr->state == NBR_STALE) {
+				nbr->state = NBR_DELAY;
+				stimer_set(&nbr->reachable, UIP_ND6_DELAY_FIRST_PROBE_TIME);
+				nbr->nscount = 0;
+				PRINTF("tcpip_ipv6_output: nbr cache entry stale moving to delay\n");
+			}
+#endif /* UIP_ND6_SEND_NA */
+
+			tcpip_output(uip_ds6_nbr_get_ll(nbr));
+
+#if UIP_CONF_IPV6_QUEUE_PKT
+			/*
+			 * Send the queued packets from here, may not be 100% perfect though.
+			 * This happens in a few cases, for example when instead of receiving a
+			 * NA after sendiong a NS, you receive a NS with SLLAO: the entry moves
+			 * to STALE, and you must both send a NA and the queued packet.
+			 */
+			if(uip_packetqueue_buflen(&nbr->packethandle) != 0) {
+				uip_len = uip_packetqueue_buflen(&nbr->packethandle);
+				memcpy(UIP_IP_BUF, uip_packetqueue_buf(&nbr->packethandle), uip_len);
+				uip_packetqueue_free(&nbr->packethandle);
+				xtcpip_output(uip_ds6_nbr_get_ll(nbr));
+			}
+#endif /*UIP_CONF_IPV6_QUEUE_PKT*/
+
+			uip_len = 0;
+			return;
+		}
+		return;
+	}
+
+	/* Multicast IP destination address. */
+	tcpip_output(NULL);
+	uip_len = 0;
+	uip_ext_len = 0;
+}
+#endif /* UIP_CONF_IPV6 */
+
+/*---------------------------------------------------------------------------*/
+
+#if UIP_UDP
+void
+tcpip_poll_udp(struct uip_udp_conn *conn)
+{
+  process_post(&tcpip_process, UDP_POLL, conn);
+}
+#endif /* UIP_UDP */
+/*---------------------------------------------------------------------------*/
+#if UIP_TCP
+void
+tcpip_poll_tcp(struct uip_conn *conn)
+{
+  process_post(&tcpip_process, TCP_POLL, conn);
+}
+#endif /* UIP_TCP */
+/*---------------------------------------------------------------------------*/
+void
+tcpip_uipcall(void)
+{
+	uip_udp_appstate_t *ts;
+
+#if UIP_UDP
+	if(uip_conn != NULL) {
+		ts = &uip_conn->appstate;
+	} else {
+		ts = &uip_udp_conn->appstate;
+	}
+#else /* UIP_UDP */
+	ts = &uip_conn->appstate;
+#endif /* UIP_UDP */
+
+#if UIP_TCP
+	{
+		static unsigned char i;
+		struct listenport *l;
+
+		/* If this is a connection request for a listening port, we must
+		   mark the connection with the right process ID. */
+		if(uip_connected()) {
+			l = &s.listenports[0];
+			for(i = 0; i < UIP_LISTENPORTS; ++i) {
+				if(l->port == uip_conn->lport && l->p != PROCESS_NONE) {
+#if NO_XMOS_PROJECT
+					ts->p = l->p;
+					ts->state = NULL;
+#else
+          printf("### %s: Here the process should be called.\n", __func__);
+#endif
+					break;
+				}
+				++l;
+			}
+			/* Start the periodic polling, if it isn't already active. */
+			start_periodic_tcp_timer();
+		}
+	}
+#endif /* UIP_TCP */
+	if(ts->p != NULL) {
+		process_post_synch(ts->p, tcpip_event, ts->state);
+	}
+}
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(tcpip_process, ev, data)
+{
+	PROCESS_BEGIN();
+
+#if UIP_TCP
+	{
+		static unsigned char i;
+
+		for(i = 0; i < UIP_LISTENPORTS; ++i) {
+			s.listenports[i].port = 0;
+		}
+		s.p = PROCESS_CURRENT();
+	}
+#endif
+
+	tcpip_event = process_alloc_event();
+#if UIP_CONF_ICMP6
+	tcpip_icmp6_event = process_alloc_event();
+#endif /* UIP_CONF_ICMP6 */
+	etimer_set(&periodic, CLOCK_SECOND / 2);
+	uip_init();
+#ifdef UIP_FALLBACK_INTERFACE
+	UIP_FALLBACK_INTERFACE.init();
+#endif
+/* initialize RPL if configured for using RPL */
+#if UIP_CONF_IPV6 && UIP_CONF_IPV6_RPL
+	rpl_init();
+#endif /* UIP_CONF_IPV6_RPL */
+
+	while(1) {
+		PROCESS_YIELD();
+  		eventhandler(ev, data);
+	}
+  
+	PROCESS_END();
+}
+#endif /* NO_XMOS_PROJECT */
+/*---------------------------------------------------------------------------*/

--- a/module_xtcp/src/xtcp_uip6/contiki/net/tcpip.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/tcpip.h
@@ -1,0 +1,380 @@
+/**
+ * \addtogroup uip
+ * @{
+ */
+
+/**
+ * \defgroup tcpip The Contiki/uIP interface
+ * @{
+ *
+ * TCP/IP support in Contiki is implemented using the uIP TCP/IP
+ * stack. For sending and receiving data, Contiki uses the functions
+ * provided by the uIP module, but Contiki adds a set of functions for
+ * connection management. The connection management functions make
+ * sure that the uIP TCP/IP connections are connected to the correct
+ * process.
+ *
+ * Contiki also includes an optional protosocket library that provides
+ * an API similar to the BSD socket API.
+ *
+ * \sa \ref uip "The uIP TCP/IP stack"
+ * \sa \ref psock "Protosockets library"
+ *
+ */
+
+/**
+ * \file
+ *          Header for the Contiki/uIP interface.
+ * \author  Adam Dunkels <adam@sics.se>
+ * \author  Mathilde Durvy <mdurvy@cisco.com> (IPv6 related code)
+ * \author  Julien Abeille <jabeille@cisco.com> (IPv6 related code)
+ */
+
+/*
+ * Copyright (c) 2004, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ * Author: Adam Dunkels <adam@sics.se>
+ *
+ */
+#ifndef __TCPIP_H__
+#define __TCPIP_H__
+
+#include "contiki.h"
+
+struct uip_conn;
+
+struct tcpip_uipstate {
+  struct process *p;
+  void *state;
+};
+
+#if NO_XMOS_PROJECT
+#define UIP_APPCALL tcpip_uipcall
+#define UIP_UDP_APPCALL tcpip_uipcall
+#define UIP_ICMP6_APPCALL tcpip_icmp6_call
+#endif
+
+/*#define UIP_APPSTATE_SIZE sizeof(struct tcpip_uipstate)*/
+#if NO_XMOS_PROJECT
+typedef struct tcpip_uipstate uip_udp_appstate_t;
+typedef struct tcpip_uipstate uip_tcp_appstate_t;
+#endif
+typedef struct tcpip_uipstate uip_icmp6_appstate_t;
+#include "net/uip.h"
+void tcpip_uipcall(void);
+
+/**
+ * \name TCP functions
+ * @{
+ */
+
+/**
+ * Attach a TCP connection to the current process
+ *
+ * This function attaches the current process to a TCP
+ * connection. Each TCP connection must be attached to a process in
+ * order for the process to be able to receive and send
+ * data. Additionally, this function can add a pointer with connection
+ * state to the connection.
+ *
+ * \param conn A pointer to the TCP connection.
+ *
+ * \param appstate An opaque pointer that will be passed to the
+ * process whenever an event occurs on the connection.
+ *
+ */
+void tcp_attach(struct uip_conn *conn,
+		     void *appstate);
+#define tcp_markconn(conn, appstate) tcp_attach(conn, appstate)
+
+/**
+ * Open a TCP port.
+ *
+ * This function opens a TCP port for listening. When a TCP connection
+ * request occurs for the port, the process will be sent a tcpip_event
+ * with the new connection request.
+ *
+ * \note Port numbers must always be given in network byte order. The
+ * functions UIP_HTONS() and uip_htons() can be used to convert port numbers
+ * from host byte order to network byte order.
+ *
+ * \param port The port number in network byte order.
+ *
+ */
+void tcp_listen(uint16_t port);
+
+/**
+ * Close a listening TCP port.
+ *
+ * This function closes a listening TCP port.
+ *
+ * \note Port numbers must always be given in network byte order. The
+ * functions UIP_HTONS() and uip_htons() can be used to convert port numbers
+ * from host byte order to network byte order.
+ *
+ * \param port The port number in network byte order.
+ *
+ */
+void tcp_unlisten(uint16_t port);
+
+/**
+ * Open a TCP connection to the specified IP address and port.
+ *
+ * This function opens a TCP connection to the specified port at the
+ * host specified with an IP address. Additionally, an opaque pointer
+ * can be attached to the connection. This pointer will be sent
+ * together with uIP events to the process.
+ *
+ * \note The port number must be provided in network byte order so a
+ * conversion with UIP_HTONS() usually is necessary.
+ *
+ * \note This function will only create the connection. The connection
+ * is not opened directly. uIP will try to open the connection the
+ * next time the uIP stack is scheduled by Contiki.
+ *
+ * \param ripaddr Pointer to the IP address of the remote host.
+ * \param port Port number in network byte order.
+ * \param appstate Pointer to application defined data.
+ *
+ * \return A pointer to the newly created connection, or NULL if
+ * memory could not be allocated for the connection.
+ *
+ */
+struct uip_conn *tcp_connect(uip_ipaddr_t *ripaddr, uint16_t port,
+				  void *appstate);
+
+/**
+ * Cause a specified TCP connection to be polled.
+ *
+ * This function causes uIP to poll the specified TCP connection. The
+ * function is used when the application has data that is to be sent
+ * immediately and do not wish to wait for the periodic uIP polling
+ * mechanism.
+ *
+ * \param conn A pointer to the TCP connection that should be polled.
+ *
+ */
+void tcpip_poll_tcp(struct uip_conn *conn);
+
+/** @} */
+
+/**
+ * \name UDP functions
+ * @{
+ */
+
+struct uip_udp_conn;
+/**
+ * Attach the current process to a UDP connection
+ *
+ * This function attaches the current process to a UDP
+ * connection. Each UDP connection must have a process attached to it
+ * in order for the process to be able to receive and send data over
+ * the connection. Additionally, this function can add a pointer with
+ * connection state to the connection.
+ *
+ * \param conn A pointer to the UDP connection.
+ *
+ * \param appstate An opaque pointer that will be passed to the
+ * process whenever an event occurs on the connection.
+ *
+ */
+void udp_attach(struct uip_udp_conn *conn,
+		void *appstate);
+#define udp_markconn(conn, appstate) udp_attach(conn, appstate)
+
+/**
+ * Create a new UDP connection.
+ *
+ * This function creates a new UDP connection with the specified
+ * remote endpoint.
+ *
+ * \note The port number must be provided in network byte order so a
+ * conversion with UIP_HTONS() usually is necessary.
+ *
+ * \sa udp_bind()
+ *
+ * \param ripaddr Pointer to the IP address of the remote host.
+ * \param port Port number in network byte order.
+ * \param appstate Pointer to application defined data.
+ *
+ * \return A pointer to the newly created connection, or NULL if
+ * memory could not be allocated for the connection.
+ */
+struct uip_udp_conn *udp_new(const uip_ipaddr_t *ripaddr, uint16_t port,
+				  void *appstate);
+
+/**
+ * Create a new UDP broadcast connection.
+ *
+ * This function creates a new (link-local) broadcast UDP connection
+ * to a specified port.
+ *
+ * \param port Port number in network byte order.
+ * \param appstate Pointer to application defined data.
+ *
+ * \return A pointer to the newly created connection, or NULL if
+ * memory could not be allocated for the connection.
+ */
+struct uip_udp_conn *udp_broadcast_new(uint16_t port, void *appstate);
+
+/**
+ * Bind a UDP connection to a local port.
+ *
+ * This function binds a UDP connection to a specified local port.
+ *
+ * When a connection is created with udp_new(), it gets a local port
+ * number assigned automatically. If the application needs to bind the
+ * connection to a specified local port, this function should be used.
+ *
+ * \note The port number must be provided in network byte order so a
+ * conversion with UIP_HTONS() usually is necessary.
+ *
+ * \param conn A pointer to the UDP connection that is to be bound.
+ * \param port The port number in network byte order to which to bind
+ * the connection.
+ */
+#define udp_bind(conn, port) uip_udp_bind(conn, port)
+
+/**
+ * Cause a specified UDP connection to be polled.
+ *
+ * This function causes uIP to poll the specified UDP connection. The
+ * function is used when the application has data that is to be sent
+ * immediately and do not wish to wait for the periodic uIP polling
+ * mechanism.
+ *
+ * \param conn A pointer to the UDP connection that should be polled.
+ *
+ */
+void tcpip_poll_udp(struct uip_udp_conn *conn);
+
+/** @} */
+ 
+/**
+ * \name ICMPv6 functions
+ * @{
+ */
+
+#if UIP_CONF_ICMP6
+
+/**
+ * The ICMP6 event.
+ *
+ * This event is posted to a process whenever a uIP ICMP event has occurred.
+ */
+extern process_event_t tcpip_icmp6_event;
+
+/**
+ * \brief register an ICMPv6 callback
+ * \return 0 if success, 1 if failure (one application already registered)
+ *
+ * This function just registers a process to be polled when
+ * an ICMPv6 message is received.
+ * If no application registers, some ICMPv6 packets will be
+ * processed by the "kernel" as usual (NS, NA, RS, RA, Echo request),
+ * others will be dropped.
+ * If an application registers here, it will be polled with a
+ * process_post_synch every time an ICMPv6 packet is received.
+ */
+uint8_t icmp6_new(void *appstate);
+
+/**
+ * This function is called at reception of an ICMPv6 packet
+ * If an application registered as an ICMPv6 listener (with
+ * icmp6_new), it will be called through a process_post_synch()
+ */
+void tcpip_icmp6_call(uint8_t type);
+#endif /*UIP_CONF_ICMP6*/
+
+/** @} */
+/**
+ * The uIP event.
+ *
+ * This event is posted to a process whenever a uIP event has occurred.
+ */
+extern process_event_t tcpip_event;
+
+/**
+ * \name TCP/IP packet processing
+ * @{
+ */
+
+/**
+ * \brief      Deliver an incoming packet to the TCP/IP stack
+ *
+ *             This function is called by network device drivers to
+ *             deliver an incoming packet to the TCP/IP stack. The
+ *             incoming packet must be present in the uip_buf buffer,
+ *             and the length of the packet must be in the global
+ *             uip_len variable.
+ */
+void tcpip_input(void);
+
+/**
+ * \brief Output packet to layer 2
+ * The eventual parameter is the MAC address of the destination.
+ */
+#if UIP_CONF_IPV6
+uint8_t tcpip_output(uip_lladdr_t *);
+void tcpip_set_outputfunc(uint8_t (* f)(uip_lladdr_t *));
+#else
+uint8_t tcpip_output(void);
+void tcpip_set_outputfunc(uint8_t (* f)(void));
+#endif
+
+/**
+ * \brief This function does address resolution and then calls tcpip_output
+ */
+#if UIP_CONF_IPV6
+void tcpip_ipv6_output(void);
+#endif
+
+/**
+ * \brief Is forwarding generally enabled?
+ */
+extern unsigned char tcpip_do_forwarding;
+
+/*
+ * Are we at the moment forwarding the contents of uip_buf[]?
+ */
+extern unsigned char tcpip_is_forwarding;
+
+
+#define tcpip_set_forwarding(forwarding) tcpip_do_forwarding = (forwarding)
+
+/** @} */
+
+PROCESS_NAME(tcpip_process);
+
+#endif /* __TCPIP_H__ */
+
+/** @} */
+/** @} */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/uip-debug.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/uip-debug.c
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2010, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+/**
+ * \file
+ *         A set of debugging tools
+ * \author
+ *         Nicolas Tsiftes <nvt@sics.se>
+ *         Niclas Finne <nfi@sics.se>
+ *         Joakim Eriksson <joakime@sics.se>
+ */
+
+#include "net/uip-debug.h"
+
+/*---------------------------------------------------------------------------*/
+void
+uip_debug_ipaddr_print(const uip_ipaddr_t *addr)
+{
+  if(addr == NULL || addr->u8 == NULL) {
+    printf("(NULL IP addr)");
+    return;
+  }
+#if UIP_CONF_IPV6
+  uint16_t a;
+  unsigned int i;
+  int f;
+  for(i = 0, f = 0; i < sizeof(uip_ipaddr_t); i += 2) {
+    a = (addr->u8[i] << 8) + addr->u8[i + 1];
+    if(a == 0 && f >= 0) {
+      if(f++ == 0) {
+        PRINTA("::");
+      }
+    } else {
+      if(f > 0) {
+        f = -1;
+      } else if(i > 0) {
+        PRINTA(":");
+      }
+      PRINTA("%x", a);
+    }
+  }
+#else /* UIP_CONF_IPV6 */
+  PRINTA("%u.%u.%u.%u", addr->u8[0], addr->u8[1], addr->u8[2], addr->u8[3]);
+#endif /* UIP_CONF_IPV6 */
+}
+/*---------------------------------------------------------------------------*/
+void
+uip_debug_lladdr_print(const uip_lladdr_t *addr)
+{
+  unsigned int i;
+  for(i = 0; i < sizeof(uip_lladdr_t); i++) {
+    if(i > 0) {
+      PRINTA(":");
+    }
+    PRINTA("%02x", addr->addr[i]);
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+void uip_debug_buf_dump(uint8_t *buf,uint16_t len) {
+	for(int i=0; i<len; i++){
+		if(i%0x10 == 0x00){
+			printf("%04x ", i);
+		} else if(i%0x10 == (0x10/2)){
+			printf(" ");
+		}
+		printf("%02x ", buf[i]);
+		if(i%0x10 == (0x10-1)) {
+			printf("\n");\
+		}
+	}
+	printf("\n");\
+}
+
+/*---------------------------------------------------------------------------*/

--- a/module_xtcp/src/xtcp_uip6/contiki/net/uip-debug.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/uip-debug.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2010, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+/**
+ * \file
+ *         A set of debugging macros.
+ *
+ * \author Nicolas Tsiftes <nvt@sics.se>
+ *         Niclas Finne <nfi@sics.se>
+ *         Joakim Eriksson <joakime@sics.se>
+ */
+
+#ifndef UIP_DEBUG_H
+#define UIP_DEBUG_H
+
+#include "net/uip.h"
+#include <stdio.h>
+
+void uip_debug_ipaddr_print(const uip_ipaddr_t *addr);
+void uip_debug_lladdr_print(const uip_lladdr_t *addr);
+void uip_debug_buf_dump(uint8_t *buf, uint16_t len);
+
+#define DEBUG_NONE      0
+#define DEBUG_PRINT     1
+#define DEBUG_ANNOTATE  2
+#define DEBUG_BUF_DUMP  4
+#define DEBUG_FULL      DEBUG_ANNOTATE | DEBUG_PRINT | DEBUG_BUF_DUMP
+
+/* PRINTA will always print if the debug routines are called directly */
+#ifdef __AVR__
+#include <avr/pgmspace.h>
+#define PRINTA(FORMAT,args...) printf_P(PSTR(FORMAT),##args)
+#else
+#define PRINTA(...) printf(__VA_ARGS__)
+#endif
+
+#if (DEBUG) & DEBUG_ANNOTATE
+#ifdef __AVR__
+#define ANNOTATE(FORMAT,args...) printf_P(PSTR(FORMAT),##args)
+#else
+#define ANNOTATE(...) printf(__VA_ARGS__)
+#endif
+#else
+#define ANNOTATE(...)
+#endif /* (DEBUG) & DEBUG_ANNOTATE */
+
+#if (DEBUG) & DEBUG_PRINT
+#ifdef __AVR__
+#define PRINTF(FORMAT,args...) printf_P(PSTR(FORMAT),##args)
+#else
+#define PRINTF(...) printf(__VA_ARGS__)
+#endif
+#define PRINT6ADDR(addr) uip_debug_ipaddr_print(addr)
+#define PRINTLLADDR(lladdr) uip_debug_lladdr_print(lladdr)
+#else
+#define PRINTF(...)
+#define PRINT6ADDR(addr)
+#define PRINTLLADDR(lladdr)
+#endif /* (DEBUG) & DEBUG_PRINT */
+
+#if (DEBUG) & DEBUG_BUF_DUMP
+#define BUF_DUMP(buf, len) uip_debug_buf_dump(buf, len)
+#else
+#define BUF_DUMP(buf, len)
+#endif
+
+#endif

--- a/module_xtcp/src/xtcp_uip6/contiki/net/uip-ds6-nbr.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/uip-ds6-nbr.c
@@ -1,0 +1,299 @@
+/**
+ * \addtogroup uip6
+ * @{
+ */
+
+/*
+ * Copyright (c) 2013, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *
+ */
+
+/**
+ * \file
+ *         IPv6 Neighbor cache (link-layer/IPv6 address mapping)
+ * \author Mathilde Durvy <mdurvy@cisco.com>
+ * \author Julien Abeille <jabeille@cisco.com>
+ * \author Simon Duquennoy <simonduq@sics.se>
+ *
+ */
+
+#include <string.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include "lib/list.h"
+#include "net/rime/rimeaddr.h"
+#include "net/packetbuf.h"
+#include "net/uip-ds6-nbr.h"
+#include "nbr-table.h"
+
+#define DEBUG DEBUG_NONE
+#include "net/uip-debug.h"
+
+#ifdef UIP_CONF_DS6_NEIGHBOR_STATE_CHANGED
+#define NEIGHBOR_STATE_CHANGED(n) UIP_CONF_DS6_NEIGHBOR_STATE_CHANGED(n)
+void NEIGHBOR_STATE_CHANGED(uip_ds6_nbr_t *n);
+#else
+#define NEIGHBOR_STATE_CHANGED(n)
+#endif /* UIP_DS6_CONF_NEIGHBOR_STATE_CHANGED */
+
+#ifdef UIP_CONF_DS6_LINK_NEIGHBOR_CALLBACK
+#define LINK_NEIGHBOR_CALLBACK(addr, status, numtx) UIP_CONF_DS6_LINK_NEIGHBOR_CALLBACK(addr, status, numtx)
+void LINK_NEIGHBOR_CALLBACK(const rimeaddr_t *addr, int status, int numtx);
+#else
+#define LINK_NEIGHBOR_CALLBACK(addr, status, numtx)
+#endif /* UIP_CONF_DS6_LINK_NEIGHBOR_CALLBACK */
+
+NBR_TABLE_GLOBAL(uip_ds6_nbr_t, ds6_neighbors);
+
+/*---------------------------------------------------------------------------*/
+void
+uip_ds6_neighbors_init(void)
+{
+  nbr_table_register(ds6_neighbors, (nbr_table_callback *)uip_ds6_nbr_rm);
+}
+/*---------------------------------------------------------------------------*/
+uip_ds6_nbr_t *
+uip_ds6_nbr_add(uip_ipaddr_t *ipaddr, uip_lladdr_t *lladdr,
+                uint8_t isrouter, uint8_t state)
+{
+  uip_ds6_nbr_t *nbr = nbr_table_add_lladdr(ds6_neighbors, (rimeaddr_t*)lladdr);
+  if(nbr) {
+    uip_ipaddr_copy(&nbr->ipaddr, ipaddr);
+    nbr->isrouter = isrouter;
+    nbr->state = state;
+  #if UIP_CONF_IPV6_QUEUE_PKT
+    uip_packetqueue_new(&nbr->packethandle);
+  #endif /* UIP_CONF_IPV6_QUEUE_PKT */
+    /* timers are set separately, for now we put them in expired state */
+    stimer_set(&nbr->reachable, 0);
+    stimer_set(&nbr->sendns, 0);
+    nbr->nscount = 0;
+    PRINTF("Adding neighbor with ip addr ");
+    PRINT6ADDR(ipaddr);
+    PRINTF(" link addr ");
+    PRINTLLADDR(lladdr);
+    PRINTF(" state %u\n", state);
+    NEIGHBOR_STATE_CHANGED(nbr);
+    return nbr;
+  } else {
+    PRINTF("uip_ds6_nbr_add drop ip addr ");
+    PRINT6ADDR(ipaddr);
+    PRINTF(" link addr (%p) ", lladdr);
+    PRINTLLADDR(lladdr);
+    PRINTF(" state %u\n", state);
+    return NULL;
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+void
+uip_ds6_nbr_rm(uip_ds6_nbr_t *nbr)
+{
+  if(nbr != NULL) {
+#if UIP_CONF_IPV6_QUEUE_PKT
+    uip_packetqueue_free(&nbr->packethandle);
+#endif /* UIP_CONF_IPV6_QUEUE_PKT */
+    NEIGHBOR_STATE_CHANGED(nbr);
+    nbr_table_remove(ds6_neighbors, nbr);
+  }
+  return;
+}
+
+/*---------------------------------------------------------------------------*/
+uip_ipaddr_t *
+uip_ds6_nbr_get_ipaddr(uip_ds6_nbr_t *nbr)
+{
+  return (nbr != NULL) ? &nbr->ipaddr : NULL;
+}
+
+/*---------------------------------------------------------------------------*/
+uip_lladdr_t *
+uip_ds6_nbr_get_ll(uip_ds6_nbr_t *nbr)
+{
+  return (uip_lladdr_t *)nbr_table_get_lladdr(ds6_neighbors, nbr);
+}
+/*---------------------------------------------------------------------------*/
+int
+uip_ds6_nbr_num(void)
+{
+  uip_ds6_nbr_t *nbr;
+  int num;
+
+  num = 0;
+  for(nbr = nbr_table_head(ds6_neighbors);
+      nbr != NULL;
+      nbr = nbr_table_next(ds6_neighbors, nbr)) {
+    num++;
+  }
+  return num;
+}
+/*---------------------------------------------------------------------------*/
+uip_ds6_nbr_t *
+uip_ds6_nbr_lookup(uip_ipaddr_t *ipaddr)
+{
+  uip_ds6_nbr_t *nbr = nbr_table_head(ds6_neighbors);
+  if(ipaddr != NULL) {
+    while(nbr != NULL) {
+      if(uip_ipaddr_cmp(&nbr->ipaddr, ipaddr)) {
+        return nbr;
+      }
+      nbr = nbr_table_next(ds6_neighbors, nbr);
+    }
+  }
+  return NULL;
+}
+/*---------------------------------------------------------------------------*/
+uip_ds6_nbr_t *
+uip_ds6_nbr_ll_lookup(uip_lladdr_t *lladdr)
+{
+  return nbr_table_get_from_lladdr(ds6_neighbors, (rimeaddr_t*)lladdr);
+}
+
+/*---------------------------------------------------------------------------*/
+uip_ipaddr_t *
+uip_ds6_nbr_ipaddr_from_lladdr(uip_lladdr_t *lladdr)
+{
+  uip_ds6_nbr_t *nbr = uip_ds6_nbr_ll_lookup(lladdr);
+  return nbr ? &nbr->ipaddr : NULL;
+}
+
+/*---------------------------------------------------------------------------*/
+uip_lladdr_t *
+uip_ds6_nbr_lladdr_from_ipaddr(uip_ipaddr_t *ipaddr)
+{
+  uip_ds6_nbr_t *nbr = uip_ds6_nbr_lookup(ipaddr);
+  return nbr ? uip_ds6_nbr_get_ll(nbr) : NULL;
+}
+/*---------------------------------------------------------------------------*/
+void
+uip_ds6_link_neighbor_callback(int status, int numtx)
+{
+  const rimeaddr_t *dest = packetbuf_addr(PACKETBUF_ADDR_RECEIVER);
+  if(rimeaddr_cmp(dest, &rimeaddr_null)) {
+    return;
+  }
+
+  LINK_NEIGHBOR_CALLBACK(dest, status, numtx);
+
+#if UIP_DS6_LL_NUD
+  if(status == MAC_TX_OK) {
+    uip_ds6_nbr_t *nbr;
+    nbr = uip_ds6_nbr_ll_lookup((uip_lladdr_t *)dest);
+    if(nbr != NULL &&
+        (nbr->state == NBR_STALE || nbr->state == NBR_DELAY ||
+         nbr->state == NBR_PROBE)) {
+      nbr->state = NBR_REACHABLE;
+      stimer_set(&nbr->reachable, UIP_ND6_REACHABLE_TIME / 1000);
+      PRINTF("uip-ds6-neighbor : received a link layer ACK : ");
+      PRINTLLADDR((uip_lladdr_t *)dest);
+      PRINTF(" is reachable.\n");
+    }
+  }
+#endif /* UIP_DS6_LL_NUD */
+
+}
+/*---------------------------------------------------------------------------*/
+void
+uip_ds6_neighbor_periodic(void)
+{
+  /* Periodic processing on neighbors */
+  uip_ds6_nbr_t *nbr = nbr_table_head(ds6_neighbors);
+  while(nbr != NULL) {
+    switch(nbr->state) {
+    case NBR_REACHABLE:
+      if(stimer_expired(&nbr->reachable)) {
+        PRINTF("REACHABLE: moving to STALE (");
+        PRINT6ADDR(&nbr->ipaddr);
+        PRINTF(")\n");
+        nbr->state = NBR_STALE;
+      }
+      break;
+#if UIP_ND6_SEND_NA
+    case NBR_INCOMPLETE:
+      if(nbr->nscount >= UIP_ND6_MAX_MULTICAST_SOLICIT) {
+        uip_ds6_nbr_rm(nbr);
+      } else if(stimer_expired(&nbr->sendns) && (uip_len == 0)) {
+        nbr->nscount++;
+        PRINTF("NBR_INCOMPLETE: NS %u\n", nbr->nscount);
+        uip_nd6_ns_output(NULL, NULL, &nbr->ipaddr);
+        stimer_set(&nbr->sendns, uip_ds6_if.retrans_timer / 1000);
+      }
+      break;
+    case NBR_DELAY:
+      if(stimer_expired(&nbr->reachable)) {
+        nbr->state = NBR_PROBE;
+        nbr->nscount = 0;
+        PRINTF("DELAY: moving to PROBE\n");
+        stimer_set(&nbr->sendns, 0);
+      }
+      break;
+    case NBR_PROBE:
+      if(nbr->nscount >= UIP_ND6_MAX_UNICAST_SOLICIT) {
+        uip_ds6_defrt_t *locdefrt;
+        PRINTF("PROBE END\n");
+        if((locdefrt = uip_ds6_defrt_lookup(&nbr->ipaddr)) != NULL) {
+          if (!locdefrt->isinfinite) {
+            uip_ds6_defrt_rm(locdefrt);
+          }
+        }
+        uip_ds6_nbr_rm(nbr);
+      } else if(stimer_expired(&nbr->sendns) && (uip_len == 0)) {
+        nbr->nscount++;
+        PRINTF("PROBE: NS %u\n", nbr->nscount);
+        uip_nd6_ns_output(NULL, &nbr->ipaddr, &nbr->ipaddr);
+        stimer_set(&nbr->sendns, uip_ds6_if.retrans_timer / 1000);
+      }
+      break;
+#endif /* UIP_ND6_SEND_NA */
+    default:
+      break;
+    }
+    nbr = nbr_table_next(ds6_neighbors, nbr);
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+uip_ds6_nbr_t *
+uip_ds6_get_least_lifetime_neighbor(void)
+{
+  uip_ds6_nbr_t *nbr = nbr_table_head(ds6_neighbors);
+  uip_ds6_nbr_t *nbr_expiring = NULL;
+  while(nbr != NULL) {
+    if(nbr_expiring != NULL) {
+      clock_time_t curr = stimer_remaining(&nbr->reachable);
+      if(curr < stimer_remaining(&nbr->reachable)) {
+        nbr_expiring = nbr;
+      }
+    } else {
+      nbr_expiring = nbr;
+    }
+    nbr = nbr_table_next(ds6_neighbors, nbr);
+  }
+  return nbr_expiring;
+}

--- a/module_xtcp/src/xtcp_uip6/contiki/net/uip-ds6-nbr.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/uip-ds6-nbr.h
@@ -1,0 +1,110 @@
+/**
+ * \addtogroup uip6
+ * @{
+ */
+
+/*
+ * Copyright (c) 2013, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *
+ */
+
+/**
+ * \file
+ *         IPv6 Neighbor cache (link-layer/IPv6 address mapping)
+ * \author Mathilde Durvy <mdurvy@cisco.com>
+ * \author Julien Abeille <jabeille@cisco.com>
+ * \author Simon Duquennoy <simonduq@sics.se>
+ *
+ */
+
+#ifndef __UIP_DS6_NEIGHBOR_H__
+#define __UIP_DS6_NEIGHBOR_H__
+
+#include "net/uip.h"
+#include "net/nbr-table.h"
+#include "sys/stimer.h"
+#include "net/uip-ds6.h"
+#include "net/nbr-table.h"
+
+#if UIP_CONF_IPV6_QUEUE_PKT
+#include "net/uip-packetqueue.h"
+#endif                          /*UIP_CONF_QUEUE_PKT */
+
+/*--------------------------------------------------*/
+/** \brief Possible states for the nbr cache entries */
+#define  NBR_INCOMPLETE 0
+#define  NBR_REACHABLE 1
+#define  NBR_STALE 2
+#define  NBR_DELAY 3
+#define  NBR_PROBE 4
+
+NBR_TABLE_DECLARE(ds6_neighbors);
+
+/** \brief An entry in the nbr cache */
+typedef struct uip_ds6_nbr {
+  uip_ipaddr_t ipaddr;
+  struct stimer reachable;
+  struct stimer sendns;
+  uint8_t nscount;
+  uint8_t isrouter;
+  uint8_t state;
+#if UIP_CONF_IPV6_QUEUE_PKT
+  struct uip_packetqueue_handle packethandle;
+#define UIP_DS6_NBR_PACKET_LIFETIME CLOCK_SECOND * 4
+#endif                          /*UIP_CONF_QUEUE_PKT */
+} uip_ds6_nbr_t;
+
+void uip_ds6_neighbors_init(void);
+
+/** \brief Neighbor Cache basic routines */
+uip_ds6_nbr_t *uip_ds6_nbr_add(uip_ipaddr_t *ipaddr, uip_lladdr_t *lladdr,
+                               uint8_t isrouter, uint8_t state);
+void uip_ds6_nbr_rm(uip_ds6_nbr_t *nbr);
+uip_lladdr_t *uip_ds6_nbr_get_ll(uip_ds6_nbr_t *nbr);
+uip_ipaddr_t *uip_ds6_nbr_get_ipaddr(uip_ds6_nbr_t *nbr);
+uip_ds6_nbr_t *uip_ds6_nbr_lookup(uip_ipaddr_t *ipaddr);
+uip_ds6_nbr_t *uip_ds6_nbr_ll_lookup(uip_lladdr_t *lladdr);
+uip_ipaddr_t *uip_ds6_nbr_ipaddr_from_lladdr(uip_lladdr_t *lladdr);
+uip_lladdr_t *uip_ds6_nbr_lladdr_from_ipaddr(uip_ipaddr_t *ipaddr);
+void uip_ds6_link_neighbor_callback(int status, int numtx);
+void uip_ds6_neighbor_periodic(void);
+int uip_ds6_nbr_num(void);
+
+/**
+ * \brief
+ *     This searches inside the neighbor table for the neighbor that is about to
+ *     expire the next.
+ *
+ * \return
+ *     A reference to the neighbor about to expire the next or NULL if
+ *     table is empty.
+ */
+uip_ds6_nbr_t *uip_ds6_get_least_lifetime_neighbor(void);
+
+#endif /* __UIP_DS6_NEIGHBOR_H__ */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/uip-ds6-route.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/uip-ds6-route.c
@@ -1,0 +1,594 @@
+/*
+ * Copyright (c) 2012, Thingsquare, http://www.thingsquare.com/.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#include "net/uip-ds6.h"
+#include "net/uip.h"
+
+#include "lib/list.h"
+#include "lib/memb.h"
+#include "net/nbr-table.h"
+
+#if UIP_CONF_IPV6
+
+#include <string.h>
+
+/* The nbr_routes holds a neighbor table to be able to maintain
+   information about what routes go through what neighbor. This
+   neighbor table is registered with the central nbr-table repository
+   so that it will be maintained along with the rest of the neighbor
+   tables in the system. */
+NBR_TABLE(struct uip_ds6_route_neighbor_routes, nbr_routes);
+
+/* Each route is repressented by a uip_ds6_route_t structure and
+   memory for each route is allocated from the routememb memory
+   block. These routes are maintained on lists of route entries that
+   are attached to each neighbor, via the nbr_routes neighbor
+   table. */
+MEMB(routememb, uip_ds6_route_t, UIP_DS6_ROUTE_NB);
+
+/* Default routes are held on the defaultrouterlist and their
+   structures are allocated from the defaultroutermemb memory block.*/
+LIST(defaultrouterlist);
+MEMB(defaultroutermemb, uip_ds6_defrt_t, UIP_DS6_DEFRT_NB);
+
+#if UIP_DS6_NOTIFICATIONS
+LIST(notificationlist);
+#endif
+
+static int num_routes = 0;
+
+#undef DEBUG
+#define DEBUG DEBUG_NONE
+#include "net/uip-debug.h"
+
+static void rm_routelist_callback(nbr_table_item_t *ptr);
+/*---------------------------------------------------------------------------*/
+#if DEBUG != DEBUG_NONE
+static void
+assert_nbr_routes_list_sane(void)
+{
+  uip_ds6_route_t *r;
+  int count;
+
+  /* Check if the route list has an infinite loop. */
+  for(r = uip_ds6_route_head(),
+        count = 0;
+      r != NULL &&
+        count < UIP_DS6_ROUTE_NB;
+      r = uip_ds6_route_next(r),
+        count++);
+
+  if(count >= UIP_DS6_ROUTE_NB) {
+    printf("uip-ds6-route.c: assert_nbr_routes_list_sane route list is in infinite loop\n");
+  }
+
+  /* Make sure that the route list has as many entries as the
+     num_routes vairable. */
+  if(count < num_routes) {
+    printf("uip-ds6-route.c: assert_nbr_routes_list_sane too few entries on route list: should be %d, is %d, max %d\n",
+           num_routes, count, UIP_CONF_MAX_ROUTES);
+  }
+}
+#endif /* DEBUG != DEBUG_NONE */
+/*---------------------------------------------------------------------------*/
+#if UIP_DS6_NOTIFICATIONS
+#pragma stackfunction 50	//TODO: CHSC find out, how mutch stack is realy used
+static void
+call_route_callback(int event, uip_ipaddr_t *route,
+		    uip_ipaddr_t *nexthop)
+{
+  int num;
+  struct uip_ds6_notification *n;
+  for(n = list_head(notificationlist);
+      n != NULL;
+      n = list_item_next(n)) {
+    if(event == UIP_DS6_NOTIFICATION_DEFRT_ADD ||
+       event == UIP_DS6_NOTIFICATION_DEFRT_RM) {
+      num = list_length(defaultrouterlist);
+    } else {
+      num = num_routes;
+    }
+    n->callback(event, route, nexthop, num);
+  }
+}
+/*---------------------------------------------------------------------------*/
+void
+uip_ds6_notification_add(struct uip_ds6_notification *n,
+			 uip_ds6_notification_callback c)
+{
+  if(n != NULL && c != NULL) {
+    n->callback = c;
+    list_add(notificationlist, n);
+  }
+}
+/*---------------------------------------------------------------------------*/
+void
+uip_ds6_notification_rm(struct uip_ds6_notification *n)
+{
+  list_remove(notificationlist, n);
+}
+#endif
+/*---------------------------------------------------------------------------*/
+void
+uip_ds6_route_init(void)
+{
+  memb_init(&routememb);
+  nbr_table_register(nbr_routes,
+                     (nbr_table_callback *)rm_routelist_callback);
+
+  memb_init(&defaultroutermemb);
+  list_init(defaultrouterlist);
+
+#if UIP_DS6_NOTIFICATIONS
+  list_init(notificationlist);
+#endif
+}
+/*---------------------------------------------------------------------------*/
+static uip_lladdr_t *
+uip_ds6_route_nexthop_lladdr(uip_ds6_route_t *route)
+{
+  if(route != NULL) {
+    return (uip_lladdr_t *)nbr_table_get_lladdr(nbr_routes, route->routes);
+  } else {
+    return NULL;
+  }
+}
+/*---------------------------------------------------------------------------*/
+uip_ipaddr_t *
+uip_ds6_route_nexthop(uip_ds6_route_t *route)
+{
+  if(route != NULL) {
+    return uip_ds6_nbr_ipaddr_from_lladdr(uip_ds6_route_nexthop_lladdr(route));
+  } else {
+    return NULL;
+  }
+}
+/*---------------------------------------------------------------------------*/
+uip_ds6_route_t *
+uip_ds6_route_head(void)
+{
+  struct uip_ds6_route_neighbor_routes *routes;
+
+  routes = (struct uip_ds6_route_neighbor_routes *)nbr_table_head(nbr_routes);
+  if(routes != NULL) {
+    if(list_head(routes->route_list) == NULL) {
+      PRINTF("uip_ds6_route_head lead_head(nbr_route_list) is NULL\n");
+    }
+    return list_head(routes->route_list);
+  } else {
+    return NULL;
+  }
+}
+/*---------------------------------------------------------------------------*/
+uip_ds6_route_t *
+uip_ds6_route_next(uip_ds6_route_t *r)
+{
+  if(r != NULL) {
+    uip_ds6_route_t *n = list_item_next(r);
+    if(n != NULL) {
+      return n;
+    } else {
+      struct uip_ds6_route_neighbor_routes *routes;
+      routes = (struct uip_ds6_route_neighbor_routes *)
+        nbr_table_next(nbr_routes, r->routes);
+      if(routes != NULL) {
+        return list_head(routes->route_list);
+      }
+    }
+  }
+
+  return NULL;
+}
+/*---------------------------------------------------------------------------*/
+int
+uip_ds6_route_num_routes(void)
+{
+  return num_routes;
+}
+/*---------------------------------------------------------------------------*/
+uip_ds6_route_t *
+uip_ds6_route_lookup(uip_ipaddr_t *addr)
+{
+  uip_ds6_route_t *r;
+  uip_ds6_route_t *found_route;
+  uint8_t longestmatch;
+
+  PRINTF("uip-ds6-route: Looking up route for ");
+  PRINT6ADDR(addr);
+  PRINTF("\n");
+
+
+  found_route = NULL;
+  longestmatch = 0;
+  for(r = uip_ds6_route_head();
+      r != NULL;
+      r = uip_ds6_route_next(r)) {
+    if(r->length >= longestmatch &&
+       uip_ipaddr_prefixcmp(addr, &r->ipaddr, r->length)) {
+      longestmatch = r->length;
+      found_route = r;
+    }
+  }
+
+  if(found_route != NULL) {
+    PRINTF("uip-ds6-route: Found route: ");
+    PRINT6ADDR(addr);
+    PRINTF(" via ");
+    PRINT6ADDR(uip_ds6_route_nexthop(found_route));
+    PRINTF("\n");
+  } else {
+    PRINTF("uip-ds6-route: No route found\n");
+  }
+
+  return found_route;
+}
+/*---------------------------------------------------------------------------*/
+uip_ds6_route_t *
+uip_ds6_route_add(uip_ipaddr_t *ipaddr, uint8_t length,
+		  uip_ipaddr_t *nexthop)
+{
+  uip_ds6_route_t *r;
+
+#if DEBUG != DEBUG_NONE
+  assert_nbr_routes_list_sane();
+#endif /* DEBUG != DEBUG_NONE */
+
+  /* Get link-layer address of next hop, make sure it is in neighbor table */
+  uip_lladdr_t *nexthop_lladdr = uip_ds6_nbr_lladdr_from_ipaddr(nexthop);
+  if(nexthop_lladdr == NULL) {
+    PRINTF("uip_ds6_route_add: neighbor link-local address unknown ");
+    PRINT6ADDR(ipaddr);
+    PRINTF("\n");
+    return NULL;
+  }
+
+  /* First make sure that we don't add a route twice. If we find an
+     existing route for our destination, we'll just update the old
+     one. */
+  r = uip_ds6_route_lookup(ipaddr);
+  if(r != NULL) {
+    PRINTF("uip_ds6_route_add: old route already found, updating this one instead: ");
+    PRINT6ADDR(ipaddr);
+    PRINTF("\n");
+  } else {
+    struct uip_ds6_route_neighbor_routes *routes;
+    /* If there is no routing entry, create one */
+
+    /* Every neighbor on our neighbor table holds a struct
+       uip_ds6_route_neighbor_routes which holds a list of routes that
+       go through the neighbor. We add our route entry to this list.
+
+       We first check to see if we already have this neighbor in our
+       nbr_route table. If so, the neighbor already has a route entry
+       list.
+    */
+    routes = nbr_table_get_from_lladdr(nbr_routes,
+                                       (rimeaddr_t *)nexthop_lladdr);
+
+    if(routes == NULL) {
+      /* If the neighbor did not have an entry in our neighbor table,
+         we create one. The nbr_table_add_lladdr() function returns a
+         pointer to a pointer that we may use for our own purposes. We
+         initialize this pointer with the list of routing entries that
+         are attached to this neighbor. */
+      routes = nbr_table_add_lladdr(nbr_routes,
+                                    (rimeaddr_t *)nexthop_lladdr);
+      if(routes == NULL) {
+        PRINTF("uip_ds6_route_add: could not allocate a neighbor table entri for new route to ");
+        PRINT6ADDR(ipaddr);
+        PRINTF(", dropping it\n");
+        return NULL;
+      }
+      LIST_STRUCT_INIT(routes, route_list);
+    }
+
+    /* Allocate a routing entry and populate it. */
+    r = memb_alloc(&routememb);
+
+    if(r == NULL) {
+      PRINTF("uip_ds6_route_add: could not allocate memory for new route to ");
+      PRINT6ADDR(ipaddr);
+      PRINTF(", dropping it\n");
+      return NULL;
+    }
+
+
+    /* Add the route to this neighbor */
+    list_add(routes->route_list, r);
+    num_routes++;
+
+    PRINTF("uip_ds6_route_add num %d\n", num_routes);
+    r->routes = routes;
+  }
+
+  uip_ipaddr_copy(&(r->ipaddr), ipaddr);
+  r->length = length;
+
+#ifdef UIP_DS6_ROUTE_STATE_TYPE
+  memset(&r->state, 0, sizeof(UIP_DS6_ROUTE_STATE_TYPE));
+#endif
+
+  PRINTF("uip_ds6_route_add: adding route: ");
+  PRINT6ADDR(ipaddr);
+  PRINTF(" via ");
+  PRINT6ADDR(nexthop);
+  PRINTF("\n");
+  ANNOTATE("#L %u 1;blue\n", nexthop->u8[sizeof(uip_ipaddr_t) - 1]);
+
+#if UIP_DS6_NOTIFICATIONS
+  call_route_callback(UIP_DS6_NOTIFICATION_ROUTE_ADD, ipaddr, nexthop);
+#endif
+
+#if DEBUG != DEBUG_NONE
+  assert_nbr_routes_list_sane();
+#endif /* DEBUG != DEBUG_NONE */
+  return r;
+}
+
+/*---------------------------------------------------------------------------*/
+void
+uip_ds6_route_rm(uip_ds6_route_t *route)
+{
+#if DEBUG != DEBUG_NONE
+  assert_nbr_routes_list_sane();
+#endif /* DEBUG != DEBUG_NONE */
+  if(route != NULL && route->routes != NULL) {
+
+    PRINTF("uip_ds6_route_rm: removing route: ");
+    PRINT6ADDR(&route->ipaddr);
+    PRINTF("\n");
+
+    list_remove(route->routes->route_list, route);
+    if(list_head(route->routes->route_list) == NULL) {
+      /* If this was the only route using this neighbor, remove the
+         neibhor from the table */
+      PRINTF("uip_ds6_route_rm: removing neighbor too\n");
+      nbr_table_remove(nbr_routes, route->routes->route_list);
+    }
+    memb_free(&routememb, route);
+
+    num_routes--;
+
+    PRINTF("uip_ds6_route_rm num %d\n", num_routes);
+
+#if UIP_DS6_NOTIFICATIONS
+    call_route_callback(UIP_DS6_NOTIFICATION_ROUTE_RM,
+        &route->ipaddr, uip_ds6_route_nexthop(route));
+#endif
+#if 0 //(DEBUG & DEBUG_ANNOTATE) == DEBUG_ANNOTATE
+    /* we need to check if this was the last route towards "nexthop" */
+    /* if so - remove that link (annotation) */
+    uip_ds6_route_t *r;
+    for(r = uip_ds6_route_head();
+        r != NULL;
+        r = uip_ds6_route_next(r)) {
+      uip_ipaddr_t *nextr, *nextroute;
+      nextr = uip_ds6_route_nexthop(r);
+      nextroute = uip_ds6_route_nexthop(route);
+      if(nextr != NULL &&
+         nextroute != NULL &&
+         uip_ipaddr_cmp(nextr, nextroute)) {
+        /* we found another link using the specific nexthop, so keep the #L */
+        return;
+      }
+    }
+    ANNOTATE("#L %u 0\n", uip_ds6_route_nexthop(route)->u8[sizeof(uip_ipaddr_t) - 1]);
+#endif
+  }
+
+#if DEBUG != DEBUG_NONE
+  assert_nbr_routes_list_sane();
+#endif /* DEBUG != DEBUG_NONE */
+  return;
+}
+/*---------------------------------------------------------------------------*/
+static void
+rm_routelist(struct uip_ds6_route_neighbor_routes *routes)
+{
+#if DEBUG != DEBUG_NONE
+  assert_nbr_routes_list_sane();
+#endif /* DEBUG != DEBUG_NONE */
+  PRINTF("uip_ds6_route_rm_routelist\n");
+  if(routes != NULL && routes->route_list != NULL) {
+    uip_ds6_route_t *r;
+    r = list_head(routes->route_list);
+    while(r != NULL) {
+      uip_ds6_route_rm(r);
+      r = list_head(routes->route_list);
+    }
+    nbr_table_remove(nbr_routes, routes);
+  }
+#if DEBUG != DEBUG_NONE
+  assert_nbr_routes_list_sane();
+#endif /* DEBUG != DEBUG_NONE */
+}
+/*---------------------------------------------------------------------------*/
+static void
+rm_routelist_callback(nbr_table_item_t *ptr)
+{
+  rm_routelist((struct uip_ds6_route_neighbor_routes *)ptr);
+}
+/*---------------------------------------------------------------------------*/
+void
+uip_ds6_route_rm_by_nexthop(uip_ipaddr_t *nexthop)
+{
+  /* Get routing entry list of this neighbor */
+  uip_lladdr_t *nexthop_lladdr;
+  struct uip_ds6_route_neighbor_routes *routes;
+
+  nexthop_lladdr = uip_ds6_nbr_lladdr_from_ipaddr(nexthop);
+  routes = nbr_table_get_from_lladdr(nbr_routes,
+                                     (rimeaddr_t *)nexthop_lladdr);
+  rm_routelist(routes);
+}
+/*---------------------------------------------------------------------------*/
+uip_ds6_defrt_t *
+uip_ds6_defrt_add(uip_ipaddr_t *ipaddr, unsigned long interval)
+{
+  uip_ds6_defrt_t *d;
+
+#if DEBUG != DEBUG_NONE
+  assert_nbr_routes_list_sane();
+#endif /* DEBUG != DEBUG_NONE */
+
+  PRINTF("uip_ds6_defrt_add\n");
+  d = uip_ds6_defrt_lookup(ipaddr);
+  if(d == NULL) {
+    d = memb_alloc(&defaultroutermemb);
+    if(d == NULL) {
+      PRINTF("uip_ds6_defrt_add: could not add default route to ");
+      PRINT6ADDR(ipaddr);
+      PRINTF(", out of memory\n");
+      return NULL;
+    } else {
+      PRINTF("uip_ds6_defrt_add: adding default route to ");
+      PRINT6ADDR(ipaddr);
+      PRINTF("\n");
+    }
+
+    list_push(defaultrouterlist, d);
+  }
+
+  uip_ipaddr_copy(&d->ipaddr, ipaddr);
+  if(interval != 0) {
+    stimer_set(&d->lifetime, interval);
+    d->isinfinite = 0;
+  } else {
+    d->isinfinite = 1;
+  }
+
+  ANNOTATE("#L %u 1\n", ipaddr->u8[sizeof(uip_ipaddr_t) - 1]);
+
+#if UIP_DS6_NOTIFICATIONS
+  call_route_callback(UIP_DS6_NOTIFICATION_DEFRT_ADD, ipaddr, ipaddr);
+#endif
+
+#if DEBUG != DEBUG_NONE
+  assert_nbr_routes_list_sane();
+#endif /* DEBUG != DEBUG_NONE */
+
+  return d;
+}
+/*---------------------------------------------------------------------------*/
+void
+uip_ds6_defrt_rm(uip_ds6_defrt_t *defrt)
+{
+  uip_ds6_defrt_t *d;
+
+#if DEBUG != DEBUG_NONE
+  assert_nbr_routes_list_sane();
+#endif /* DEBUG != DEBUG_NONE */
+
+  /* Make sure that the defrt is in the list before we remove it. */
+  for(d = list_head(defaultrouterlist);
+      d != NULL;
+      d = list_item_next(d)) {
+    if(d == defrt) {
+      PRINTF("Removing default route\n");
+      list_remove(defaultrouterlist, defrt);
+      memb_free(&defaultroutermemb, defrt);
+      ANNOTATE("#L %u 0\n", defrt->ipaddr.u8[sizeof(uip_ipaddr_t) - 1]);
+#if UIP_DS6_NOTIFICATIONS
+      call_route_callback(UIP_DS6_NOTIFICATION_DEFRT_RM,
+			  &defrt->ipaddr, &defrt->ipaddr);
+#endif
+      return;
+    }
+  }
+#if DEBUG != DEBUG_NONE
+  assert_nbr_routes_list_sane();
+#endif /* DEBUG != DEBUG_NONE */
+
+}
+/*---------------------------------------------------------------------------*/
+uip_ds6_defrt_t *
+uip_ds6_defrt_lookup(uip_ipaddr_t *ipaddr)
+{
+  uip_ds6_defrt_t *d;
+  for(d = list_head(defaultrouterlist);
+      d != NULL;
+      d = list_item_next(d)) {
+    if(uip_ipaddr_cmp(&d->ipaddr, ipaddr)) {
+      return d;
+    }
+  }
+  return NULL;
+}
+/*---------------------------------------------------------------------------*/
+uip_ipaddr_t *
+uip_ds6_defrt_choose(void)
+{
+  uip_ds6_defrt_t *d;
+  uip_ds6_nbr_t *bestnbr;
+  uip_ipaddr_t *addr;
+
+  addr = NULL;
+  for(d = list_head(defaultrouterlist);
+      d != NULL;
+      d = list_item_next(d)) {
+    PRINTF("Defrt, IP address ");
+    PRINT6ADDR(&d->ipaddr);
+    PRINTF("\n");
+    bestnbr = uip_ds6_nbr_lookup(&d->ipaddr);
+    if(bestnbr != NULL && bestnbr->state != NBR_INCOMPLETE) {
+      PRINTF("Defrt found, IP address ");
+      PRINT6ADDR(&d->ipaddr);
+      PRINTF("\n");
+      return &d->ipaddr;
+    } else {
+      addr = &d->ipaddr;
+      PRINTF("Defrt INCOMPLETE found, IP address ");
+      PRINT6ADDR(&d->ipaddr);
+      PRINTF("\n");
+    }
+  }
+  return addr;
+}
+/*---------------------------------------------------------------------------*/
+void
+uip_ds6_defrt_periodic(void)
+{
+  uip_ds6_defrt_t *d;
+  d = list_head(defaultrouterlist);
+  while(d != NULL) {
+    if(!d->isinfinite &&
+       stimer_expired(&d->lifetime)) {
+      PRINTF("uip_ds6_defrt_periodic: defrt lifetime expired\n");
+      uip_ds6_defrt_rm(d);
+      d = list_head(defaultrouterlist);
+    } else {
+      d = list_item_next(d);
+    }
+  }
+}
+/*---------------------------------------------------------------------------*/
+
+#endif /* UIP_CONF_IPV6 */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/uip-ds6-route.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/uip-ds6-route.h
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2012, Thingsquare, http://www.thingsquare.com/.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#ifndef UIP_DS6_ROUTE_H
+#define UIP_DS6_ROUTE_H
+
+#include "lib/list.h"
+
+void uip_ds6_route_init(void);
+
+#ifndef UIP_CONF_UIP_DS6_NOTIFICATIONS
+#define UIP_DS6_NOTIFICATIONS 1
+#else
+#define UIP_DS6_NOTIFICATIONS UIP_CONF_UIP_DS6_NOTIFICATIONS
+#endif
+
+#if UIP_DS6_NOTIFICATIONS
+/* Event constants for the uip-ds6 route notification interface. The
+   notification interface allows for a user program to be notified via
+   a callback when a route has been added or removed and when the
+   system has added or removed a default route. */
+#define UIP_DS6_NOTIFICATION_DEFRT_ADD 0
+#define UIP_DS6_NOTIFICATION_DEFRT_RM  1
+#define UIP_DS6_NOTIFICATION_ROUTE_ADD 2
+#define UIP_DS6_NOTIFICATION_ROUTE_RM  3
+
+typedef void (* uip_ds6_notification_callback)(int event,
+					       uip_ipaddr_t *route,
+					       uip_ipaddr_t *nexthop,
+					       int num_routes);
+struct uip_ds6_notification {
+  struct uip_ds6_notification *next;
+  uip_ds6_notification_callback callback;
+};
+
+void uip_ds6_notification_add(struct uip_ds6_notification *n,
+			      uip_ds6_notification_callback c);
+
+void uip_ds6_notification_rm(struct uip_ds6_notification *n);
+/*--------------------------------------------------*/
+#endif
+
+/* Routing table */
+#ifndef UIP_CONF_MAX_ROUTES
+#ifdef UIP_CONF_DS6_ROUTE_NBU
+#define UIP_DS6_ROUTE_NB UIP_CONF_DS6_ROUTE_NBU
+#else /* UIP_CONF_DS6_ROUTE_NBU */
+#define UIP_DS6_ROUTE_NB 4
+#endif /* UIP_CONF_DS6_ROUTE_NBU */
+#else /* UIP_CONF_MAX_ROUTES */
+#define UIP_DS6_ROUTE_NB UIP_CONF_MAX_ROUTES
+#endif /* UIP_CONF_MAX_ROUTES */
+
+/** \brief define some additional RPL related route state and
+ *  neighbor callback for RPL - if not a DS6_ROUTE_STATE is already set */
+#ifndef UIP_DS6_ROUTE_STATE_TYPE
+#define UIP_DS6_ROUTE_STATE_TYPE rpl_route_entry_t
+/* Needed for the extended route entry state when using ContikiRPL */
+typedef struct rpl_route_entry {
+  uint32_t lifetime;
+  void *dag;
+  uint8_t learned_from;
+  uint8_t nopath_received;
+} rpl_route_entry_t;
+#endif /* UIP_DS6_ROUTE_STATE_TYPE */
+
+/** \brief The neighbor routes hold a list of routing table entries
+    that are attached to a specific neihbor. */
+struct uip_ds6_route_neighbor_routes {
+  LIST_STRUCT(route_list);
+};
+
+/** \brief An entry in the routing table */
+typedef struct uip_ds6_route {
+  struct uip_ds6_route *next;
+  /* Each route entry belongs to a specific neighbor. That neighbor
+     holds a list of all routing entries that go through it. The
+     routes field point to the uip_ds6_route_neighbor_routes that
+     belong to the neighbor table entry that this routing table entry
+     uses. */
+  struct uip_ds6_route_neighbor_routes *routes;
+  uip_ipaddr_t ipaddr;
+#ifdef UIP_DS6_ROUTE_STATE_TYPE
+  UIP_DS6_ROUTE_STATE_TYPE state;
+#endif
+  uint8_t length;
+} uip_ds6_route_t;
+
+
+
+/** \brief An entry in the default router list */
+typedef struct uip_ds6_defrt {
+  struct uip_ds6_defrt *next;
+  uip_ipaddr_t ipaddr;
+  struct stimer lifetime;
+  uint8_t isinfinite;
+} uip_ds6_defrt_t;
+
+/** \name Default router list basic routines */
+/** @{ */
+uip_ds6_defrt_t *uip_ds6_defrt_add(uip_ipaddr_t *ipaddr,
+                                   unsigned long interval);
+void uip_ds6_defrt_rm(uip_ds6_defrt_t *defrt);
+uip_ds6_defrt_t *uip_ds6_defrt_lookup(uip_ipaddr_t *ipaddr);
+uip_ipaddr_t *uip_ds6_defrt_choose(void);
+
+void uip_ds6_defrt_periodic(void);
+/** @} */
+
+
+/** \name Routing Table basic routines */
+/** @{ */
+uip_ds6_route_t *uip_ds6_route_lookup(uip_ipaddr_t *destipaddr);
+uip_ds6_route_t *uip_ds6_route_add(uip_ipaddr_t *ipaddr, uint8_t length,
+                                   uip_ipaddr_t *next_hop);
+void uip_ds6_route_rm(uip_ds6_route_t *route);
+void uip_ds6_route_rm_by_nexthop(uip_ipaddr_t *nexthop);
+
+uip_ipaddr_t *uip_ds6_route_nexthop(uip_ds6_route_t *);
+int uip_ds6_route_num_routes(void);
+uip_ds6_route_t *uip_ds6_route_head(void);
+uip_ds6_route_t *uip_ds6_route_next(uip_ds6_route_t *);
+
+/** @} */
+
+#endif /* UIP_DS6_ROUTE_H */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/uip-ds6.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/uip-ds6.c
@@ -1,0 +1,702 @@
+/**
+ * \addtogroup uip6
+ * @{
+ */
+
+/**
+ * \file
+ *         IPv6 data structures handling functions.
+ *         Comprises part of the Neighbor discovery (RFC 4861)
+ *         and auto configuration (RFC 4862) state machines.
+ * \author Mathilde Durvy <mdurvy@cisco.com>
+ * \author Julien Abeille <jabeille@cisco.com>
+ */
+/*
+ * Copyright (c) 2006, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+#include <string.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include "lib/random.h"
+#include "net/uip-nd6.h"
+#include "net/uip-ds6.h"
+#include "net/uip-packetqueue.h"
+
+#if UIP_CONF_IPV6
+
+#define DEBUG DEBUG_NONE
+#include "net/uip-debug.h"
+
+struct etimer uip_ds6_timer_periodic;                           /** \brief Timer for maintenance of data structures */
+
+#if UIP_CONF_ROUTER
+struct stimer uip_ds6_timer_ra;                                 /** \brief RA timer, to schedule RA sending */
+#if UIP_ND6_SEND_RA
+static uint8_t racount;                                         /** \brief number of RA already sent */
+static uint16_t rand_time;                                      /** \brief random time value for timers */
+#endif
+#else /* UIP_CONF_ROUTER */
+struct etimer uip_ds6_timer_rs;                                 /** \brief RS timer, to schedule RS sending */
+static uint8_t rscount;                                         /** \brief number of rs already sent */
+#endif /* UIP_CONF_ROUTER */
+
+/** \name "DS6" Data structures */
+/** @{ */
+uip_ds6_netif_t uip_ds6_if;                                       /** \brief The single interface */
+uip_ds6_prefix_t uip_ds6_prefix_list[UIP_DS6_PREFIX_NB];          /** \brief Prefix list */
+
+/* Used by Cooja to enable extraction of addresses from memory.*/
+uint8_t uip_ds6_addr_size;
+uint8_t uip_ds6_netif_addr_list_offset;
+
+/** @} */
+
+/* "full" (as opposed to pointer) ip address used in this file,  */
+static uip_ipaddr_t loc_fipaddr;
+
+/* Pointers used in this file */
+static uip_ds6_addr_t *locaddr;
+static uip_ds6_maddr_t *locmaddr;
+static uip_ds6_aaddr_t *locaaddr;
+static uip_ds6_prefix_t *locprefix;
+
+/*---------------------------------------------------------------------------*/
+void
+uip_ds6_init(void)
+{
+
+  uip_ds6_neighbors_init();
+  uip_ds6_route_init();
+
+  PRINTF("Init of IPv6 data structures\n");
+  PRINTF("%u neighbors\n%u default routers\n%u prefixes\n%u routes\n%u unicast addresses\n%u multicast addresses\n%u anycast addresses\n",
+     NBR_TABLE_MAX_NEIGHBORS, UIP_DS6_DEFRT_NB, UIP_DS6_PREFIX_NB, UIP_DS6_ROUTE_NB,
+     UIP_DS6_ADDR_NB, UIP_DS6_MADDR_NB, UIP_DS6_AADDR_NB);
+  memset(uip_ds6_prefix_list, 0, sizeof(uip_ds6_prefix_list));
+  memset(&uip_ds6_if, 0, sizeof(uip_ds6_if));
+  uip_ds6_addr_size = sizeof(struct uip_ds6_addr);
+  uip_ds6_netif_addr_list_offset = offsetof(struct uip_ds6_netif, addr_list);
+
+  /* Set interface parameters */
+  uip_ds6_if.link_mtu = UIP_LINK_MTU;
+  uip_ds6_if.cur_hop_limit = UIP_TTL;
+  uip_ds6_if.base_reachable_time = UIP_ND6_REACHABLE_TIME;
+  uip_ds6_if.reachable_time = uip_ds6_compute_reachable_time();
+  uip_ds6_if.retrans_timer = UIP_ND6_RETRANS_TIMER;
+  uip_ds6_if.maxdadns = UIP_ND6_DEF_MAXDADNS;
+
+  /* Create link local address, prefix, multicast addresses, anycast addresses */
+  uip_create_linklocal_prefix(&loc_fipaddr);
+#if UIP_CONF_ROUTER
+  uip_ds6_prefix_add(&loc_fipaddr, UIP_DEFAULT_PREFIX_LEN, 0, 0, 0, 0);
+#else /* UIP_CONF_ROUTER */
+  uip_ds6_prefix_add(&loc_fipaddr, UIP_DEFAULT_PREFIX_LEN, 0);
+#endif /* UIP_CONF_ROUTER */
+  uip_ds6_set_addr_iid(&loc_fipaddr, &uip_lladdr);
+  uip_ds6_addr_add(&loc_fipaddr, 0, ADDR_AUTOCONF);
+
+  uip_create_linklocal_allnodes_mcast(&loc_fipaddr);
+  uip_ds6_maddr_add(&loc_fipaddr);
+#if UIP_CONF_ROUTER
+  uip_create_linklocal_allrouters_mcast(&loc_fipaddr);
+  uip_ds6_maddr_add(&loc_fipaddr);
+#if UIP_ND6_SEND_RA
+  stimer_set(&uip_ds6_timer_ra, 2);     /* wait to have a link local IP address */
+#endif /* UIP_ND6_SEND_RA */
+#else /* UIP_CONF_ROUTER */
+  etimer_set(&uip_ds6_timer_rs,
+             random_rand() % (UIP_ND6_MAX_RTR_SOLICITATION_DELAY *
+                              CLOCK_SECOND));
+#endif /* UIP_CONF_ROUTER */
+  etimer_set(&uip_ds6_timer_periodic, UIP_DS6_PERIOD);
+
+  return;
+}
+
+
+/*---------------------------------------------------------------------------*/
+void
+uip_ds6_periodic(void)
+{
+
+  /* Periodic processing on unicast addresses */
+  for(locaddr = uip_ds6_if.addr_list;
+      locaddr < uip_ds6_if.addr_list + UIP_DS6_ADDR_NB; locaddr++) {
+    if(locaddr->isused) {
+      if((!locaddr->isinfinite) && (stimer_expired(&locaddr->vlifetime))) {
+        uip_ds6_addr_rm(locaddr);
+#if UIP_ND6_DEF_MAXDADNS > 0
+      } else if((locaddr->state == ADDR_TENTATIVE)
+                && (locaddr->dadnscount <= uip_ds6_if.maxdadns)
+                && (timer_expired(&locaddr->dadtimer))
+                && (uip_len == 0)) {
+        uip_ds6_dad(locaddr);
+#endif /* UIP_ND6_DEF_MAXDADNS > 0 */
+      }
+    }
+  }
+
+  /* Periodic processing on default routers */
+  uip_ds6_defrt_periodic();
+  /*  for(locdefrt = uip_ds6_defrt_list;
+      locdefrt < uip_ds6_defrt_list + UIP_DS6_DEFRT_NB; locdefrt++) {
+    if((locdefrt->isused) && (!locdefrt->isinfinite) &&
+       (stimer_expired(&(locdefrt->lifetime)))) {
+      uip_ds6_defrt_rm(locdefrt);
+    }
+    }*/
+
+#if !UIP_CONF_ROUTER
+  /* Periodic processing on prefixes */
+  for(locprefix = uip_ds6_prefix_list;
+      locprefix < uip_ds6_prefix_list + UIP_DS6_PREFIX_NB;
+      locprefix++) {
+    if(locprefix->isused && !locprefix->isinfinite
+       && stimer_expired(&(locprefix->vlifetime))) {
+      uip_ds6_prefix_rm(locprefix);
+    }
+  }
+#endif /* !UIP_CONF_ROUTER */
+
+  uip_ds6_neighbor_periodic();
+
+#if UIP_CONF_ROUTER & UIP_ND6_SEND_RA
+  /* Periodic RA sending */
+  if(stimer_expired(&uip_ds6_timer_ra) && (uip_len == 0)) {
+    uip_ds6_send_ra_periodic();
+  }
+#endif /* UIP_CONF_ROUTER & UIP_ND6_SEND_RA */
+  etimer_reset(&uip_ds6_timer_periodic);
+  return;
+}
+
+/*---------------------------------------------------------------------------*/
+uint8_t
+uip_ds6_list_loop(uip_ds6_element_t *list, uint8_t size,
+                  uint16_t elementsize, uip_ipaddr_t *ipaddr,
+                  uint8_t ipaddrlen, uip_ds6_element_t **out_element)
+{
+  uip_ds6_element_t *element;
+
+  *out_element = NULL;
+
+  for(element = list;
+      element <
+      (uip_ds6_element_t *)((uint8_t *)list + (size * elementsize));
+      element = (uip_ds6_element_t *)((uint8_t *)element + elementsize)) {
+    if(element->isused) {
+      if(uip_ipaddr_prefixcmp(&element->ipaddr, ipaddr, ipaddrlen)) {
+        *out_element = element;
+        return FOUND;
+      }
+    } else {
+      *out_element = element;
+    }
+  }
+
+  return *out_element != NULL ? FREESPACE : NOSPACE;
+}
+
+/*---------------------------------------------------------------------------*/
+#if UIP_CONF_ROUTER
+/*---------------------------------------------------------------------------*/
+uip_ds6_prefix_t *
+uip_ds6_prefix_add(uip_ipaddr_t *ipaddr, uint8_t ipaddrlen,
+                   uint8_t advertise, uint8_t flags, unsigned long vtime,
+                   unsigned long ptime)
+{
+  if(uip_ds6_list_loop
+     ((uip_ds6_element_t *)uip_ds6_prefix_list, UIP_DS6_PREFIX_NB,
+      sizeof(uip_ds6_prefix_t), ipaddr, ipaddrlen,
+      (uip_ds6_element_t **)&locprefix) == FREESPACE) {
+    locprefix->isused = 1;
+    uip_ipaddr_copy(&locprefix->ipaddr, ipaddr);
+    locprefix->length = ipaddrlen;
+    locprefix->advertise = advertise;
+    locprefix->l_a_reserved = flags;
+    locprefix->vlifetime = vtime;
+    locprefix->plifetime = ptime;
+    PRINTF("Adding prefix ");
+    PRINT6ADDR(&locprefix->ipaddr);
+    PRINTF("length %u, flags %x, Valid lifetime %lx, Preffered lifetime %lx\n",
+       ipaddrlen, flags, vtime, ptime);
+    return locprefix;
+  } else {
+    PRINTF("No more space in Prefix list\n");
+  }
+  return NULL;
+}
+
+
+#else /* UIP_CONF_ROUTER */
+uip_ds6_prefix_t *
+uip_ds6_prefix_add(uip_ipaddr_t *ipaddr, uint8_t ipaddrlen,
+                   unsigned long interval)
+{
+  if(uip_ds6_list_loop
+     ((uip_ds6_element_t *)uip_ds6_prefix_list, UIP_DS6_PREFIX_NB,
+      sizeof(uip_ds6_prefix_t), ipaddr, ipaddrlen,
+      (uip_ds6_element_t **)&locprefix) == FREESPACE) {
+    locprefix->isused = 1;
+    uip_ipaddr_copy(&locprefix->ipaddr, ipaddr);
+    locprefix->length = ipaddrlen;
+    if(interval != 0) {
+      stimer_set(&(locprefix->vlifetime), interval);
+      locprefix->isinfinite = 0;
+    } else {
+      locprefix->isinfinite = 1;
+    }
+    PRINTF("Adding prefix ");
+    PRINT6ADDR(&locprefix->ipaddr);
+    PRINTF("length %u, vlifetime %lu\n", ipaddrlen, interval);
+  }
+  return NULL;
+}
+#endif /* UIP_CONF_ROUTER */
+
+/*---------------------------------------------------------------------------*/
+void
+uip_ds6_prefix_rm(uip_ds6_prefix_t *prefix)
+{
+  if(prefix != NULL) {
+    prefix->isused = 0;
+  }
+  return;
+}
+/*---------------------------------------------------------------------------*/
+uip_ds6_prefix_t *
+uip_ds6_prefix_lookup(uip_ipaddr_t *ipaddr, uint8_t ipaddrlen)
+{
+  if(uip_ds6_list_loop((uip_ds6_element_t *)uip_ds6_prefix_list,
+		       UIP_DS6_PREFIX_NB, sizeof(uip_ds6_prefix_t),
+		       ipaddr, ipaddrlen,
+		       (uip_ds6_element_t **)&locprefix) == FOUND) {
+    return locprefix;
+  }
+  return NULL;
+}
+
+/*---------------------------------------------------------------------------*/
+uint8_t
+uip_ds6_is_addr_onlink(uip_ipaddr_t *ipaddr)
+{
+  for(locprefix = uip_ds6_prefix_list;
+      locprefix < uip_ds6_prefix_list + UIP_DS6_PREFIX_NB; locprefix++) {
+    if(locprefix->isused &&
+       uip_ipaddr_prefixcmp(&locprefix->ipaddr, ipaddr, locprefix->length)) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+/*---------------------------------------------------------------------------*/
+uip_ds6_addr_t *
+uip_ds6_addr_add(uip_ipaddr_t *ipaddr, unsigned long vlifetime, uint8_t type)
+{
+  if(uip_ds6_list_loop
+     ((uip_ds6_element_t *)uip_ds6_if.addr_list, UIP_DS6_ADDR_NB,
+      sizeof(uip_ds6_addr_t), ipaddr, 128,
+      (uip_ds6_element_t **)&locaddr) == FREESPACE) {
+    locaddr->isused = 1;
+    uip_ipaddr_copy(&locaddr->ipaddr, ipaddr);
+    locaddr->type = type;
+    if(vlifetime == 0) {
+      locaddr->isinfinite = 1;
+    } else {
+      locaddr->isinfinite = 0;
+      stimer_set(&(locaddr->vlifetime), vlifetime);
+    }
+#if UIP_ND6_DEF_MAXDADNS > 0
+    locaddr->state = ADDR_TENTATIVE;
+    timer_set(&locaddr->dadtimer,
+              random_rand() % (UIP_ND6_MAX_RTR_SOLICITATION_DELAY *
+                               CLOCK_SECOND));
+    locaddr->dadnscount = 0;
+#else /* UIP_ND6_DEF_MAXDADNS > 0 */
+    locaddr->state = ADDR_PREFERRED;
+#endif /* UIP_ND6_DEF_MAXDADNS > 0 */
+    uip_create_solicited_node(ipaddr, &loc_fipaddr);
+    uip_ds6_maddr_add(&loc_fipaddr);
+    return locaddr;
+  }
+  return NULL;
+}
+
+/*---------------------------------------------------------------------------*/
+void
+uip_ds6_addr_rm(uip_ds6_addr_t *addr)
+{
+  if(addr != NULL) {
+    uip_create_solicited_node(&addr->ipaddr, &loc_fipaddr);
+    if((locmaddr = uip_ds6_maddr_lookup(&loc_fipaddr)) != NULL) {
+      uip_ds6_maddr_rm(locmaddr);
+    }
+    addr->isused = 0;
+  }
+  return;
+}
+
+/*---------------------------------------------------------------------------*/
+uip_ds6_addr_t *
+uip_ds6_addr_lookup(uip_ipaddr_t *ipaddr)
+{
+  if(uip_ds6_list_loop
+     ((uip_ds6_element_t *)uip_ds6_if.addr_list, UIP_DS6_ADDR_NB,
+      sizeof(uip_ds6_addr_t), ipaddr, 128,
+      (uip_ds6_element_t **)&locaddr) == FOUND) {
+    return locaddr;
+  }
+  return NULL;
+}
+
+/*---------------------------------------------------------------------------*/
+/*
+ * get a link local address -
+ * state = -1 => any address is ok. Otherwise state = desired state of addr.
+ * (TENTATIVE, PREFERRED, DEPRECATED)
+ */
+uip_ds6_addr_t *
+uip_ds6_get_link_local(int8_t state)
+{
+  for(locaddr = uip_ds6_if.addr_list;
+      locaddr < uip_ds6_if.addr_list + UIP_DS6_ADDR_NB; locaddr++) {
+    if(locaddr->isused && (state == -1 || locaddr->state == state)
+       && (uip_is_addr_link_local(&locaddr->ipaddr))) {
+      return locaddr;
+    }
+  }
+  return NULL;
+}
+
+/*---------------------------------------------------------------------------*/
+/*
+ * get a global address -
+ * state = -1 => any address is ok. Otherwise state = desired state of addr.
+ * (TENTATIVE, PREFERRED, DEPRECATED)
+ */
+uip_ds6_addr_t *
+uip_ds6_get_global(int8_t state)
+{
+  for(locaddr = uip_ds6_if.addr_list;
+      locaddr < uip_ds6_if.addr_list + UIP_DS6_ADDR_NB; locaddr++) {
+    if(locaddr->isused && (state == -1 || locaddr->state == state)
+       && !(uip_is_addr_link_local(&locaddr->ipaddr))) {
+      return locaddr;
+    }
+  }
+  return NULL;
+}
+
+/*---------------------------------------------------------------------------*/
+uip_ds6_maddr_t *
+uip_ds6_maddr_add(const uip_ipaddr_t *ipaddr)
+{
+  if(uip_ds6_list_loop
+     ((uip_ds6_element_t *)uip_ds6_if.maddr_list, UIP_DS6_MADDR_NB,
+      sizeof(uip_ds6_maddr_t), (void*)ipaddr, 128,
+      (uip_ds6_element_t **)&locmaddr) == FREESPACE) {
+    locmaddr->isused = 1;
+    uip_ipaddr_copy(&locmaddr->ipaddr, ipaddr);
+    return locmaddr;
+  }
+  return NULL;
+}
+
+/*---------------------------------------------------------------------------*/
+void
+uip_ds6_maddr_rm(uip_ds6_maddr_t *maddr)
+{
+  if(maddr != NULL) {
+    maddr->isused = 0;
+  }
+  return;
+}
+
+/*---------------------------------------------------------------------------*/
+uip_ds6_maddr_t *
+uip_ds6_maddr_lookup(const uip_ipaddr_t *ipaddr)
+{
+  if(uip_ds6_list_loop
+     ((uip_ds6_element_t *)uip_ds6_if.maddr_list, UIP_DS6_MADDR_NB,
+      sizeof(uip_ds6_maddr_t), (void*)ipaddr, 128,
+      (uip_ds6_element_t **)&locmaddr) == FOUND) {
+    return locmaddr;
+  }
+  return NULL;
+}
+
+
+/*---------------------------------------------------------------------------*/
+uip_ds6_aaddr_t *
+uip_ds6_aaddr_add(uip_ipaddr_t *ipaddr)
+{
+  if(uip_ds6_list_loop
+     ((uip_ds6_element_t *)uip_ds6_if.aaddr_list, UIP_DS6_AADDR_NB,
+      sizeof(uip_ds6_aaddr_t), ipaddr, 128,
+      (uip_ds6_element_t **)&locaaddr) == FREESPACE) {
+    locaaddr->isused = 1;
+    uip_ipaddr_copy(&locaaddr->ipaddr, ipaddr);
+    return locaaddr;
+  }
+  return NULL;
+}
+
+/*---------------------------------------------------------------------------*/
+void
+uip_ds6_aaddr_rm(uip_ds6_aaddr_t *aaddr)
+{
+  if(aaddr != NULL) {
+    aaddr->isused = 0;
+  }
+  return;
+}
+
+/*---------------------------------------------------------------------------*/
+uip_ds6_aaddr_t *
+uip_ds6_aaddr_lookup(uip_ipaddr_t *ipaddr)
+{
+  if(uip_ds6_list_loop((uip_ds6_element_t *)uip_ds6_if.aaddr_list,
+		       UIP_DS6_AADDR_NB, sizeof(uip_ds6_aaddr_t), ipaddr, 128,
+		       (uip_ds6_element_t **)&locaaddr) == FOUND) {
+    return locaaddr;
+  }
+  return NULL;
+}
+
+/*---------------------------------------------------------------------------*/
+void
+uip_ds6_select_src(uip_ipaddr_t *src, uip_ipaddr_t *dst)
+{
+  uint8_t best = 0;             /* number of bit in common with best match */
+  uint8_t n = 0;
+  uip_ds6_addr_t *matchaddr = NULL;
+
+  if(!uip_is_addr_link_local(dst) && !uip_is_addr_mcast(dst)) {
+    /* find longest match */
+    for(locaddr = uip_ds6_if.addr_list;
+        locaddr < uip_ds6_if.addr_list + UIP_DS6_ADDR_NB; locaddr++) {
+      /* Only preferred global (not link-local) addresses */
+      if(locaddr->isused && locaddr->state == ADDR_PREFERRED &&
+         !uip_is_addr_link_local(&locaddr->ipaddr)) {
+        n = get_match_length(dst, &locaddr->ipaddr);
+        if(n >= best) {
+          best = n;
+          matchaddr = locaddr;
+        }
+      }
+    }
+  } else {
+    matchaddr = uip_ds6_get_link_local(ADDR_PREFERRED);
+  }
+
+  /* use the :: (unspecified address) as source if no match found */
+  if(matchaddr == NULL) {
+    uip_create_unspecified(src);
+  } else {
+    uip_ipaddr_copy(src, &matchaddr->ipaddr);
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+void
+uip_ds6_set_addr_iid(uip_ipaddr_t *ipaddr, uip_lladdr_t *lladdr)
+{
+  /* We consider only links with IEEE EUI-64 identifier or
+   * IEEE 48-bit MAC addresses */
+#if (UIP_LLADDR_LEN == 8)
+  memcpy(ipaddr->u8 + 8, lladdr, UIP_LLADDR_LEN);
+  ipaddr->u8[8] ^= 0x02;
+#elif (UIP_LLADDR_LEN == 6)
+  memcpy(ipaddr->u8 + 8, lladdr, 3);
+  ipaddr->u8[11] = 0xff;
+  ipaddr->u8[12] = 0xfe;
+  memcpy(ipaddr->u8 + 13, (uint8_t *)lladdr + 3, 3);
+  ipaddr->u8[8] ^= 0x02;
+#else
+#error uip-ds6.c cannot build interface address when UIP_LLADDR_LEN is not 6 or 8
+#endif
+}
+
+/*---------------------------------------------------------------------------*/
+uint8_t
+get_match_length(uip_ipaddr_t *src, uip_ipaddr_t *dst)
+{
+  uint8_t j, k, x_or;
+  uint8_t len = 0;
+
+  for(j = 0; j < 16; j++) {
+    if(src->u8[j] == dst->u8[j]) {
+      len += 8;
+    } else {
+      x_or = src->u8[j] ^ dst->u8[j];
+      for(k = 0; k < 8; k++) {
+        if((x_or & 0x80) == 0) {
+          len++;
+          x_or <<= 1;
+        } else {
+          break;
+        }
+      }
+      break;
+    }
+  }
+  return len;
+}
+
+/*---------------------------------------------------------------------------*/
+#if UIP_ND6_DEF_MAXDADNS > 0
+void
+uip_ds6_dad(uip_ds6_addr_t *addr)
+{
+  /* send maxdadns NS for DAD  */
+  if(addr->dadnscount < uip_ds6_if.maxdadns) {
+    uip_nd6_ns_output(NULL, NULL, &addr->ipaddr);
+    addr->dadnscount++;
+    timer_set(&addr->dadtimer,
+              uip_ds6_if.retrans_timer / 1000 * CLOCK_SECOND);
+    return;
+  }
+  /*
+   * If we arrive here it means DAD succeeded, otherwise the dad process
+   * would have been interrupted in ds6_dad_ns/na_input
+   */
+  PRINTF("DAD succeeded, ipaddr:");
+  PRINT6ADDR(&addr->ipaddr);
+  PRINTF("\n");
+
+  addr->state = ADDR_PREFERRED;
+  return;
+}
+
+/*---------------------------------------------------------------------------*/
+/*
+ * Calling code must handle when this returns 0 (e.g. link local
+ * address can not be used).
+ */
+int
+uip_ds6_dad_failed(uip_ds6_addr_t *addr)
+{
+  if(uip_is_addr_link_local(&addr->ipaddr)) {
+    PRINTF("Contiki shutdown, DAD for link local address failed\n");
+    return 0;
+  }
+  uip_ds6_addr_rm(addr);
+  return 1;
+}
+#endif /*UIP_ND6_DEF_MAXDADNS > 0 */
+
+/*---------------------------------------------------------------------------*/
+#if UIP_CONF_ROUTER
+#if UIP_ND6_SEND_RA
+void
+uip_ds6_send_ra_sollicited(void)
+{
+  /* We have a pb here: RA timer max possible value is 1800s,
+   * hence we have to use stimers. However, when receiving a RS, we
+   * should delay the reply by a random value between 0 and 500ms timers.
+   * stimers are in seconds, hence we cannot do this. Therefore we just send
+   * the RA (setting the timer to 0 below). We keep the code logic for
+   * the days contiki will support appropriate timers */
+  rand_time = 0;
+  PRINTF("Solicited RA, random time %u\n", rand_time);
+
+  if(stimer_remaining(&uip_ds6_timer_ra) > rand_time) {
+    if(stimer_elapsed(&uip_ds6_timer_ra) < UIP_ND6_MIN_DELAY_BETWEEN_RAS) {
+      /* Ensure that the RAs are rate limited */
+/*      stimer_set(&uip_ds6_timer_ra, rand_time +
+                 UIP_ND6_MIN_DELAY_BETWEEN_RAS -
+                 stimer_elapsed(&uip_ds6_timer_ra));
+  */ } else {
+      stimer_set(&uip_ds6_timer_ra, rand_time);
+    }
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+void
+uip_ds6_send_ra_periodic(void)
+{
+  if(racount > 0) {
+    /* send previously scheduled RA */
+    uip_nd6_ra_output(NULL);
+    PRINTF("Sending periodic RA\n");
+  }
+
+  rand_time = UIP_ND6_MIN_RA_INTERVAL + random_rand() %
+    (uint16_t) (UIP_ND6_MAX_RA_INTERVAL - UIP_ND6_MIN_RA_INTERVAL);
+  PRINTF("Random time 1 = %u\n", rand_time);
+
+  if(racount < UIP_ND6_MAX_INITIAL_RAS) {
+    if(rand_time > UIP_ND6_MAX_INITIAL_RA_INTERVAL) {
+      rand_time = UIP_ND6_MAX_INITIAL_RA_INTERVAL;
+      PRINTF("Random time 2 = %u\n", rand_time);
+    }
+    racount++;
+  }
+  PRINTF("Random time 3 = %u\n", rand_time);
+  stimer_set(&uip_ds6_timer_ra, rand_time);
+}
+
+#endif /* UIP_ND6_SEND_RA */
+#else /* UIP_CONF_ROUTER */
+/*---------------------------------------------------------------------------*/
+void
+uip_ds6_send_rs(void)
+{
+  if((uip_ds6_defrt_choose() == NULL)
+     && (rscount < UIP_ND6_MAX_RTR_SOLICITATIONS)) {
+    PRINTF("Sending RS %u\n", rscount);
+    uip_nd6_rs_output();
+    rscount++;
+    etimer_set(&uip_ds6_timer_rs,
+               UIP_ND6_RTR_SOLICITATION_INTERVAL * CLOCK_SECOND);
+  } else {
+    PRINTF("Router found ? (boolean): %u\n",
+           (uip_ds6_defrt_choose() != NULL));
+    etimer_stop(&uip_ds6_timer_rs);
+  }
+  return;
+}
+
+#endif /* UIP_CONF_ROUTER */
+/*---------------------------------------------------------------------------*/
+uint32_t
+uip_ds6_compute_reachable_time(void)
+{
+  return (uint32_t) (UIP_ND6_MIN_RANDOM_FACTOR
+                     (uip_ds6_if.base_reachable_time)) +
+    ((uint16_t) (random_rand() << 8) +
+     (uint16_t) random_rand()) %
+    (uint32_t) (UIP_ND6_MAX_RANDOM_FACTOR(uip_ds6_if.base_reachable_time) -
+                UIP_ND6_MIN_RANDOM_FACTOR(uip_ds6_if.base_reachable_time));
+}
+/*---------------------------------------------------------------------------*/
+/** @} */
+#endif /* UIP_CONF_IPV6 */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/uip-ds6.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/uip-ds6.h
@@ -1,0 +1,340 @@
+/**
+ * \addtogroup uip6
+ * @{
+ */
+
+/**
+ * \file
+ *         Network interface and stateless autoconfiguration (RFC 4862)
+ * \author Mathilde Durvy <mdurvy@cisco.com>
+ * \author Julien Abeille <jabeille@cisco.com>
+ *
+ */
+/*
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *
+ */
+
+#ifndef __UIP_DS6_H__
+#define __UIP_DS6_H__
+
+#include "net/uip.h"
+#include "sys/stimer.h"
+/* The size of uip_ds6_addr_t depends on UIP_ND6_DEF_MAXDADNS. Include uip-nd6.h to define it. */
+#include "net/uip-nd6.h"
+#include "net/uip-ds6-route.h"
+#include "net/uip-ds6-nbr.h"
+
+/*--------------------------------------------------*/
+/** Configuration. For all tables (Neighbor cache, Prefix List, Routing Table,
+ * Default Router List, Unicast address list, multicast address list, anycast address list),
+ * we define:
+ * - the number of elements requested by the user in contiki configuration (name suffixed by _NBU)
+ * - the number of elements assigned by the system (name suffixed by _NBS)
+ * - the total number of elements is the sum (name suffixed by _NB)
+*/
+
+/* Default router list */
+#define UIP_DS6_DEFRT_NBS 0
+#ifndef UIP_CONF_DS6_DEFRT_NBU
+#define UIP_DS6_DEFRT_NBU 2
+#else
+#define UIP_DS6_DEFRT_NBU UIP_CONF_DS6_DEFRT_NBU
+#endif
+#define UIP_DS6_DEFRT_NB UIP_DS6_DEFRT_NBS + UIP_DS6_DEFRT_NBU
+
+/* Prefix list */
+#define UIP_DS6_PREFIX_NBS  1
+#ifndef UIP_CONF_DS6_PREFIX_NBU
+#define UIP_DS6_PREFIX_NBU  2
+#else
+#define UIP_DS6_PREFIX_NBU UIP_CONF_DS6_PREFIX_NBU
+#endif
+#define UIP_DS6_PREFIX_NB UIP_DS6_PREFIX_NBS + UIP_DS6_PREFIX_NBU
+
+/* Unicast address list*/
+#define UIP_DS6_ADDR_NBS 1
+#ifndef UIP_CONF_DS6_ADDR_NBU
+#define UIP_DS6_ADDR_NBU 2
+#else
+#define UIP_DS6_ADDR_NBU UIP_CONF_DS6_ADDR_NBU
+#endif
+#define UIP_DS6_ADDR_NB UIP_DS6_ADDR_NBS + UIP_DS6_ADDR_NBU
+
+/* Multicast address list */
+#if UIP_CONF_ROUTER
+#define UIP_DS6_MADDR_NBS 2 + UIP_DS6_ADDR_NB   /* all routers + all nodes + one solicited per unicast */
+#else
+#define UIP_DS6_MADDR_NBS 1 + UIP_DS6_ADDR_NB   /* all nodes + one solicited per unicast */
+#endif
+#ifndef UIP_CONF_DS6_MADDR_NBU
+#define UIP_DS6_MADDR_NBU 0
+#else
+#define UIP_DS6_MADDR_NBU UIP_CONF_DS6_MADDR_NBU
+#endif
+#define UIP_DS6_MADDR_NB UIP_DS6_MADDR_NBS + UIP_DS6_MADDR_NBU
+
+/* Anycast address list */
+#if UIP_CONF_ROUTER
+#define UIP_DS6_AADDR_NBS UIP_DS6_PREFIX_NB - 1 /* One per non link local prefix (subnet prefix anycast address) */
+#else
+#define UIP_DS6_AADDR_NBS 0
+#endif
+#ifndef UIP_CONF_DS6_AADDR_NBU
+#define UIP_DS6_AADDR_NBU 0
+#else
+#define UIP_DS6_AADDR_NBU UIP_CONF_DS6_AADDR_NBU
+#endif
+#define UIP_DS6_AADDR_NB UIP_DS6_AADDR_NBS + UIP_DS6_AADDR_NBU
+
+/*--------------------------------------------------*/
+/* Should we use LinkLayer acks in NUD ?*/
+#ifndef UIP_CONF_DS6_LL_NUD
+#define UIP_DS6_LL_NUD 0
+#else
+#define UIP_DS6_LL_NUD UIP_CONF_DS6_LL_NUD
+#endif
+
+/** \brief Possible states for the an address  (RFC 4862) */
+#define ADDR_TENTATIVE 0
+#define ADDR_PREFERRED 1
+#define ADDR_DEPRECATED 2
+
+/** \brief How the address was acquired: Autoconf, DHCP or manually */
+#define  ADDR_ANYTYPE 0
+#define  ADDR_AUTOCONF 1
+#define  ADDR_DHCP 2
+#define  ADDR_MANUAL 3
+
+/** \brief General DS6 definitions */
+#define UIP_DS6_PERIOD   (CLOCK_SECOND/10)  /** Period for uip-ds6 periodic task*/
+#define FOUND 0
+#define FREESPACE 1
+#define NOSPACE 2
+/*--------------------------------------------------*/
+
+#if UIP_CONF_IPV6_QUEUE_PKT
+#include "net/uip-packetqueue.h"
+#endif                          /*UIP_CONF_QUEUE_PKT */
+
+/** \brief A prefix list entry */
+#if UIP_CONF_ROUTER
+typedef struct uip_ds6_prefix {
+  uint8_t isused;
+  uip_ipaddr_t ipaddr;
+  uint8_t length;
+  uint8_t advertise;
+  uint32_t vlifetime;
+  uint32_t plifetime;
+  uint8_t l_a_reserved; /**< on-link and autonomous flags + 6 reserved bits */
+} uip_ds6_prefix_t;
+#else /* UIP_CONF_ROUTER */
+typedef struct uip_ds6_prefix {
+  uint8_t isused;
+  uip_ipaddr_t ipaddr;
+  uint8_t length;
+  struct stimer vlifetime;
+  uint8_t isinfinite;
+} uip_ds6_prefix_t;
+#endif /*UIP_CONF_ROUTER */
+
+/** * \brief Unicast address structure */
+typedef struct uip_ds6_addr {
+  uint8_t isused;
+  uip_ipaddr_t ipaddr;
+  uint8_t state;
+  uint8_t type;
+  uint8_t isinfinite;
+  struct stimer vlifetime;
+#if UIP_ND6_DEF_MAXDADNS > 0
+  struct uip_timer dadtimer;
+  uint8_t dadnscount;
+#endif /* UIP_ND6_DEF_MAXDADNS > 0 */
+} uip_ds6_addr_t;
+
+/** \brief Anycast address  */
+typedef struct uip_ds6_aaddr {
+  uint8_t isused;
+  uip_ipaddr_t ipaddr;
+} uip_ds6_aaddr_t;
+
+/** \brief A multicast address */
+typedef struct uip_ds6_maddr {
+  uint8_t isused;
+  uip_ipaddr_t ipaddr;
+} uip_ds6_maddr_t;
+
+/* only define the callback if RPL is active */
+#if UIP_CONF_IPV6_RPL
+#ifndef UIP_CONF_DS6_NEIGHBOR_STATE_CHANGED
+#define UIP_CONF_DS6_NEIGHBOR_STATE_CHANGED rpl_ipv6_neighbor_callback
+#endif /* UIP_CONF_DS6_NEIGHBOR_STATE_CHANGED */
+#endif /* UIP_CONF_IPV6_RPL */
+
+#if UIP_CONF_IPV6_RPL
+#ifndef UIP_CONF_DS6_LINK_NEIGHBOR_CALLBACK
+#define UIP_CONF_DS6_LINK_NEIGHBOR_CALLBACK rpl_link_neighbor_callback
+#endif /* UIP_CONF_DS6_NEIGHBOR_STATE_CHANGED */
+#endif /* UIP_CONF_IPV6_RPL */
+
+
+/** \brief  Interface structure (contains all the interface variables) */
+typedef struct uip_ds6_netif {
+  uint32_t link_mtu;
+  uint8_t cur_hop_limit;
+  uint32_t base_reachable_time; /* in msec */
+  uint32_t reachable_time;      /* in msec */
+  uint32_t retrans_timer;       /* in msec */
+  uint8_t maxdadns;
+  uip_ds6_addr_t addr_list[UIP_DS6_ADDR_NB];	/* Unicast address */
+  uip_ds6_aaddr_t aaddr_list[UIP_DS6_AADDR_NB];	/* Anycast address */
+  uip_ds6_maddr_t maddr_list[UIP_DS6_MADDR_NB]; /* Multicast addresses */
+} uip_ds6_netif_t;
+
+/** \brief Generic type for a DS6, to use a common loop though all DS */
+typedef struct uip_ds6_element {
+  uint8_t isused;
+  uip_ipaddr_t ipaddr;
+} uip_ds6_element_t;
+
+
+/*---------------------------------------------------------------------------*/
+extern uip_ds6_netif_t uip_ds6_if;
+extern struct etimer uip_ds6_timer_periodic;
+
+#if UIP_CONF_ROUTER
+extern uip_ds6_prefix_t uip_ds6_prefix_list[UIP_DS6_PREFIX_NB];
+#else /* UIP_CONF_ROUTER */
+extern struct etimer uip_ds6_timer_rs;
+#endif /* UIP_CONF_ROUTER */
+
+
+/*---------------------------------------------------------------------------*/
+/** \brief Initialize data structures */
+void uip_ds6_init(void);
+
+/** \brief Periodic processing of data structures */
+void uip_ds6_periodic(void);
+
+/** \brief Generic loop routine on an abstract data structure, which generalizes
+ * all data structures used in DS6 */
+uint8_t uip_ds6_list_loop(uip_ds6_element_t *list, uint8_t size,
+                          uint16_t elementsize, uip_ipaddr_t *ipaddr,
+                          uint8_t ipaddrlen,
+                          uip_ds6_element_t **out_element);
+
+/** @} */
+
+
+/** \name Prefix list basic routines */
+/** @{ */
+#if UIP_CONF_ROUTER
+uip_ds6_prefix_t *uip_ds6_prefix_add(uip_ipaddr_t *ipaddr, uint8_t length,
+                                     uint8_t advertise, uint8_t flags,
+                                     unsigned long vtime,
+                                     unsigned long ptime);
+#else /* UIP_CONF_ROUTER */
+uip_ds6_prefix_t *uip_ds6_prefix_add(uip_ipaddr_t *ipaddr, uint8_t length,
+                                     unsigned long interval);
+#endif /* UIP_CONF_ROUTER */
+void uip_ds6_prefix_rm(uip_ds6_prefix_t *prefix);
+uip_ds6_prefix_t *uip_ds6_prefix_lookup(uip_ipaddr_t *ipaddr,
+                                        uint8_t ipaddrlen);
+uint8_t uip_ds6_is_addr_onlink(uip_ipaddr_t *ipaddr);
+
+/** @} */
+
+/** \name Unicast address list basic routines */
+/** @{ */
+uip_ds6_addr_t *uip_ds6_addr_add(uip_ipaddr_t *ipaddr,
+                                 unsigned long vlifetime, uint8_t type);
+void uip_ds6_addr_rm(uip_ds6_addr_t *addr);
+uip_ds6_addr_t *uip_ds6_addr_lookup(uip_ipaddr_t *ipaddr);
+uip_ds6_addr_t *uip_ds6_get_link_local(int8_t state);
+uip_ds6_addr_t *uip_ds6_get_global(int8_t state);
+
+/** @} */
+
+/** \name Multicast address list basic routines */
+/** @{ */
+uip_ds6_maddr_t *uip_ds6_maddr_add(const uip_ipaddr_t *ipaddr);
+void uip_ds6_maddr_rm(uip_ds6_maddr_t *maddr);
+uip_ds6_maddr_t *uip_ds6_maddr_lookup(const uip_ipaddr_t *ipaddr);
+
+/** @} */
+
+/** \name Anycast address list basic routines */
+/** @{ */
+uip_ds6_aaddr_t *uip_ds6_aaddr_add(uip_ipaddr_t *ipaddr);
+void uip_ds6_aaddr_rm(uip_ds6_aaddr_t *aaddr);
+uip_ds6_aaddr_t *uip_ds6_aaddr_lookup(uip_ipaddr_t *ipaddr);
+
+/** @} */
+
+
+/** \brief set the last 64 bits of an IP address based on the MAC address */
+void uip_ds6_set_addr_iid(uip_ipaddr_t *ipaddr, uip_lladdr_t *lladdr);
+
+/** \brief Get the number of matching bits of two addresses */
+uint8_t get_match_length(uip_ipaddr_t *src, uip_ipaddr_t *dst);
+
+#if UIP_ND6_DEF_MAXDADNS >0
+/** \brief Perform Duplicate Address Selection on one address */
+void uip_ds6_dad(uip_ds6_addr_t *ifaddr);
+
+/** \brief Callback when DAD failed */
+int uip_ds6_dad_failed(uip_ds6_addr_t *ifaddr);
+#endif /* UIP_ND6_DEF_MAXDADNS */
+
+/** \brief Source address selection, see RFC 3484 */
+void uip_ds6_select_src(uip_ipaddr_t *src, uip_ipaddr_t *dst);
+
+#if UIP_CONF_ROUTER
+#if UIP_ND6_SEND_RA
+/** \brief Send a RA as an asnwer to a RS */
+void uip_ds6_send_ra_sollicited(void);
+
+/** \brief Send a periodic RA */
+void uip_ds6_send_ra_periodic(void);
+#endif /* UIP_ND6_SEND_RA */
+#else /* UIP_CONF_ROUTER */
+/** \brief Send periodic RS to find router */
+void uip_ds6_send_rs(void);
+#endif /* UIP_CONF_ROUTER */
+
+/** \brief Compute the reachable time based on base reachable time, see RFC 4861*/
+uint32_t uip_ds6_compute_reachable_time(void); /** \brief compute random reachable timer */
+
+/** \name Macros to check if an IP address (unicast, multicast or anycast) is mine */
+/** @{ */
+#define uip_ds6_is_my_addr(addr)  (uip_ds6_addr_lookup(addr) != NULL)
+#define uip_ds6_is_my_maddr(addr) (uip_ds6_maddr_lookup(addr) != NULL)
+#define uip_ds6_is_my_aaddr(addr) (uip_ds6_aaddr_lookup(addr) != NULL)
+/** @} */
+/** @} */
+
+#endif /* __UIP_DS6_H__ */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/uip-icmp6.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/uip-icmp6.c
@@ -1,0 +1,282 @@
+/**
+ * \addtogroup uip6
+ * @{
+ */
+
+/**
+ * \file
+ *         ICMPv6 echo request and error messages (RFC 4443)
+ * \author Julien Abeille <jabeille@cisco.com> 
+ * \author Mathilde Durvy <mdurvy@cisco.com>
+ */
+
+/*
+ * Copyright (c) 2001-2003, Adam Dunkels.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This file is part of the uIP TCP/IP stack.
+ *
+ */
+
+#include <string.h>
+#include "net/uip-ds6.h"
+#include "net/uip-icmp6.h"
+#if NO_XMOS_PROJECT
+#include "contiki-default-conf.h"
+#else
+#include "uip.h"
+#endif
+
+#define DEBUG DEBUG_NONE
+#include "uip-debug.h"
+
+#if !BUF_32BIT_ALIGN
+#define UIP_IP_BUF                ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN])
+#define UIP_ICMP_BUF            ((struct uip_icmp_hdr *)&uip_buf[uip_l2_l3_hdr_len])
+#define UIP_ICMP6_ERROR_BUF  ((struct uip_icmp6_error *)&uip_buf[uip_l2_l3_icmp_hdr_len])
+#define UIP_EXT_BUF              ((struct uip_ext_hdr *)&uip_buf[uip_l2_l3_hdr_len])
+#define UIP_FIRST_EXT_BUF        ((struct uip_ext_hdr *)&uip_buf[UIP_LLIPH_LEN])
+#else
+#define UIP_IP_BUF                ((struct uip_ip_hdr *)&uip_buf16(UIP_LLH_LEN))
+#define UIP_ICMP_BUF            ((struct uip_icmp_hdr *)&uip_buf16(uip_l2_l3_hdr_len))
+#define UIP_ICMP6_ERROR_BUF  ((struct uip_icmp6_error *)&uip_buf16(uip_l2_l3_icmp_hdr_len))
+#define UIP_EXT_BUF              ((struct uip_ext_hdr *)&uip_buf16(uip_l2_l3_hdr_len))
+#define UIP_FIRST_EXT_BUF        ((struct uip_ext_hdr *)&uip_buf16(UIP_LLIPH_LEN))
+#endif
+/** \brief temporary IP address */
+static uip_ipaddr_t tmp_ipaddr;
+
+#if UIP_CONF_IPV6_RPL
+#include "rpl/rpl.h"
+#endif /* UIP_CONF_IPV6_RPL */
+
+#if UIP_CONF_IPV6
+/*---------------------------------------------------------------------------*/
+void
+uip_icmp6_echo_request_input(void)
+{
+#if UIP_CONF_IPV6_RPL
+  uint8_t temp_ext_len;
+#endif /* UIP_CONF_IPV6_RPL */
+  /*
+   * we send an echo reply. It is trivial if there was no extension
+   * headers in the request otherwise we need to remove the extension
+   * headers and change a few fields
+   */
+  PRINTF("Received Echo Request from ");
+  PRINT6ADDR(&UIP_IP_BUF->srcipaddr);
+  PRINTF(" to ");
+  PRINT6ADDR(&UIP_IP_BUF->destipaddr);
+  PRINTF("\n");
+
+  /* IP header */
+  UIP_IP_BUF->ttl = uip_ds6_if.cur_hop_limit;
+
+  if(uip_is_addr_mcast(&UIP_IP_BUF->destipaddr)){
+    uip_ipaddr_copy(&UIP_IP_BUF->destipaddr, &UIP_IP_BUF->srcipaddr);
+    uip_ds6_select_src(&UIP_IP_BUF->srcipaddr, &UIP_IP_BUF->destipaddr);
+  } else {
+    uip_ipaddr_copy(&tmp_ipaddr, &UIP_IP_BUF->srcipaddr);
+    uip_ipaddr_copy(&UIP_IP_BUF->srcipaddr, &UIP_IP_BUF->destipaddr);
+    uip_ipaddr_copy(&UIP_IP_BUF->destipaddr, &tmp_ipaddr);
+  }
+
+  if(uip_ext_len > 0) {
+#if UIP_CONF_IPV6_RPL
+    if((temp_ext_len = rpl_invert_header())) {
+      /* If there were other extension headers*/
+      UIP_FIRST_EXT_BUF->next = UIP_PROTO_ICMP6;
+      if (uip_ext_len != temp_ext_len) {
+        uip_len -= (uip_ext_len - temp_ext_len);
+        UIP_IP_BUF->len[0] = ((uip_len - UIP_IPH_LEN) >> 8);
+        UIP_IP_BUF->len[1] = ((uip_len - UIP_IPH_LEN) & 0xff);
+        /* move the echo request payload (starting after the icmp header)
+         * to the new location in the reply.
+         * The shift is equal to the length of the remaining extension headers present
+         * Note: UIP_ICMP_BUF still points to the echo request at this stage
+         */
+      memmove((uint8_t *)UIP_ICMP_BUF + UIP_ICMPH_LEN - (uip_ext_len - temp_ext_len),
+              (uint8_t *)UIP_ICMP_BUF + UIP_ICMPH_LEN,
+              (uip_len - UIP_IPH_LEN - temp_ext_len - UIP_ICMPH_LEN));
+      }
+      uip_ext_len = temp_ext_len;
+    } else {
+#endif /* UIP_CONF_IPV6_RPL */
+      /* If there were extension headers*/
+      UIP_IP_BUF->proto = UIP_PROTO_ICMP6;
+      uip_len -= uip_ext_len;
+      UIP_IP_BUF->len[0] = ((uip_len - UIP_IPH_LEN) >> 8);
+      UIP_IP_BUF->len[1] = ((uip_len - UIP_IPH_LEN) & 0xff);
+      /* move the echo request payload (starting after the icmp header)
+       * to the new location in the reply.
+       * The shift is equal to the length of the extension headers present
+       * Note: UIP_ICMP_BUF still points to the echo request at this stage
+       */
+      memmove((uint8_t *)UIP_ICMP_BUF + UIP_ICMPH_LEN - uip_ext_len,
+              (uint8_t *)UIP_ICMP_BUF + UIP_ICMPH_LEN,
+              (uip_len - UIP_IPH_LEN - UIP_ICMPH_LEN));
+      uip_ext_len = 0;
+#if UIP_CONF_IPV6_RPL
+    }
+#endif /* UIP_CONF_IPV6_RPL */
+  }
+  /* Below is important for the correctness of UIP_ICMP_BUF and the
+   * checksum
+   */
+
+  /* Note: now UIP_ICMP_BUF points to the beginning of the echo reply */
+  UIP_ICMP_BUF->type = ICMP6_ECHO_REPLY;
+  UIP_ICMP_BUF->icode = 0;
+  UIP_ICMP_BUF->icmpchksum = 0;
+  UIP_ICMP_BUF->icmpchksum = ~uip_icmp6chksum();
+
+  PRINTF("Sending Echo Reply to ");
+  PRINT6ADDR(&UIP_IP_BUF->destipaddr);
+  PRINTF(" from ");
+  PRINT6ADDR(&UIP_IP_BUF->srcipaddr);
+  PRINTF("\n");
+  UIP_STAT(++uip_stat.icmp.sent);
+  return;
+}
+/*---------------------------------------------------------------------------*/
+void
+uip_icmp6_error_output(uint8_t type, uint8_t code, uint32_t param) {
+
+ /* check if originating packet is not an ICMP error*/
+  if (uip_ext_len) {
+    if(UIP_EXT_BUF->next == UIP_PROTO_ICMP6 && UIP_ICMP_BUF->type < 128){
+      uip_len = 0;
+      return;
+    }
+  } else {
+    if(UIP_IP_BUF->proto == UIP_PROTO_ICMP6 && UIP_ICMP_BUF->type < 128){
+      uip_len = 0;
+      return;
+    }
+  }
+
+#if UIP_CONF_IPV6_RPL
+  uip_ext_len = rpl_invert_header();
+#else /* UIP_CONF_IPV6_RPL */
+  uip_ext_len = 0;
+#endif /* UIP_CONF_IPV6_RPL */
+
+  /* remember data of original packet before shifting */
+  uip_ipaddr_copy(&tmp_ipaddr, &UIP_IP_BUF->destipaddr);
+
+  uip_len += UIP_IPICMPH_LEN + UIP_ICMP6_ERROR_LEN;
+
+  if(uip_len > UIP_LINK_MTU)
+    uip_len = UIP_LINK_MTU;
+
+  memmove((uint8_t *)UIP_ICMP6_ERROR_BUF + uip_ext_len + UIP_ICMP6_ERROR_LEN,
+          (void *)UIP_IP_BUF, uip_len - UIP_IPICMPH_LEN - uip_ext_len - UIP_ICMP6_ERROR_LEN);
+
+  UIP_IP_BUF->vtc = 0x60;
+  UIP_IP_BUF->tcflow = 0;
+  UIP_IP_BUF->flow = 0;
+  if (uip_ext_len) {
+    UIP_FIRST_EXT_BUF->next = UIP_PROTO_ICMP6;
+  } else {
+    UIP_IP_BUF->proto = UIP_PROTO_ICMP6;
+  }
+  UIP_IP_BUF->ttl = uip_ds6_if.cur_hop_limit;
+
+  /* the source should not be unspecified nor multicast, the check for
+     multicast is done in uip_process */
+  if(uip_is_addr_unspecified(&UIP_IP_BUF->srcipaddr)){
+    uip_len = 0;
+    return;
+  }
+
+  uip_ipaddr_copy(&UIP_IP_BUF->destipaddr, &UIP_IP_BUF->srcipaddr);
+
+  if(uip_is_addr_mcast(&tmp_ipaddr)){
+    if(type == ICMP6_PARAM_PROB && code == ICMP6_PARAMPROB_OPTION){
+      uip_ds6_select_src(&UIP_IP_BUF->srcipaddr, &tmp_ipaddr);
+    } else {
+      uip_len = 0;
+      return;
+    }
+  } else {
+#if UIP_CONF_ROUTER
+    /* need to pick a source that corresponds to this node */
+    uip_ds6_select_src(&UIP_IP_BUF->srcipaddr, &tmp_ipaddr);
+#else
+    uip_ipaddr_copy(&UIP_IP_BUF->srcipaddr, &tmp_ipaddr);
+#endif
+  }
+
+  UIP_ICMP_BUF->type = type;
+  UIP_ICMP_BUF->icode = code;
+  UIP_ICMP6_ERROR_BUF->param = uip_htonl(param);
+  UIP_IP_BUF->len[0] = ((uip_len - UIP_IPH_LEN) >> 8);
+  UIP_IP_BUF->len[1] = ((uip_len - UIP_IPH_LEN) & 0xff);
+  UIP_ICMP_BUF->icmpchksum = 0;
+  UIP_ICMP_BUF->icmpchksum = ~uip_icmp6chksum();
+
+  UIP_STAT(++uip_stat.icmp.sent);
+
+  PRINTF("Sending ICMPv6 ERROR message to");
+  PRINT6ADDR(&UIP_IP_BUF->destipaddr);
+  PRINTF("from");
+  PRINT6ADDR(&UIP_IP_BUF->srcipaddr);
+  PRINTF("\n");
+  return;
+}
+
+/*---------------------------------------------------------------------------*/
+void
+uip_icmp6_send(uip_ipaddr_t *dest, int type, int code, int payload_len)
+{
+
+  UIP_IP_BUF->vtc = 0x60;
+  UIP_IP_BUF->tcflow = 0;
+  UIP_IP_BUF->flow = 0;
+  UIP_IP_BUF->proto = UIP_PROTO_ICMP6;
+  UIP_IP_BUF->ttl = uip_ds6_if.cur_hop_limit;
+  UIP_IP_BUF->len[0] = (UIP_ICMPH_LEN + payload_len) >> 8;
+  UIP_IP_BUF->len[1] = (UIP_ICMPH_LEN + payload_len) & 0xff;
+
+  memcpy(&UIP_IP_BUF->destipaddr, dest, sizeof(*dest));
+  uip_ds6_select_src(&UIP_IP_BUF->srcipaddr, &UIP_IP_BUF->destipaddr);
+
+  UIP_ICMP_BUF->type = type;
+  UIP_ICMP_BUF->icode = code;
+
+  UIP_ICMP_BUF->icmpchksum = 0;
+  UIP_ICMP_BUF->icmpchksum = ~uip_icmp6chksum();
+
+  uip_len = UIP_IPH_LEN + UIP_ICMPH_LEN + payload_len;
+//  tcpip_ipv6_output();
+  /* XXX CHSC: Just uncommted because it is actually unsed and the API of
+   *           tcpip_ipv6_output => xtcpip_ipv6_output has changed */
+}
+/*---------------------------------------------------------------------------*/
+
+/** @} */
+#endif /* UIP_CONF_IPV6 */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/uip-icmp6.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/uip-icmp6.h
@@ -1,0 +1,140 @@
+/**
+ * \addtogroup uip6
+ * @{
+ */
+
+/**
+ * \file
+ *         ICMPv6 echo request and error messages (RFC 4443)
+ * \author Julien Abeille <jabeille@cisco.com> 
+ * \author Mathilde Durvy <mdurvy@cisco.com>
+ */
+
+/*
+ * Copyright (c) 2006, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+
+#ifndef __ICMP6_H__
+#define __ICMP6_H__
+
+#include "net/uip.h"
+
+
+/** \name ICMPv6 message types */
+/** @{ */
+#define ICMP6_DST_UNREACH                 1	/**< dest unreachable */
+#define ICMP6_PACKET_TOO_BIG              2	/**< packet too big */
+#define ICMP6_TIME_EXCEEDED               3	/**< time exceeded */
+#define ICMP6_PARAM_PROB                  4	/**< ip6 header bad */
+#define ICMP6_ECHO_REQUEST              128  /**< Echo request */
+#define ICMP6_ECHO_REPLY                129  /**< Echo reply */
+
+#define ICMP6_RS                        133  /**< Router Solicitation */
+#define ICMP6_RA                        134  /**< Router Advertisement */
+#define ICMP6_NS                        135  /**< Neighbor Solicitation */
+#define ICMP6_NA                        136  /**< Neighbor advertisement */
+#define ICMP6_REDIRECT                  137  /**< Redirect */
+
+#define ICMP6_RPL                       155  /**< RPL */
+/** @} */
+
+
+/** \name ICMPv6 Destination Unreachable message codes*/
+/** @{ */
+#define ICMP6_DST_UNREACH_NOROUTE         0 /**< no route to destination */
+#define ICMP6_DST_UNREACH_ADMIN	         1 /**< administratively prohibited */
+#define ICMP6_DST_UNREACH_NOTNEIGHBOR     2 /**< not a neighbor(obsolete) */
+#define ICMP6_DST_UNREACH_BEYONDSCOPE     2 /**< beyond scope of source address */
+#define ICMP6_DST_UNREACH_ADDR	         3 /**< address unreachable */
+#define ICMP6_DST_UNREACH_NOPORT          4 /**< port unreachable */
+/** @} */
+
+/** \name ICMPv6 Time Exceeded message codes*/
+/** @{ */
+#define ICMP6_TIME_EXCEED_TRANSIT         0 /**< ttl==0 in transit */
+#define ICMP6_TIME_EXCEED_REASSEMBLY      1 /**< ttl==0 in reass */
+/** @} */
+
+/** \name ICMPv6 Parameter Problem message codes*/
+/** @{ */
+#define ICMP6_PARAMPROB_HEADER            0 /**< erroneous header field */
+#define ICMP6_PARAMPROB_NEXTHEADER        1 /**< unrecognized next header */
+#define ICMP6_PARAMPROB_OPTION            2 /**< unrecognized option */
+/** @} */
+
+/** \brief Echo Request constant part length */
+#define UIP_ICMP6_ECHO_REQUEST_LEN        4
+
+/** \brief ICMPv6 Error message constant part length */
+#define UIP_ICMP6_ERROR_LEN               4
+
+/** \brief ICMPv6 Error message constant part */
+typedef struct uip_icmp6_error{
+  uint32_t param;
+} uip_icmp6_error;
+
+/** \name ICMPv6 RFC4443 Message processing and sending */
+/** @{ */
+/** \
+ * brief Process an echo request 
+ *
+ * Perform a few checks, then send an Echo reply. The reply is 
+ * built here.
+  */
+void
+uip_icmp6_echo_request_input(void);
+
+/**
+ * \brief Send an icmpv6 error message
+ * \param type type of the error message
+ * \param code of the error message
+ * \param type 32 bit parameter of the error message, semantic depends on error 
+ */
+void
+uip_icmp6_error_output(uint8_t type, uint8_t code, uint32_t param); 
+
+/**
+ * \brief Send an icmpv6 message
+ * \param dest destination address of the message
+ * \param type type of the message
+ * \param code of the message
+ * \param payload_len length of the payload
+ */
+void
+uip_icmp6_send(uip_ipaddr_t *dest, int type, int code, int payload_len);
+
+
+/** @} */
+
+#endif /*__ICMP6_H__*/
+/** @} */
+

--- a/module_xtcp/src/xtcp_uip6/contiki/net/uip-nd6.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/uip-nd6.c
@@ -1,0 +1,974 @@
+/**
+ * \addtogroup uip6
+ * @{
+ */
+
+/**
+ * \file
+ *         Neighbor discovery (RFC 4861)
+ * \author Mathilde Durvy <mdurvy@cisco.com>
+ * \author Julien Abeille <jabeille@cisco.com>
+ */
+
+/*
+ * Copyright (C) 1995, 1996, 1997, and 1998 WIDE Project.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the project nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE PROJECT AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE PROJECT OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+/*
+ * Copyright (c) 2006, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#include <string.h>
+#include "net/uip-icmp6.h"
+#include "net/uip-nd6.h"
+#include "net/uip-ds6.h"
+#include "lib/random.h"
+
+#if UIP_CONF_IPV6
+/*------------------------------------------------------------------*/
+#define DEBUG DEBUG_NONE
+#include "net/uip-debug.h"
+
+#if UIP_LOGGING
+#include <stdio.h>
+void uip_log(char *msg);
+
+#define UIP_LOG(m) uip_log(m)
+#else
+#define UIP_LOG(m)
+#endif /* UIP_LOGGING == 1 */
+
+/*------------------------------------------------------------------*/
+/** @{ */
+/** \name Pointers to the header structures.
+ *  All pointers except UIP_IP_BUF depend on uip_ext_len, which at
+ *  packet reception, is the total length of the extension headers.
+ *  
+ *  The pointer to ND6 options header also depends on nd6_opt_offset,
+ *  which we set in each function.
+ *
+ *  Care should be taken when manipulating these buffers about the
+ *  value of these length variables
+ */
+
+#define UIP_IP_BUF                ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN])  /**< Pointer to IP header */
+#define UIP_ICMP_BUF            ((struct uip_icmp_hdr *)&uip_buf[uip_l2_l3_hdr_len])  /**< Pointer to ICMP header*/
+/**@{  Pointers to messages just after icmp header */
+#define UIP_ND6_RS_BUF            ((uip_nd6_rs *)&uip_buf[uip_l2_l3_icmp_hdr_len])
+#define UIP_ND6_RA_BUF            ((uip_nd6_ra *)&uip_buf[uip_l2_l3_icmp_hdr_len])
+#define UIP_ND6_NS_BUF            ((uip_nd6_ns *)&uip_buf[uip_l2_l3_icmp_hdr_len])
+#define UIP_ND6_NA_BUF            ((uip_nd6_na *)&uip_buf[uip_l2_l3_icmp_hdr_len])
+/** @} */
+/** Pointer to ND option */
+#define UIP_ND6_OPT_HDR_BUF  ((uip_nd6_opt_hdr *)&uip_buf[uip_l2_l3_icmp_hdr_len + nd6_opt_offset])
+#define UIP_ND6_OPT_PREFIX_BUF ((uip_nd6_opt_prefix_info *)&uip_buf[uip_l2_l3_icmp_hdr_len + nd6_opt_offset])
+#define UIP_ND6_OPT_MTU_BUF ((uip_nd6_opt_mtu *)&uip_buf[uip_l2_l3_icmp_hdr_len + nd6_opt_offset])
+/** @} */
+
+static uint8_t nd6_opt_offset;                     /** Offset from the end of the icmpv6 header to the option in uip_buf*/
+static uint8_t *nd6_opt_llao;   /**  Pointer to llao option in uip_buf */
+
+#if !UIP_CONF_ROUTER            // TBD see if we move it to ra_input
+static uip_nd6_opt_prefix_info *nd6_opt_prefix_info; /**  Pointer to prefix information option in uip_buf */
+static uip_ipaddr_t ipaddr;
+static uip_ds6_prefix_t *prefix; /**  Pointer to a prefix list entry */
+#endif
+static uip_ds6_nbr_t *nbr; /**  Pointer to a nbr cache entry*/
+static uip_ds6_defrt_t *defrt; /**  Pointer to a router list entry */
+static uip_ds6_addr_t *addr; /**  Pointer to an interface address */
+
+
+/*------------------------------------------------------------------*/
+/* create a llao */ 
+static void
+create_llao(uint8_t *llao, uint8_t type) {
+  llao[UIP_ND6_OPT_TYPE_OFFSET] = type;
+  llao[UIP_ND6_OPT_LEN_OFFSET] = UIP_ND6_OPT_LLAO_LEN >> 3;
+  memcpy(&llao[UIP_ND6_OPT_DATA_OFFSET], &uip_lladdr, UIP_LLADDR_LEN);
+  /* padding on some */
+  memset(&llao[UIP_ND6_OPT_DATA_OFFSET + UIP_LLADDR_LEN], 0,
+         UIP_ND6_OPT_LLAO_LEN - 2 - UIP_LLADDR_LEN);
+}
+
+/*------------------------------------------------------------------*/
+
+
+void
+uip_nd6_ns_input(void)
+{
+  uint8_t flags;
+  PRINTF("Received NS from ");
+  PRINT6ADDR(&UIP_IP_BUF->srcipaddr);
+  PRINTF(" to ");
+  PRINT6ADDR(&UIP_IP_BUF->destipaddr);
+  PRINTF(" with target address ");
+  PRINT6ADDR((uip_ipaddr_t *) (&UIP_ND6_NS_BUF->tgtipaddr));
+  PRINTF("\n");
+  UIP_STAT(++uip_stat.nd6.recv);
+
+#if UIP_CONF_IPV6_CHECKS
+  if((UIP_IP_BUF->ttl != UIP_ND6_HOP_LIMIT) ||
+     (uip_is_addr_mcast(&UIP_ND6_NS_BUF->tgtipaddr)) ||
+     (UIP_ICMP_BUF->icode != 0)) {
+    PRINTF("NS received is bad\n");
+    goto discard;
+  }
+#endif /* UIP_CONF_IPV6_CHECKS */
+
+  /* Options processing */
+  nd6_opt_llao = NULL;
+  nd6_opt_offset = UIP_ND6_NS_LEN;
+  while(uip_l3_icmp_hdr_len + nd6_opt_offset < uip_len) {
+#if UIP_CONF_IPV6_CHECKS
+    if(UIP_ND6_OPT_HDR_BUF->len == 0) {
+      PRINTF("NS received is bad\n");
+      goto discard;
+    }
+#endif /* UIP_CONF_IPV6_CHECKS */
+    switch (UIP_ND6_OPT_HDR_BUF->type) {
+    case UIP_ND6_OPT_SLLAO:
+      nd6_opt_llao = &uip_buf[uip_l2_l3_icmp_hdr_len + nd6_opt_offset];
+#if UIP_CONF_IPV6_CHECKS
+      /* There must be NO option in a DAD NS */
+      if(uip_is_addr_unspecified(&UIP_IP_BUF->srcipaddr)) {
+        PRINTF("NS received is bad\n");
+        goto discard;
+      } else {
+#endif /*UIP_CONF_IPV6_CHECKS */
+        nbr = uip_ds6_nbr_lookup(&UIP_IP_BUF->srcipaddr);
+        if(nbr == NULL) {
+          uip_ds6_nbr_add(&UIP_IP_BUF->srcipaddr,
+			  (uip_lladdr_t *)&nd6_opt_llao[UIP_ND6_OPT_DATA_OFFSET],
+			  0, NBR_STALE);
+        } else {
+          uip_lladdr_t *lladdr = uip_ds6_nbr_get_ll(nbr);
+          if(memcmp(&nd6_opt_llao[UIP_ND6_OPT_DATA_OFFSET],
+		    lladdr, UIP_LLADDR_LEN) != 0) {
+            memcpy(lladdr, &nd6_opt_llao[UIP_ND6_OPT_DATA_OFFSET],
+		   UIP_LLADDR_LEN);
+            nbr->state = NBR_STALE;
+          } else {
+            if(nbr->state == NBR_INCOMPLETE) {
+              nbr->state = NBR_STALE;
+            }
+          }
+        }
+#if UIP_CONF_IPV6_CHECKS
+      }
+#endif /*UIP_CONF_IPV6_CHECKS */
+      break;
+    default:
+      PRINTF("ND option not supported in NS\n");
+      break;
+    }
+    nd6_opt_offset += (UIP_ND6_OPT_HDR_BUF->len << 3);
+  }
+
+  addr = uip_ds6_addr_lookup(&UIP_ND6_NS_BUF->tgtipaddr);
+  if(addr != NULL) {
+#if UIP_ND6_DEF_MAXDADNS > 0
+    if(uip_is_addr_unspecified(&UIP_IP_BUF->srcipaddr)) {
+      /* DAD CASE */
+#if UIP_CONF_IPV6_CHECKS
+      if(!uip_is_addr_solicited_node(&UIP_IP_BUF->destipaddr)) {
+        PRINTF("NS received is bad\n");
+        goto discard;
+      }
+#endif /* UIP_CONF_IPV6_CHECKS */
+      if(addr->state != ADDR_TENTATIVE) {
+        uip_create_linklocal_allnodes_mcast(&UIP_IP_BUF->destipaddr);
+        uip_ds6_select_src(&UIP_IP_BUF->srcipaddr, &UIP_IP_BUF->destipaddr);
+        flags = UIP_ND6_NA_FLAG_OVERRIDE;
+        goto create_na;
+      } else {
+          /** \todo if I sent a NS before him, I win */
+        uip_ds6_dad_failed(addr);
+        goto discard;
+      }
+#else /* UIP_ND6_DEF_MAXDADNS > 0 */
+    if(uip_is_addr_unspecified(&UIP_IP_BUF->srcipaddr)) {
+      /* DAD CASE */
+      goto discard;
+#endif /* UIP_ND6_DEF_MAXDADNS > 0 */
+    }
+#if UIP_CONF_IPV6_CHECKS
+    if(uip_ds6_is_my_addr(&UIP_IP_BUF->srcipaddr)) {
+        /**
+         * \NOTE do we do something here? we both are using the same address.
+         * If we are doing dad, we could cancel it, though we should receive a
+         * NA in response of DAD NS we sent, hence DAD will fail anyway. If we
+         * were not doing DAD, it means there is a duplicate in the network!
+         */
+      PRINTF("NS received is bad\n");
+      goto discard;
+    }
+#endif /*UIP_CONF_IPV6_CHECKS */
+
+    /* Address resolution case */
+    if(uip_is_addr_solicited_node(&UIP_IP_BUF->destipaddr)) {
+      uip_ipaddr_copy(&UIP_IP_BUF->destipaddr, &UIP_IP_BUF->srcipaddr);
+      uip_ipaddr_copy(&UIP_IP_BUF->srcipaddr, &UIP_ND6_NS_BUF->tgtipaddr);
+      flags = UIP_ND6_NA_FLAG_SOLICITED | UIP_ND6_NA_FLAG_OVERRIDE;
+      goto create_na;
+    }
+
+    /* NUD CASE */
+    if(uip_ds6_addr_lookup(&UIP_IP_BUF->destipaddr) == addr) {
+      uip_ipaddr_copy(&UIP_IP_BUF->destipaddr, &UIP_IP_BUF->srcipaddr);
+      uip_ipaddr_copy(&UIP_IP_BUF->srcipaddr, &UIP_ND6_NS_BUF->tgtipaddr);
+      flags = UIP_ND6_NA_FLAG_SOLICITED | UIP_ND6_NA_FLAG_OVERRIDE;
+      goto create_na;
+    } else {
+#if UIP_CONF_IPV6_CHECKS
+      PRINTF("NS received is bad\n");
+      goto discard;
+#endif /* UIP_CONF_IPV6_CHECKS */
+    }
+  } else {
+    goto discard;
+  }
+
+
+create_na:
+    /* If the node is a router it should set R flag in NAs */
+#if UIP_CONF_ROUTER
+    flags = flags | UIP_ND6_NA_FLAG_ROUTER;
+#endif
+  uip_ext_len = 0;
+  UIP_IP_BUF->vtc = 0x60;
+  UIP_IP_BUF->tcflow = 0;
+  UIP_IP_BUF->flow = 0;
+  UIP_IP_BUF->len[0] = 0;       /* length will not be more than 255 */
+  UIP_IP_BUF->len[1] = UIP_ICMPH_LEN + UIP_ND6_NA_LEN + UIP_ND6_OPT_LLAO_LEN;
+  UIP_IP_BUF->proto = UIP_PROTO_ICMP6;
+  UIP_IP_BUF->ttl = UIP_ND6_HOP_LIMIT;
+
+  UIP_ICMP_BUF->type = ICMP6_NA;
+  UIP_ICMP_BUF->icode = 0;
+
+  UIP_ND6_NA_BUF->flagsreserved = flags;
+  memcpy(&UIP_ND6_NA_BUF->tgtipaddr, &addr->ipaddr, sizeof(uip_ipaddr_t));
+
+  create_llao(&uip_buf[uip_l2_l3_icmp_hdr_len + UIP_ND6_NA_LEN],
+              UIP_ND6_OPT_TLLAO);
+
+  UIP_ICMP_BUF->icmpchksum = 0;
+  UIP_ICMP_BUF->icmpchksum = ~uip_icmp6chksum();
+
+  uip_len =
+    UIP_IPH_LEN + UIP_ICMPH_LEN + UIP_ND6_NA_LEN + UIP_ND6_OPT_LLAO_LEN;
+
+  UIP_STAT(++uip_stat.nd6.sent);
+  PRINTF("Sending NA to ");
+  PRINT6ADDR(&UIP_IP_BUF->destipaddr);
+  PRINTF(" from ");
+  PRINT6ADDR(&UIP_IP_BUF->srcipaddr);
+  PRINTF(" with target address ");
+  PRINT6ADDR(&UIP_ND6_NA_BUF->tgtipaddr);
+  PRINTF("\n");
+  return;
+
+discard:
+  uip_len = 0;
+  return;
+}
+
+
+
+/*------------------------------------------------------------------*/
+void
+uip_nd6_ns_output(uip_ipaddr_t * src, uip_ipaddr_t * dest, uip_ipaddr_t * tgt)
+{
+  uip_ext_len = 0;
+  UIP_IP_BUF->vtc = 0x60;
+  UIP_IP_BUF->tcflow = 0;
+  UIP_IP_BUF->flow = 0;
+  UIP_IP_BUF->proto = UIP_PROTO_ICMP6;
+  UIP_IP_BUF->ttl = UIP_ND6_HOP_LIMIT;
+
+  if(dest == NULL) {
+    uip_create_solicited_node(tgt, &UIP_IP_BUF->destipaddr);
+  } else {
+    uip_ipaddr_copy(&UIP_IP_BUF->destipaddr, dest);
+  }
+  UIP_ICMP_BUF->type = ICMP6_NS;
+  UIP_ICMP_BUF->icode = 0;
+  UIP_ND6_NS_BUF->reserved = 0;
+  uip_ipaddr_copy((uip_ipaddr_t *) &UIP_ND6_NS_BUF->tgtipaddr, tgt);
+  UIP_IP_BUF->len[0] = 0;       /* length will not be more than 255 */
+  /*
+   * check if we add a SLLAO option: for DAD, MUST NOT, for NUD, MAY
+   * (here yes), for Address resolution , MUST 
+   */
+  if(!(uip_ds6_is_my_addr(tgt))) {
+    if(src != NULL) {
+      uip_ipaddr_copy(&UIP_IP_BUF->srcipaddr, src);
+    } else {
+      uip_ds6_select_src(&UIP_IP_BUF->srcipaddr, &UIP_IP_BUF->destipaddr);
+    }
+    if (uip_is_addr_unspecified(&UIP_IP_BUF->srcipaddr)) {
+      PRINTF("Dropping NS due to no suitable source address\n");
+      uip_len = 0;
+      return;
+    }
+    UIP_IP_BUF->len[1] =
+      UIP_ICMPH_LEN + UIP_ND6_NS_LEN + UIP_ND6_OPT_LLAO_LEN;
+
+    create_llao(&uip_buf[uip_l2_l3_icmp_hdr_len + UIP_ND6_NS_LEN],
+		UIP_ND6_OPT_SLLAO);
+
+    uip_len =
+      UIP_IPH_LEN + UIP_ICMPH_LEN + UIP_ND6_NS_LEN + UIP_ND6_OPT_LLAO_LEN;
+  } else {
+    uip_create_unspecified(&UIP_IP_BUF->srcipaddr);
+    UIP_IP_BUF->len[1] = UIP_ICMPH_LEN + UIP_ND6_NS_LEN;
+    uip_len = UIP_IPH_LEN + UIP_ICMPH_LEN + UIP_ND6_NS_LEN;
+  }
+
+  UIP_ICMP_BUF->icmpchksum = 0;
+  UIP_ICMP_BUF->icmpchksum = ~uip_icmp6chksum();
+
+  UIP_STAT(++uip_stat.nd6.sent);
+  PRINTF("Sending NS to ");
+  PRINT6ADDR(&UIP_IP_BUF->destipaddr);
+  PRINTF(" from ");
+  PRINT6ADDR(&UIP_IP_BUF->srcipaddr);
+  PRINTF(" with target address ");
+  PRINT6ADDR(tgt);
+  PRINTF("\n");
+  return;
+}
+
+
+
+/*------------------------------------------------------------------*/
+void
+uip_nd6_na_input(void)
+{
+  uint8_t is_llchange;
+  uint8_t is_router;
+  uint8_t is_solicited;
+  uint8_t is_override;
+
+  PRINTF("Received NA from ");
+  PRINT6ADDR(&UIP_IP_BUF->srcipaddr);
+  PRINTF(" to ");
+  PRINT6ADDR(&UIP_IP_BUF->destipaddr);
+  PRINTF(" with target address ");
+  PRINT6ADDR((uip_ipaddr_t *) (&UIP_ND6_NA_BUF->tgtipaddr));
+  PRINTF("\n");
+  UIP_STAT(++uip_stat.nd6.recv);
+
+  /* 
+   * booleans. the three last one are not 0 or 1 but 0 or 0x80, 0x40, 0x20
+   * but it works. Be careful though, do not use tests such as is_router == 1 
+   */
+  is_llchange = 0;
+  is_router = ((UIP_ND6_NA_BUF->flagsreserved & UIP_ND6_NA_FLAG_ROUTER));
+  is_solicited =
+    ((UIP_ND6_NA_BUF->flagsreserved & UIP_ND6_NA_FLAG_SOLICITED));
+  is_override =
+    ((UIP_ND6_NA_BUF->flagsreserved & UIP_ND6_NA_FLAG_OVERRIDE));
+
+#if UIP_CONF_IPV6_CHECKS
+  if((UIP_IP_BUF->ttl != UIP_ND6_HOP_LIMIT) ||
+     (UIP_ICMP_BUF->icode != 0) ||
+     (uip_is_addr_mcast(&UIP_ND6_NA_BUF->tgtipaddr)) ||
+     (is_solicited && uip_is_addr_mcast(&UIP_IP_BUF->destipaddr))) {
+    PRINTF("NA received is bad\n");
+    goto discard;
+  }
+#endif /*UIP_CONF_IPV6_CHECKS */
+
+  /* Options processing: we handle TLLAO, and must ignore others */
+  nd6_opt_offset = UIP_ND6_NA_LEN;
+  nd6_opt_llao = NULL;
+  while(uip_l3_icmp_hdr_len + nd6_opt_offset < uip_len) {
+#if UIP_CONF_IPV6_CHECKS
+    if(UIP_ND6_OPT_HDR_BUF->len == 0) {
+      PRINTF("NA received is bad\n");
+      goto discard;
+    }
+#endif /*UIP_CONF_IPV6_CHECKS */
+    switch (UIP_ND6_OPT_HDR_BUF->type) {
+    case UIP_ND6_OPT_TLLAO:
+      nd6_opt_llao = (uint8_t *)UIP_ND6_OPT_HDR_BUF;
+      break;
+    default:
+      PRINTF("ND option not supported in NA\n");
+      break;
+    }
+    nd6_opt_offset += (UIP_ND6_OPT_HDR_BUF->len << 3);
+  }
+  addr = uip_ds6_addr_lookup(&UIP_ND6_NA_BUF->tgtipaddr);
+  /* Message processing, including TLLAO if any */
+  if(addr != NULL) {
+#if UIP_ND6_DEF_MAXDADNS > 0
+    if(addr->state == ADDR_TENTATIVE) {
+      uip_ds6_dad_failed(addr);
+    }
+#endif /*UIP_ND6_DEF_MAXDADNS > 0 */
+    PRINTF("NA received is bad\n");
+    goto discard;
+  } else {
+    uip_lladdr_t *lladdr;
+    nbr = uip_ds6_nbr_lookup(&UIP_ND6_NA_BUF->tgtipaddr);
+    lladdr = uip_ds6_nbr_get_ll(nbr);
+    if(nbr == NULL) {
+      goto discard;
+    }
+    if(nd6_opt_llao != 0) {
+      is_llchange =
+        memcmp(&nd6_opt_llao[UIP_ND6_OPT_DATA_OFFSET], (void *)lladdr,
+               UIP_LLADDR_LEN);
+    }
+    if(nbr->state == NBR_INCOMPLETE) {
+      if(nd6_opt_llao == NULL) {
+        goto discard;
+      }
+      memcpy(lladdr, &nd6_opt_llao[UIP_ND6_OPT_DATA_OFFSET],
+	     UIP_LLADDR_LEN);
+      if(is_solicited) {
+        nbr->state = NBR_REACHABLE;
+        nbr->nscount = 0;
+
+        /* reachable time is stored in ms */
+        stimer_set(&(nbr->reachable), uip_ds6_if.reachable_time / 1000);
+
+      } else {
+        nbr->state = NBR_STALE;
+      }
+      nbr->isrouter = is_router;
+    } else {
+      if(!is_override && is_llchange) {
+        if(nbr->state == NBR_REACHABLE) {
+          nbr->state = NBR_STALE;
+        }
+        goto discard;
+      } else {
+        if(is_override || (!is_override && nd6_opt_llao != 0 && !is_llchange)
+           || nd6_opt_llao == 0) {
+          if(nd6_opt_llao != 0) {
+            memcpy(lladdr, &nd6_opt_llao[UIP_ND6_OPT_DATA_OFFSET],
+		   UIP_LLADDR_LEN);
+          }
+          if(is_solicited) {
+            nbr->state = NBR_REACHABLE;
+            /* reachable time is stored in ms */
+            stimer_set(&(nbr->reachable), uip_ds6_if.reachable_time / 1000);
+          } else {
+            if(nd6_opt_llao != 0 && is_llchange) {
+              nbr->state = NBR_STALE;
+            }
+          }
+        }
+      }
+      if(nbr->isrouter && !is_router) {
+        defrt = uip_ds6_defrt_lookup(&UIP_IP_BUF->srcipaddr);
+        if(defrt != NULL) {
+          uip_ds6_defrt_rm(defrt);
+        }
+      }
+      nbr->isrouter = is_router;
+    }
+  }
+#if UIP_CONF_IPV6_QUEUE_PKT
+  /* The nbr is now reachable, check if we had buffered a pkt for it */
+  /*if(nbr->queue_buf_len != 0) {
+    uip_len = nbr->queue_buf_len;
+    memcpy(UIP_IP_BUF, nbr->queue_buf, uip_len);
+    nbr->queue_buf_len = 0;
+    return;
+    }*/
+  if(uip_packetqueue_buflen(&nbr->packethandle) != 0) {
+    uip_len = uip_packetqueue_buflen(&nbr->packethandle);
+    memcpy(UIP_IP_BUF, uip_packetqueue_buf(&nbr->packethandle), uip_len);
+    uip_packetqueue_free(&nbr->packethandle);
+    return;
+  }
+  
+#endif /*UIP_CONF_IPV6_QUEUE_PKT */
+
+discard:
+  uip_len = 0;
+  return;
+}
+
+
+#if UIP_CONF_ROUTER
+#if UIP_ND6_SEND_RA
+/*---------------------------------------------------------------------------*/
+void
+uip_nd6_rs_input(void)
+{
+
+  PRINTF("Received RS from");
+  PRINT6ADDR(&UIP_IP_BUF->srcipaddr);
+  PRINTF("to");
+  PRINT6ADDR(&UIP_IP_BUF->destipaddr);
+  PRINTF("\n");
+  UIP_STAT(++uip_stat.nd6.recv);
+
+
+#if UIP_CONF_IPV6_CHECKS
+  /*
+   * Check hop limit / icmp code 
+   * target address must not be multicast
+   * if the NA is solicited, dest must not be multicast
+   */
+  if((UIP_IP_BUF->ttl != UIP_ND6_HOP_LIMIT) || (UIP_ICMP_BUF->icode != 0)) {
+    PRINTF("RS received is bad\n");
+    goto discard;
+  }
+#endif /*UIP_CONF_IPV6_CHECKS */
+
+  /* Only valid option is Source Link-Layer Address option any thing
+     else is discarded */
+  nd6_opt_offset = UIP_ND6_RS_LEN;
+  nd6_opt_llao = NULL;
+
+  while(uip_l3_icmp_hdr_len + nd6_opt_offset < uip_len) {
+#if UIP_CONF_IPV6_CHECKS
+    if(UIP_ND6_OPT_HDR_BUF->len == 0) {
+      PRINTF("RS received is bad\n");
+      goto discard;
+    }
+#endif /*UIP_CONF_IPV6_CHECKS */
+    switch (UIP_ND6_OPT_HDR_BUF->type) {
+    case UIP_ND6_OPT_SLLAO:
+      nd6_opt_llao = (uint8_t *)UIP_ND6_OPT_HDR_BUF;
+      break;
+    default:
+      PRINTF("ND option not supported in RS\n");
+      break;
+    }
+    nd6_opt_offset += (UIP_ND6_OPT_HDR_BUF->len << 3);
+  }
+  /* Options processing: only SLLAO */
+  if(nd6_opt_llao != NULL) {
+#if UIP_CONF_IPV6_CHECKS
+    if(uip_is_addr_unspecified(&UIP_IP_BUF->srcipaddr)) {
+      PRINTF("RS received is bad\n");
+      goto discard;
+    } else {
+#endif /*UIP_CONF_IPV6_CHECKS */
+      if((nbr = uip_ds6_nbr_lookup(&UIP_IP_BUF->srcipaddr)) == NULL) {
+        /* we need to add the neighbor */
+        uip_ds6_nbr_add(&UIP_IP_BUF->srcipaddr,
+                        (uip_lladdr_t *)&nd6_opt_llao[UIP_ND6_OPT_DATA_OFFSET], 0, NBR_STALE);
+      } else {
+        /* If LL address changed, set neighbor state to stale */
+        if(memcmp(&nd6_opt_llao[UIP_ND6_OPT_DATA_OFFSET],
+            uip_ds6_nbr_get_ll(nbr), UIP_LLADDR_LEN) != 0) {
+          uip_ds6_nbr_t nbr_data = *nbr;
+          uip_ds6_nbr_rm(nbr);
+          nbr = uip_ds6_nbr_add(&UIP_IP_BUF->srcipaddr,
+                                (uip_lladdr_t *)&nd6_opt_llao[UIP_ND6_OPT_DATA_OFFSET], 0, NBR_STALE);
+          nbr->reachable = nbr_data.reachable;
+          nbr->sendns = nbr_data.sendns;
+          nbr->nscount = nbr_data.nscount;
+        }
+        nbr->isrouter = 0;
+      }
+#if UIP_CONF_IPV6_CHECKS
+    }
+#endif /*UIP_CONF_IPV6_CHECKS */
+  }
+
+  /* Schedule a sollicited RA */
+  uip_ds6_send_ra_sollicited();
+
+discard:
+  uip_len = 0;
+  return;
+}
+
+/*---------------------------------------------------------------------------*/
+void
+uip_nd6_ra_output(uip_ipaddr_t * dest)
+{
+
+  UIP_IP_BUF->vtc = 0x60;
+  UIP_IP_BUF->tcflow = 0;
+  UIP_IP_BUF->flow = 0;
+  UIP_IP_BUF->proto = UIP_PROTO_ICMP6;
+  UIP_IP_BUF->ttl = UIP_ND6_HOP_LIMIT;
+
+  if(dest == NULL) {
+    uip_create_linklocal_allnodes_mcast(&UIP_IP_BUF->destipaddr);
+  } else {
+    /* For sollicited RA */
+    uip_ipaddr_copy(&UIP_IP_BUF->destipaddr, dest);
+  }
+  uip_ds6_select_src(&UIP_IP_BUF->srcipaddr, &UIP_IP_BUF->destipaddr);
+
+  UIP_ICMP_BUF->type = ICMP6_RA;
+  UIP_ICMP_BUF->icode = 0;
+
+  UIP_ND6_RA_BUF->cur_ttl = uip_ds6_if.cur_hop_limit;
+
+  UIP_ND6_RA_BUF->flags_reserved =
+    (UIP_ND6_M_FLAG << 7) | (UIP_ND6_O_FLAG << 6);
+
+  UIP_ND6_RA_BUF->router_lifetime = uip_htons(UIP_ND6_ROUTER_LIFETIME);
+  //UIP_ND6_RA_BUF->reachable_time = uip_htonl(uip_ds6_if.reachable_time);
+  //UIP_ND6_RA_BUF->retrans_timer = uip_htonl(uip_ds6_if.retrans_timer);
+  UIP_ND6_RA_BUF->reachable_time = 0;
+  UIP_ND6_RA_BUF->retrans_timer = 0;
+
+  uip_len = UIP_IPH_LEN + UIP_ICMPH_LEN + UIP_ND6_RA_LEN;
+  nd6_opt_offset = UIP_ND6_RA_LEN;
+
+
+#if !UIP_CONF_ROUTER
+  /* Prefix list */
+  for(prefix = uip_ds6_prefix_list;
+      prefix < uip_ds6_prefix_list + UIP_DS6_PREFIX_NB; prefix++) {
+    if((prefix->isused) && (prefix->advertise)) {
+      UIP_ND6_OPT_PREFIX_BUF->type = UIP_ND6_OPT_PREFIX_INFO;
+      UIP_ND6_OPT_PREFIX_BUF->len = UIP_ND6_OPT_PREFIX_INFO_LEN / 8;
+      UIP_ND6_OPT_PREFIX_BUF->preflen = prefix->length;
+      UIP_ND6_OPT_PREFIX_BUF->flagsreserved1 = prefix->l_a_reserved;
+      UIP_ND6_OPT_PREFIX_BUF->validlt = uip_htonl(prefix->vlifetime);
+      UIP_ND6_OPT_PREFIX_BUF->preferredlt = uip_htonl(prefix->plifetime);
+      UIP_ND6_OPT_PREFIX_BUF->reserved2 = 0;
+      uip_ipaddr_copy(&(UIP_ND6_OPT_PREFIX_BUF->prefix), &(prefix->ipaddr));
+      nd6_opt_offset += UIP_ND6_OPT_PREFIX_INFO_LEN;
+      uip_len += UIP_ND6_OPT_PREFIX_INFO_LEN;
+    }
+  }
+#endif /* !UIP_CONF_ROUTER */
+
+  /* Source link-layer option */
+  create_llao((uint8_t *)UIP_ND6_OPT_HDR_BUF, UIP_ND6_OPT_SLLAO);
+
+  uip_len += UIP_ND6_OPT_LLAO_LEN;
+  nd6_opt_offset += UIP_ND6_OPT_LLAO_LEN;
+
+  /* MTU */
+  UIP_ND6_OPT_MTU_BUF->type = UIP_ND6_OPT_MTU;
+  UIP_ND6_OPT_MTU_BUF->len = UIP_ND6_OPT_MTU_LEN >> 3;
+  UIP_ND6_OPT_MTU_BUF->reserved = 0;
+  //UIP_ND6_OPT_MTU_BUF->mtu = uip_htonl(uip_ds6_if.link_mtu);
+  UIP_ND6_OPT_MTU_BUF->mtu = uip_htonl(1500);
+
+  uip_len += UIP_ND6_OPT_MTU_LEN;
+  nd6_opt_offset += UIP_ND6_OPT_MTU_LEN;
+  UIP_IP_BUF->len[0] = ((uip_len - UIP_IPH_LEN) >> 8);
+  UIP_IP_BUF->len[1] = ((uip_len - UIP_IPH_LEN) & 0xff);
+
+  /*ICMP checksum */
+  UIP_ICMP_BUF->icmpchksum = 0;
+  UIP_ICMP_BUF->icmpchksum = ~uip_icmp6chksum();
+
+  UIP_STAT(++uip_stat.nd6.sent);
+  PRINTF("Sending RA to");
+  PRINT6ADDR(&UIP_IP_BUF->destipaddr);
+  PRINTF("from");
+  PRINT6ADDR(&UIP_IP_BUF->srcipaddr);
+  PRINTF("\n");
+  return;
+}
+#endif /* UIP_ND6_SEND_RA */
+#endif /* UIP_CONF_ROUTER */
+
+#if !UIP_CONF_ROUTER
+/*---------------------------------------------------------------------------*/
+void
+uip_nd6_rs_output(void)
+{
+  UIP_IP_BUF->vtc = 0x60;
+  UIP_IP_BUF->tcflow = 0;
+  UIP_IP_BUF->flow = 0;
+  UIP_IP_BUF->proto = UIP_PROTO_ICMP6;
+  UIP_IP_BUF->ttl = UIP_ND6_HOP_LIMIT;
+  uip_create_linklocal_allrouters_mcast(&UIP_IP_BUF->destipaddr);
+  uip_ds6_select_src(&UIP_IP_BUF->srcipaddr, &UIP_IP_BUF->destipaddr);
+  UIP_ICMP_BUF->type = ICMP6_RS;
+  UIP_ICMP_BUF->icode = 0;
+  UIP_IP_BUF->len[0] = 0;       /* length will not be more than 255 */
+
+  if(uip_is_addr_unspecified(&UIP_IP_BUF->srcipaddr)) {
+    UIP_IP_BUF->len[1] = UIP_ICMPH_LEN + UIP_ND6_RS_LEN;
+    uip_len = uip_l3_icmp_hdr_len + UIP_ND6_RS_LEN;
+  } else {
+    uip_len = uip_l3_icmp_hdr_len + UIP_ND6_RS_LEN + UIP_ND6_OPT_LLAO_LEN;
+    UIP_IP_BUF->len[1] =
+      UIP_ICMPH_LEN + UIP_ND6_RS_LEN + UIP_ND6_OPT_LLAO_LEN;
+
+    create_llao(&uip_buf[uip_l2_l3_icmp_hdr_len + UIP_ND6_RS_LEN],
+      UIP_ND6_OPT_SLLAO);
+  }
+
+  UIP_ICMP_BUF->icmpchksum = 0;
+  UIP_ICMP_BUF->icmpchksum = ~uip_icmp6chksum();
+
+  UIP_STAT(++uip_stat.nd6.sent);
+  PRINTF("Sending RS to ");
+  PRINT6ADDR(&UIP_IP_BUF->destipaddr);
+  PRINTF(" from ");
+  PRINT6ADDR(&UIP_IP_BUF->srcipaddr);
+  PRINTF("\n");
+  return;
+}
+
+
+/*---------------------------------------------------------------------------*/
+void
+uip_nd6_ra_input(void)
+{
+  PRINTF("Received RA from ");
+  PRINT6ADDR(&UIP_IP_BUF->srcipaddr);
+  PRINTF(" to ");
+  PRINT6ADDR(&UIP_IP_BUF->destipaddr);
+  PRINTF("\n");
+  UIP_STAT(++uip_stat.nd6.recv);
+
+#if UIP_CONF_IPV6_CHECKS
+  if((UIP_IP_BUF->ttl != UIP_ND6_HOP_LIMIT) ||
+     (!uip_is_addr_link_local(&UIP_IP_BUF->srcipaddr)) ||
+     (UIP_ICMP_BUF->icode != 0)) {
+    PRINTF("RA received is bad");
+    goto discard;
+  }
+#endif /*UIP_CONF_IPV6_CHECKS */
+
+  if(UIP_ND6_RA_BUF->cur_ttl != 0) {
+    uip_ds6_if.cur_hop_limit = UIP_ND6_RA_BUF->cur_ttl;
+    PRINTF("uip_ds6_if.cur_hop_limit %u\n", uip_ds6_if.cur_hop_limit);
+  }
+
+  if(UIP_ND6_RA_BUF->reachable_time != 0) {
+    if(uip_ds6_if.base_reachable_time !=
+       uip_ntohl(UIP_ND6_RA_BUF->reachable_time)) {
+      uip_ds6_if.base_reachable_time = uip_ntohl(UIP_ND6_RA_BUF->reachable_time);
+      uip_ds6_if.reachable_time = uip_ds6_compute_reachable_time();
+    }
+  }
+  if(UIP_ND6_RA_BUF->retrans_timer != 0) {
+    uip_ds6_if.retrans_timer = uip_ntohl(UIP_ND6_RA_BUF->retrans_timer);
+  }
+
+  /* Options processing */
+  nd6_opt_offset = UIP_ND6_RA_LEN;
+  while(uip_l3_icmp_hdr_len + nd6_opt_offset < uip_len) {
+    if(UIP_ND6_OPT_HDR_BUF->len == 0) {
+      PRINTF("RA received is bad");
+      goto discard;
+    }
+    switch (UIP_ND6_OPT_HDR_BUF->type) {
+    case UIP_ND6_OPT_SLLAO:
+      PRINTF("Processing SLLAO option in RA\n");
+      nd6_opt_llao = (uint8_t *) UIP_ND6_OPT_HDR_BUF;
+      nbr = uip_ds6_nbr_lookup(&UIP_IP_BUF->srcipaddr);
+      if(nbr == NULL) {
+        nbr = uip_ds6_nbr_add(&UIP_IP_BUF->srcipaddr,
+                              (uip_lladdr_t *)&nd6_opt_llao[UIP_ND6_OPT_DATA_OFFSET],
+			      1, NBR_STALE);
+      } else {
+        if(nbr->state == NBR_INCOMPLETE) {
+          nbr->state = NBR_STALE;
+        }
+        uip_lladdr_t *lladdr = uip_ds6_nbr_get_ll(nbr);
+        if(memcmp(&nd6_opt_llao[UIP_ND6_OPT_DATA_OFFSET],
+		  lladdr, UIP_LLADDR_LEN) != 0) {
+          memcpy(lladdr, &nd6_opt_llao[UIP_ND6_OPT_DATA_OFFSET],
+		 UIP_LLADDR_LEN);
+          nbr->state = NBR_STALE;
+        }
+        nbr->isrouter = 1;
+      }
+      break;
+    case UIP_ND6_OPT_MTU:
+      PRINTF("Processing MTU option in RA\n");
+      uip_ds6_if.link_mtu =
+        uip_ntohl(((uip_nd6_opt_mtu *) UIP_ND6_OPT_HDR_BUF)->mtu);
+      break;
+    case UIP_ND6_OPT_PREFIX_INFO:
+      PRINTF("Processing PREFIX option in RA\n");
+      nd6_opt_prefix_info = (uip_nd6_opt_prefix_info *) UIP_ND6_OPT_HDR_BUF;
+      if((uip_ntohl(nd6_opt_prefix_info->validlt) >=
+          uip_ntohl(nd6_opt_prefix_info->preferredlt))
+         && (!uip_is_addr_link_local(&nd6_opt_prefix_info->prefix))) {
+        /* on-link flag related processing */
+        if(nd6_opt_prefix_info->flagsreserved1 & UIP_ND6_RA_FLAG_ONLINK) {
+          prefix =
+            uip_ds6_prefix_lookup(&nd6_opt_prefix_info->prefix,
+                                  nd6_opt_prefix_info->preflen);
+          if(prefix == NULL) {
+            if(nd6_opt_prefix_info->validlt != 0) {
+              if(nd6_opt_prefix_info->validlt != UIP_ND6_INFINITE_LIFETIME) {
+                prefix = uip_ds6_prefix_add(&nd6_opt_prefix_info->prefix,
+                                            nd6_opt_prefix_info->preflen,
+                                            uip_ntohl(nd6_opt_prefix_info->
+                                                  validlt));
+              } else {
+                prefix = uip_ds6_prefix_add(&nd6_opt_prefix_info->prefix,
+                                            nd6_opt_prefix_info->preflen, 0);
+              }
+            }
+          } else {
+            switch (nd6_opt_prefix_info->validlt) {
+            case 0:
+              uip_ds6_prefix_rm(prefix);
+              break;
+            case UIP_ND6_INFINITE_LIFETIME:
+              prefix->isinfinite = 1;
+              break;
+            default:
+              PRINTF("Updating timer of prefix ");
+              PRINT6ADDR(&prefix->ipaddr);
+              PRINTF(" new value %lu\n", uip_ntohl(nd6_opt_prefix_info->validlt));
+              stimer_set(&prefix->vlifetime,
+                         uip_ntohl(nd6_opt_prefix_info->validlt));
+              prefix->isinfinite = 0;
+              break;
+            }
+          }
+        }
+        /* End of on-link flag related processing */
+        /* autonomous flag related processing */
+        if((nd6_opt_prefix_info->flagsreserved1 & UIP_ND6_RA_FLAG_AUTONOMOUS)
+           && (nd6_opt_prefix_info->validlt != 0)
+           && (nd6_opt_prefix_info->preflen == UIP_DEFAULT_PREFIX_LEN)) {
+	  
+          uip_ipaddr_copy(&ipaddr, &nd6_opt_prefix_info->prefix);
+          uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
+          addr = uip_ds6_addr_lookup(&ipaddr);
+          if((addr != NULL) && (addr->type == ADDR_AUTOCONF)) {
+            if(nd6_opt_prefix_info->validlt != UIP_ND6_INFINITE_LIFETIME) {
+              /* The processing below is defined in RFC4862 section 5.5.3 e */
+              if((uip_ntohl(nd6_opt_prefix_info->validlt) > 2 * 60 * 60) ||
+                 (uip_ntohl(nd6_opt_prefix_info->validlt) >
+                  stimer_remaining(&addr->vlifetime))) {
+                PRINTF("Updating timer of address ");
+                PRINT6ADDR(&addr->ipaddr);
+                PRINTF(" new value %lu\n",
+                       uip_ntohl(nd6_opt_prefix_info->validlt));
+                stimer_set(&addr->vlifetime,
+                           uip_ntohl(nd6_opt_prefix_info->validlt));
+              } else {
+                stimer_set(&addr->vlifetime, 2 * 60 * 60);
+                PRINTF("Updating timer of address ");
+                PRINT6ADDR(&addr->ipaddr);
+                PRINTF("new value %lu\n", (unsigned long)(2 * 60 * 60));
+              }
+              addr->isinfinite = 0;
+            } else {
+              addr->isinfinite = 1;
+            }
+          } else {
+            if(uip_ntohl(nd6_opt_prefix_info->validlt) ==
+               UIP_ND6_INFINITE_LIFETIME) {
+              uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
+            } else {
+              uip_ds6_addr_add(&ipaddr, uip_ntohl(nd6_opt_prefix_info->validlt),
+                               ADDR_AUTOCONF);
+            }
+          }
+        }
+        /* End of autonomous flag related processing */
+      }
+      break;
+    default:
+      PRINTF("ND option not supported in RA\n");
+      break;
+    }
+    nd6_opt_offset += (UIP_ND6_OPT_HDR_BUF->len << 3);
+  }
+
+  defrt = uip_ds6_defrt_lookup(&UIP_IP_BUF->srcipaddr);
+  if(UIP_ND6_RA_BUF->router_lifetime != 0) {
+    if(nbr != NULL) {
+      nbr->isrouter = 1;
+    }
+    if(defrt == NULL) {
+      uip_ds6_defrt_add(&UIP_IP_BUF->srcipaddr,
+                        (unsigned
+                         long)(uip_ntohs(UIP_ND6_RA_BUF->router_lifetime)));
+    } else {
+      stimer_set(&(defrt->lifetime),
+                 (unsigned long)(uip_ntohs(UIP_ND6_RA_BUF->router_lifetime)));
+    }
+  } else {
+    if(defrt != NULL) {
+      uip_ds6_defrt_rm(defrt);
+    }
+  }
+
+#if UIP_CONF_IPV6_QUEUE_PKT
+  /* If the nbr just became reachable (e.g. it was in NBR_INCOMPLETE state
+   * and we got a SLLAO), check if we had buffered a pkt for it */
+  /*  if((nbr != NULL) && (nbr->queue_buf_len != 0)) {
+    uip_len = nbr->queue_buf_len;
+    memcpy(UIP_IP_BUF, nbr->queue_buf, uip_len);
+    nbr->queue_buf_len = 0;
+    return;
+    }*/
+  if(nbr != NULL && uip_packetqueue_buflen(&nbr->packethandle) != 0) {
+    uip_len = uip_packetqueue_buflen(&nbr->packethandle);
+    memcpy(UIP_IP_BUF, uip_packetqueue_buf(&nbr->packethandle), uip_len);
+    uip_packetqueue_free(&nbr->packethandle);
+    return;
+  }
+
+#endif /*UIP_CONF_IPV6_QUEUE_PKT */
+
+discard:
+  uip_len = 0;
+  return;
+}
+#endif /* !UIP_CONF_ROUTER */
+
+ /** @} */
+#endif /* UIP_CONF_IPV6 */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/uip-nd6.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/uip-nd6.h
@@ -1,0 +1,567 @@
+/**
+ * \addtogroup uip6
+ * @{
+ */
+
+/**
+ * \file
+ *         Neighbor discovery (RFC 4861)
+ * \author Julien Abeille <jabeille@cisco.com>
+ * \author Mathilde Durvy <mdurvy@cisco.com>
+ */
+
+/*
+ * Copyright (c) 2006, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+#ifndef __UIP_ND6_H__
+#define __UIP_ND6_H__
+
+#include "net/uip.h"
+#include "sys/stimer.h"
+/**
+ *  \name General
+ * @{
+ */
+/** \brief HOP LIMIT to be used when sending ND messages (255) */
+#define UIP_ND6_HOP_LIMIT               255
+/** \brief INFINITE lifetime */
+#define UIP_ND6_INFINITE_LIFETIME       0xFFFFFFFF
+/** @} */
+
+/** \name RFC 4861 Host constant */
+/** @{ */
+#define UIP_ND6_MAX_RTR_SOLICITATION_DELAY 1
+#define UIP_ND6_RTR_SOLICITATION_INTERVAL  4
+#define UIP_ND6_MAX_RTR_SOLICITATIONS	   3
+/** @} */
+
+/** \name RFC 4861 Router constants */
+/** @{ */
+#ifndef UIP_CONF_ND6_SEND_RA
+#define UIP_ND6_SEND_RA                     1   /* enable/disable RA sending */
+#else
+#define UIP_ND6_SEND_RA UIP_CONF_ND6_SEND_RA
+#endif
+#ifndef UIP_CONF_ND6_SEND_NA
+#define UIP_ND6_SEND_NA                     1   /* enable/disable NA sending */
+#else
+#define UIP_ND6_SEND_NA UIP_CONF_ND6_SEND_NA
+#endif
+#define UIP_ND6_MAX_RA_INTERVAL             600
+#define UIP_ND6_MIN_RA_INTERVAL             (UIP_ND6_MAX_RA_INTERVAL / 3)
+#define UIP_ND6_M_FLAG                      0
+#define UIP_ND6_O_FLAG                      0
+#define UIP_ND6_ROUTER_LIFETIME             3 * UIP_ND6_MAX_RA_INTERVAL
+
+#define UIP_ND6_MAX_INITIAL_RA_INTERVAL     16  /*seconds*/
+#define UIP_ND6_MAX_INITIAL_RAS             3   /*transmissions*/
+#define UIP_ND6_MIN_DELAY_BETWEEN_RAS       3   /*seconds*/
+//#define UIP_ND6_MAX_RA_DELAY_TIME           0.5 /*seconds*/
+#define UIP_ND6_MAX_RA_DELAY_TIME_MS        500 /*milli seconds*/
+/** @} */
+
+#ifndef UIP_CONF_ND6_DEF_MAXDADNS
+/** \brief Do not try DAD when using EUI-64 as allowed by draft-ietf-6lowpan-nd-15 section 8.2 */
+#if UIP_CONF_LL_802154
+#define UIP_ND6_DEF_MAXDADNS 0
+#else /* UIP_CONF_LL_802154 */
+#define UIP_ND6_DEF_MAXDADNS UIP_ND6_SEND_NA
+#endif /* UIP_CONF_LL_802154 */
+#else /* UIP_CONF_ND6_DEF_MAXDADNS */
+#define UIP_ND6_DEF_MAXDADNS UIP_CONF_ND6_DEF_MAXDADNS
+#endif /* UIP_CONF_ND6_DEF_MAXDADNS */
+
+/** \name RFC 4861 Node constant */
+#define UIP_ND6_MAX_MULTICAST_SOLICIT  3
+
+#ifdef UIP_CONF_ND6_MAX_UNICAST_SOLICIT
+#define UIP_ND6_MAX_UNICAST_SOLICIT    UIP_CONF_ND6_MAX_UNICAST_SOLICIT
+#else /* UIP_CONF_ND6_MAX_UNICAST_SOLICIT */
+#define UIP_ND6_MAX_UNICAST_SOLICIT    3
+#endif /* UIP_CONF_ND6_MAX_UNICAST_SOLICIT */
+
+#ifdef UIP_CONF_ND6_REACHABLE_TIME
+#define UIP_ND6_REACHABLE_TIME         UIP_CONF_ND6_REACHABLE_TIME
+#else
+#define UIP_ND6_REACHABLE_TIME         30000
+#endif
+
+#ifdef UIP_CONF_ND6_RETRANS_TIMER
+#define UIP_ND6_RETRANS_TIMER	       UIP_CONF_ND6_RETRANS_TIMER
+#else
+#define UIP_ND6_RETRANS_TIMER	       1000
+#endif
+
+#define UIP_ND6_DELAY_FIRST_PROBE_TIME 5
+#define UIP_ND6_MIN_RANDOM_FACTOR(x)   (x / 2)
+#define UIP_ND6_MAX_RANDOM_FACTOR(x)   ((x) + (x) / 2)
+/** @} */
+
+
+/** \name ND6 option types */
+/** @{ */
+#define UIP_ND6_OPT_SLLAO               1
+#define UIP_ND6_OPT_TLLAO               2
+#define UIP_ND6_OPT_PREFIX_INFO         3
+#define UIP_ND6_OPT_REDIRECTED_HDR      4
+#define UIP_ND6_OPT_MTU                 5
+/** @} */
+
+/** \name ND6 option types */
+/** @{ */
+#define UIP_ND6_OPT_TYPE_OFFSET         0
+#define UIP_ND6_OPT_LEN_OFFSET          1
+#define UIP_ND6_OPT_DATA_OFFSET         2
+
+/** \name ND6 message length (excluding options) */
+/** @{ */
+#define UIP_ND6_NA_LEN                  20
+#define UIP_ND6_NS_LEN                  20
+#define UIP_ND6_RA_LEN                  12
+#define UIP_ND6_RS_LEN                  4
+/** @} */
+
+
+/** \name ND6 option length in bytes */
+/** @{ */
+#define UIP_ND6_OPT_HDR_LEN            2
+#define UIP_ND6_OPT_PREFIX_INFO_LEN    32
+#define UIP_ND6_OPT_MTU_LEN            8
+
+
+/* Length of TLLAO and SLLAO options, it is L2 dependant */
+#if UIP_CONF_LL_802154
+/* If the interface is 802.15.4. For now we use only long addresses */
+#define UIP_ND6_OPT_SHORT_LLAO_LEN     8
+#define UIP_ND6_OPT_LONG_LLAO_LEN      16
+/** \brief length of a ND6 LLAO option for 802.15.4 */
+#define UIP_ND6_OPT_LLAO_LEN UIP_ND6_OPT_LONG_LLAO_LEN
+#else /*UIP_CONF_LL_802154*/
+#if UIP_CONF_LL_80211
+/* If the interface is 802.11 */
+/** \brief length of a ND6 LLAO option for 802.11 */
+#define UIP_ND6_OPT_LLAO_LEN           8
+#else /*UIP_CONF_LL_80211*/
+/** \brief length of a ND6 LLAO option for default L2 type (e.g. Ethernet) */
+#define UIP_ND6_OPT_LLAO_LEN           8
+#endif /*UIP_CONF_LL_80211*/
+#endif /*UIP_CONF_LL_802154*/
+/** @} */
+
+
+/** \name Neighbor Advertisement flags masks */
+/** @{ */
+#define UIP_ND6_NA_FLAG_ROUTER          0x80
+#define UIP_ND6_NA_FLAG_SOLICITED       0x40
+#define UIP_ND6_NA_FLAG_OVERRIDE        0x20
+#define UIP_ND6_RA_FLAG_ONLINK          0x80
+#define UIP_ND6_RA_FLAG_AUTONOMOUS      0x40
+/** @} */
+
+/**
+ * \name ND message structures
+ * @{
+ */
+
+/**
+ * \brief A neighbor solicitation constant part
+ *
+ * Possible option is: SLLAO
+ */
+typedef struct uip_nd6_ns {
+  uint32_t reserved;
+  uip_ipaddr_t tgtipaddr;
+} uip_nd6_ns;
+
+/**
+ * \brief A neighbor advertisement constant part.
+ *
+ * Possible option is: TLLAO
+ */
+typedef struct uip_nd6_na {
+  uint8_t flagsreserved;
+  uint8_t reserved[3];
+  uip_ipaddr_t tgtipaddr;
+} uip_nd6_na;
+
+/**
+ * \brief A router solicitation  constant part
+ *
+ * Possible option is: SLLAO
+ */
+typedef struct uip_nd6_rs {
+  uint32_t reserved;
+} uip_nd6_rs;
+
+/**
+ * \brief A router advertisement constant part
+ *
+ * Possible options are: SLLAO, MTU, Prefix Information
+ */
+typedef struct uip_nd6_ra {
+  uint8_t cur_ttl;
+  uint8_t flags_reserved;
+  uint16_t router_lifetime;
+  uint32_t reachable_time;
+  uint32_t retrans_timer;
+} uip_nd6_ra;
+
+/**
+ * \brief A redirect message constant part
+ *
+ * Possible options are: TLLAO, redirected header
+ */
+typedef struct uip_nd6_redirect {
+  uint32_t reserved;
+  uip_ipaddr_t tgtipaddress;
+  uip_ipaddr_t destipaddress;
+} uip_nd6_redirect;
+/** @} */
+
+/**
+ * \name ND Option structures
+ * @{
+ */
+
+/** \brief ND option header */
+typedef struct uip_nd6_opt_hdr {
+  uint8_t type;
+  uint8_t len;
+} uip_nd6_opt_hdr;
+
+/** \brief ND option prefix information */
+typedef struct uip_nd6_opt_prefix_info {
+  uint8_t type;
+  uint8_t len;
+  uint8_t preflen;
+  uint8_t flagsreserved1;
+  uint32_t validlt;
+  uint32_t preferredlt;
+  uint32_t reserved2;
+  uip_ipaddr_t prefix;
+} uip_nd6_opt_prefix_info ;
+
+/** \brief ND option MTU */
+typedef struct uip_nd6_opt_mtu {
+  uint8_t type;
+  uint8_t len;
+  uint16_t reserved;
+  uint32_t mtu;
+} uip_nd6_opt_mtu;
+
+/** \struct Redirected header option */
+typedef struct uip_nd6_opt_redirected_hdr {
+  uint8_t type;
+  uint8_t len;
+  uint8_t reserved[6];
+} uip_nd6_opt_redirected_hdr;
+/** @} */
+
+/**
+ * \name ND Messages Processing and Generation
+ * @{
+ */
+ /**
+ * \brief Process a neighbor solicitation
+ *
+ * The NS can be received in 3 cases (procedures):
+ * - sender is performing DAD (ip src = unspecified, no SLLAO option)
+ * - sender is performing NUD (ip dst = unicast)
+ * - sender is performing address resolution (ip dest = solicited node mcast
+ * address)
+ *
+ * We do:
+ * - if the tgt belongs to me, reply, otherwise ignore
+ * - if i was performing DAD for the same address, two cases:
+ * -- I already sent a NS, hence I win
+ * -- I did not send a NS yet, hence I lose
+ *
+ * If we need to send a NA in response (i.e. the NS was done for NUD, or
+ * address resolution, or DAD and there is a conflict), we do it in this
+ * function: set src, dst, tgt address in the three cases, then for all cases
+ * set the rest, including  SLLAO
+ *
+ */
+void
+uip_nd6_ns_input(void);
+
+/**
+ * \brief Send a neighbor solicitation, send a Neighbor Advertisement
+ * \param src pointer to the src of the NS if known
+ * \param dest pointer to ip address to send the NS, for DAD or ADDR Resol,
+ * MUST be NULL, for NUD, must be correct unicast dest
+ * \param tgt  pointer to ip address to fill the target address field, must
+ * not be NULL
+ *
+ * - RFC 4861, 7.2.2 :
+ *   "If the source address of the packet prompting the solicitation is the
+ *   same as one of the addresses assigned to the outgoing interface, that
+ *   address SHOULD be placed in the IP Source Address of the outgoing
+ *   solicitation.  Otherwise, any one of the addresses assigned to the
+ *   interface should be used."
+ *   This is why we have a src ip address as argument. If NULL, we will do
+ *   src address selection, otherwise we use the argument.
+ *
+ * - we check if it is a NS for Address resolution or NUD, if yes we include
+ *   a SLLAO option, otherwise no.
+ */
+void
+uip_nd6_ns_output(uip_ipaddr_t *src, uip_ipaddr_t *dest, uip_ipaddr_t *tgt);
+
+/**
+ * \brief Process a Neighbor Advertisement
+ *
+ * we might have to send a pkt that had been buffered while address
+ * resolution was performed (if we support buffering, see UIP_CONF_QUEUE_PKT)
+ *
+ * As per RFC 4861, on link layer that have addresses, TLLAO options MUST be
+ * included when responding to multicast solicitations, SHOULD be included in
+ * response to unicast (here we assume it is for now)
+ *
+ * NA can be received after sending NS for DAD, Address resolution or NUD. Can
+ * be unsolicited as well.
+ * It can trigger update of the state of the neighbor in the neighbor cache,
+ * router in the router list.
+ * If the NS was for DAD, it means DAD failed
+ *
+ */
+void
+uip_nd6_na_input(void);
+
+#if UIP_CONF_ROUTER
+#if UIP_ND6_SEND_RA
+/**
+ * \brief Process a Router Solicitation
+ *
+ */
+void uip_nd6_rs_input(void);
+
+/**
+ * \brief send a Router Advertisement
+ *
+ * Only for router, for periodic as well as sollicited RA
+ */
+void uip_nd6_ra_output(uip_ipaddr_t *dest);
+#endif /* UIP_ND6_SEND_RA */
+#endif /*UIP_CONF_ROUTER*/
+
+/**
+ * \brief Send a Router Solicitation
+ *
+ * src is chosen through the uip_netif_select_src function. If src is
+ * unspecified  (i.e. we do not have a preferred address yet), then we do not
+ * put a SLLAO option (MUST NOT in RFC 4861). Otherwise we do.
+ *
+ * RS message format,
+ * possible option is SLLAO, MUST NOT be included if source = unspecified
+ * SHOULD be included otherwise
+ */
+void uip_nd6_rs_output(void);
+
+/**
+ *
+ * \brief process a Router Advertisement
+ *
+ * - Possible actions when receiving a RA: add router to router list,
+ *   recalculate reachable time, update link hop limit, update retrans timer.
+ * - If MTU option: update MTU.
+ * - If SLLAO option: update entry in neighbor cache
+ * - If prefix option: start autoconf, add prefix to prefix list
+ */
+void
+uip_nd6_ra_input(void);
+/** @} */
+
+
+void
+uip_appserver_addr_get(uip_ipaddr_t *ipaddr);
+/*--------------------------------------*/
+/******* ANNEX - message formats ********/
+/*--------------------------------------*/
+
+/*
+ * RS format. possible option is SLLAO
+ *    0                   1                   2                   3
+ *    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |     Type      |     Code      |          Checksum             |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |                            Reserved                           |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |   Options ...
+ *    +-+-+-+-+-+-+-+-+-+-+-+-
+ *
+ *
+ * RA format. possible options: prefix information, MTU, SLLAO
+ *    0                   1                   2                   3
+ *    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |     Type      |     Code      |          Checksum             |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    | Cur Hop Limit |M|O|  Reserved |       Router Lifetime         |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |                         Reachable Time                        |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |                          Retrans Timer                        |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |   Options ...
+ *    +-+-+-+-+-+-+-+-+-+-+-+-
+ *
+ *
+ * NS format: options should be SLLAO
+ *    0                   1                   2                   3
+ *    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |     Type      |     Code      |          Checksum             |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |                           Reserved                            |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |                                                               |
+ *    +                                                               +
+ *    |                                                               |
+ *    +                       Target Address                          +
+ *    |                                                               |
+ *    +                                                               +
+ *    |                                                               |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |   Options ...
+ *    +-+-+-+-+-+-+-+-+-+-+-+-
+ *
+ *
+ * NA message format. possible options is TLLAO
+ *
+ *    0                   1                   2                   3
+ *    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |     Type      |     Code      |          Checksum             |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |R|S|O|                     Reserved                            |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |                                                               |
+ *    +                                                               +
+ *    |                                                               |
+ *    +                       Target Address                          +
+ *    |                                                               |
+ *    +                                                               +
+ *    |                                                               |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |   Options ...
+ *    +-+-+-+-+-+-+-+-+-+-+-+-
+ *
+ *
+ * Redirect message format. Possible options are TLLAO and Redirected header
+ *
+ *    0                   1                   2                   3
+ *    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |     Type      |     Code      |          Checksum             |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |                           Reserved                            |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |                                                               |
+ *    +                                                               +
+ *    |                                                               |
+ *    +                       Target Address                          +
+ *    |                                                               |
+ *    +                                                               +
+ *    |                                                               |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |                                                               |
+ *    +                                                               +
+ *    |                                                               |
+ *    +                     Destination Address                       +
+ *    |                                                               |
+ *    +                                                               +
+ *    |                                                               |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |   Options ...
+ *    +-+-+-+-+-+-+-+-+-+-+-+-
+ *
+ *
+ * SLLAO/TLLAO option:
+ *    0                   1                   2                   3
+ *    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |     Type      |    Length     |    Link-Layer Address ...
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *
+ *
+ * Prefix information option
+ *    0                   1                   2                   3
+ *    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |     Type      |    Length     | Prefix Length |L|A| Reserved1 |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |                         Valid Lifetime                        |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |                       Preferred Lifetime                      |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |                           Reserved2                           |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |                                                               |
+ *    +                                                               +
+ *    |                                                               |
+ *    +                            Prefix                             +
+ *    |                                                               |
+ *    +                                                               +
+ *    |                                                               |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *
+ *
+ * MTU option
+ *    0                   1                   2                   3
+ *    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |     Type      |    Length     |           Reserved            |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |                              MTU                              |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *
+ *
+ * Redirected header option
+ *
+ *    0                   1                   2                   3
+ *    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |     Type      |    Length     |            Reserved           |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |                           Reserved                            |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *    |                                                               |
+ *    ~                       IP header + data                        ~
+ *    |                                                               |
+ *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *
+ */
+#endif /* __UIP_ND6_H__ */
+
+/** @} */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/uip-packetqueue.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/uip-packetqueue.c
@@ -1,0 +1,86 @@
+#include <stdio.h>
+
+#include "net/uip.h"
+
+#include "lib/memb.h"
+
+#include "net/uip-packetqueue.h"
+
+#define MAX_NUM_QUEUED_PACKETS 2
+MEMB(packets_memb, struct uip_packetqueue_packet, MAX_NUM_QUEUED_PACKETS);
+
+#define DEBUG 0
+#if DEBUG
+#include <stdio.h>
+#define PRINTF(...) printf(__VA_ARGS__)
+#else
+#define PRINTF(...)
+#endif
+
+/*---------------------------------------------------------------------------*/
+static void
+packet_timedout(void *ptr)
+{
+  struct uip_packetqueue_handle *h = ptr;
+
+  PRINTF("uip_packetqueue_free timed out %p\n", h);
+  memb_free(&packets_memb, h->packet);
+  h->packet = NULL;
+}
+/*---------------------------------------------------------------------------*/
+void
+uip_packetqueue_new(struct uip_packetqueue_handle *handle)
+{
+  PRINTF("uip_packetqueue_new %p\n", handle);
+  handle->packet = NULL;
+}
+/*---------------------------------------------------------------------------*/
+struct uip_packetqueue_packet *
+uip_packetqueue_alloc(struct uip_packetqueue_handle *handle, clock_time_t lifetime)
+{
+  PRINTF("uip_packetqueue_alloc %p\n", handle);
+  if(handle->packet != NULL) {
+    PRINTF("alloced\n");
+    return NULL;
+  }
+  handle->packet = memb_alloc(&packets_memb);
+  if(handle->packet != NULL) {
+    ctimer_set(&handle->packet->lifetimer, lifetime,
+               packet_timedout, handle);
+  } else {
+    PRINTF("uip_packetqueue_alloc failed\n");
+  }
+  return handle->packet;
+}
+/*---------------------------------------------------------------------------*/
+void
+uip_packetqueue_free(struct uip_packetqueue_handle *handle)
+{
+  PRINTF("uip_packetqueue_free %p\n", handle);
+  if(handle->packet != NULL) {
+    ctimer_stop(&handle->packet->lifetimer);
+    memb_free(&packets_memb, handle->packet);
+    handle->packet = NULL;
+  }
+}
+/*---------------------------------------------------------------------------*/
+uint8_t *
+uip_packetqueue_buf(struct uip_packetqueue_handle *h)
+{
+  return h->packet != NULL? h->packet->queue_buf: NULL;
+}
+/*---------------------------------------------------------------------------*/
+uint16_t
+uip_packetqueue_buflen(struct uip_packetqueue_handle *h)
+{
+  return h->packet != NULL? h->packet->queue_buf_len: 0;
+}
+/*---------------------------------------------------------------------------*/
+void
+uip_packetqueue_set_buflen(struct uip_packetqueue_handle *h, uint16_t len)
+{
+  if(h->packet != NULL) {
+    h->packet->queue_buf_len = len;
+  }
+}
+/*---------------------------------------------------------------------------*/

--- a/module_xtcp/src/xtcp_uip6/contiki/net/uip-packetqueue.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/uip-packetqueue.h
@@ -1,0 +1,35 @@
+#ifndef UIP_PACKETQUEUE_H
+#define UIP_PACKETQUEUE_H
+
+#include "sys/ctimer.h"
+
+struct uip_packetqueue_handle;
+
+struct uip_packetqueue_packet {
+  struct uip_ds6_queued_packet *next;
+  uint8_t queue_buf[UIP_BUFSIZE - UIP_LLH_LEN];
+  uint16_t queue_buf_len;
+  struct ctimer lifetimer;
+  struct uip_packetqueue_handle *handle;
+};
+
+struct uip_packetqueue_handle {
+  struct uip_packetqueue_packet *packet;
+};
+
+void uip_packetqueue_new(struct uip_packetqueue_handle *handle);
+
+
+struct uip_packetqueue_packet *
+uip_packetqueue_alloc(struct uip_packetqueue_handle *handle, clock_time_t lifetime);
+
+
+void
+uip_packetqueue_free(struct uip_packetqueue_handle *handle);
+
+uint8_t *uip_packetqueue_buf(struct uip_packetqueue_handle *h);
+uint16_t uip_packetqueue_buflen(struct uip_packetqueue_handle *h);
+void uip_packetqueue_set_buflen(struct uip_packetqueue_handle *h, uint16_t len);
+
+
+#endif /* UIP_PACKETQUEUE_H */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/uip-split.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/uip-split.c
@@ -1,0 +1,184 @@
+// Copyright (c) 2011, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+
+/*
+ * Copyright (c) 2004, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the uIP TCP/IP stack
+ *
+ * Author: Adam Dunkels <adam@sics.se>
+ *
+ */
+
+#include <string.h>
+
+#include "net/uip-split.h"
+#include "net/uip.h"
+#include "uip-conf.h"
+
+#include "uip_arch.h"
+#include "uip_server_support.h"
+
+#include <xccompat.h>
+#include "xcoredev.h"
+
+#include <xclib.h>
+#define BUF ((struct uip_tcpip_hdr *)&uip_buf[UIP_LLH_LEN])
+
+#ifndef UIP_PACKET_SPLIT_THRESHOLD
+#define UIP_PACKET_SPLIT_THRESHOLD ((UIP_BUFSIZE) / 2)
+#endif
+
+#define ACTUAL_UIP_PACKET_SPLIT_THRESHOLD (UIP_PACKET_SPLIT_THRESHOLD > 4 ? UIP_PACKET_SPLIT_THRESHOLD : 4)
+
+
+/*-----------------------------------------------------------------------------*/
+#if UIP_SLIDING_WINDOW
+extern int uip_do_split;
+#endif
+
+/*-----------------------------------------------------------------------------*/
+static void
+uip_split_output_send(chanend mac_tx)
+{
+	/* Recalculate the TCP checksum. */
+	BUF->tcpchksum = 0;
+	BUF->tcpchksum = ~(uip_tcpchksum());
+
+	uip_len += UIP_LLH_LEN;
+
+    /* Transmit the first packet. */
+    /*    uip_fw_output();*/
+#if UIP_CONF_IPV6
+    xtcpip_ipv6_output(mac_tx);
+#else
+    xcoredev_send(mac_tx);		//XXX CHSC: XMOS Original
+//    tcpip_output();
+#endif /* UIP_CONF_IPV6 */
+}
+
+
+// The purpose of this function is to defeat Neagles Algorithm. For packets
+// over half of the size of the max frame size (which we assume to be part of
+// a data stream and therefore need to be ACKed quickly) we break the packet
+// in two, which means that the Neagles Algorithm effect of ACKing only every
+// other packet will generate ACKs for us for each transmission.
+//
+// Without this, since we do not have a sliding window, and therefore do not
+// transmit packet 2 until packet 1 has been acknowledged, we have to wait
+// until the other end times out of the 300ms delay before sending us an ACK.
+void
+uip_split_output(chanend mac_tx)
+{
+	uint16_t tcplen, len1, len2;
+
+  /* We only split TCP segments that are larger than or equal to
+       UIP_SPLIT_SIZE, which is configurable through
+       UIP_SPLIT_CONF_SIZE. */
+  if (BUF->proto == UIP_PROTO_TCP) {
+#if UIP_SLIDING_WINDOW
+     if (uip_do_split)
+#else
+    int data_len = uip_len - UIP_TCPIP_HLEN - UIP_LLH_LEN;
+    if (data_len > ACTUAL_UIP_PACKET_SPLIT_THRESHOLD)
+#endif
+    {
+      tcplen = uip_len - UIP_TCPIP_HLEN - UIP_LLH_LEN;
+      /* Split the segment in two, making sure the first segment is an
+       * integer number of words */
+      len1 = (tcplen / 2) & ~3;
+      len2 = tcplen - len1;
+
+      /* Create the first packet. This is done by altering the length
+       field of the IP header and updating the checksums. */
+      uip_len = len1 + UIP_TCPIP_HLEN;
+#if UIP_CONF_IPV6
+      /* For IPv6, the IP length field does not include the IPv6 IP header
+         length. */
+      BUF->len[0] = ((uip_len - UIP_IPH_LEN) >> 8);
+      BUF->len[1] = ((uip_len - UIP_IPH_LEN) & 0xff);
+#else /* UIP_CONF_IPV6 */
+      BUF->len[0] = uip_len >> 8;
+      BUF->len[1] = uip_len & 0xff;
+#endif /* UIP_CONF_IPV6 */
+
+      /* Transmit the first packet. */
+      uip_split_output_send(mac_tx);
+
+      /* Now, create the second packet. To do this, it is not enough to
+       just alter the length field, but we must also update the TCP
+       sequence number and point the uip_appdata to a new place in
+       memory. This place is determined by the length of the first
+       packet (len1). */
+      uip_len = len2 + UIP_TCPIP_HLEN;
+#if UIP_CONF_IPV6
+      /* For IPv6, the IP length field does not include the IPv6 IP header length. */
+      BUF->len[0] = ((uip_len - UIP_IPH_LEN) >> 8);
+      BUF->len[1] = ((uip_len - UIP_IPH_LEN) & 0xff);
+#else /* UIP_CONF_IPV6 */
+      BUF->len[0] = uip_len >> 8;
+      BUF->len[1] = uip_len & 0xff;
+#endif /* UIP_CONF_IPV6 */
+
+      /* Sadly we must copy the packet contents down to the bottom of the packet.
+       *
+       * We know that the data sections are on a short word boundary, and not
+       * on a word boundary
+       */
+      /* uip_appdata += len1;*/
+      memcpy(uip_appdata, (uint8_t *)uip_appdata + len1, len2);
+
+      uip_add32(BUF->seqno, len1);
+      xtcp_copy_word(BUF->seqno, uip_acc32);
+
+      uip_split_output_send(mac_tx);
+    } else {
+      // We didn't compute the checksum earlier
+      BUF->tcpchksum = 0;
+      BUF->tcpchksum = ~(uip_tcpchksum());
+
+#if UIP_CONF_IPV6
+      xtcpip_ipv6_output(mac_tx);
+#else
+      xcoredev_send(mac_tx);
+//      tcpip_output();
+#endif /* UIP_CONF_IPV6 */
+    }
+  } else {
+#if UIP_CONF_IPV6
+      xtcpip_ipv6_output(mac_tx);
+#else
+      xcoredev_send(mac_tx);
+//      tcpip_output();
+#endif /* UIP_CONF_IPV6 */
+  }
+}
+/*-----------------------------------------------------------------------------*/

--- a/module_xtcp/src/xtcp_uip6/contiki/net/uip-split.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/uip-split.h
@@ -1,0 +1,102 @@
+// Copyright (c) 2011, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+
+/*
+ * Copyright (c) 2004, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the uIP TCP/IP stack
+ *
+ * Author: Adam Dunkels <adam@sics.se>
+ *
+ * $Id: uip-split.h,v 1.2 2006/06/12 08:00:30 adam Exp $
+ */
+/**
+ * \addtogroup uip
+ * @{
+ */
+
+/**
+ * \defgroup uipsplit uIP TCP throughput booster hack
+ * @{
+ *
+ * The basic uIP TCP implementation only allows each TCP connection to
+ * have a single TCP segment in flight at any given time. Because of
+ * the delayed ACK algorithm employed by most TCP receivers, uIP's
+ * limit on the amount of in-flight TCP segments seriously reduces the
+ * maximum achievable throughput for sending data from uIP.
+ *
+ * The uip-split module is a hack which tries to remedy this
+ * situation. By splitting maximum sized outgoing TCP segments into
+ * two, the delayed ACK algorithm is not invoked at TCP
+ * receivers. This improves the throughput when sending data from uIP
+ * by orders of magnitude.
+ *
+ * The uip-split module uses the uip-fw module (uIP IP packet
+ * forwarding) for sending packets. Therefore, the uip-fw module must
+ * be set up with the appropriate network interfaces for this module
+ * to work.
+ */
+
+
+/**
+ * \file
+ * Module for splitting outbound TCP segments in two to avoid the
+ * delayed ACK throughput degradation.
+ * \author
+ * Adam Dunkels <adam@sics.se>
+ *
+ */
+
+#ifndef __UIP_SPLIT_H__
+#define __UIP_SPLIT_H__
+#include <xccompat.h>
+/**
+ * Handle outgoing packets.
+ *
+ * This function inspects an outgoing packet in the uip_buf buffer and
+ * sends it out using the uip_fw_output() function. If the packet is a
+ * full-sized TCP segment it will be split into two segments and
+ * transmitted separately. This function should be called instead of
+ * the actual device driver output function, or the uip_fw_output()
+ * function.
+ *
+ * The headers of the outgoing packet is assumed to be in the uip_buf
+ * buffer and the payload is assumed to be wherever uip_appdata
+ * points. The length of the outgoing packet is assumed to be in the
+ * uip_len variable.
+ *
+ */
+void uip_split_output(chanend mac_tx);
+
+#endif /* __UIP_SPLIT_H__ */
+
+/** @} */
+/** @} */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/uip.c_
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/uip.c_
@@ -1,0 +1,2035 @@
+// Copyright (c) 2011, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+
+#define DEBUG_PRINTF(...) /*printf(__VA_ARGS__)*/
+
+/**
+ * \addtogroup uip
+ * @{
+ */
+
+/**
+ * \file
+ * The uIP TCP/IP stack code.
+ * \author Adam Dunkels <adam@dunkels.com>
+ */
+
+/*
+ * Copyright (c) 2001-2003, Adam Dunkels.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This file is part of the uIP TCP/IP stack.
+ *
+ *
+ */
+
+/*
+ * uIP is a small implementation of the IP, UDP and TCP protocols (as
+ * well as some basic ICMP stuff). The implementation couples the IP,
+ * UDP, TCP and the application layers very tightly. To keep the size
+ * of the compiled code down, this code frequently uses the goto
+ * statement. While it would be possible to break the uip_process()
+ * function into many smaller functions, this would increase the code
+ * size because of the overhead of parameter passing and the fact that
+ * the optimier would not be as efficient.
+ *
+ * The principle is that we have a small buffer, called the uip_buf,
+ * in which the device driver puts an incoming packet. The TCP/IP
+ * stack parses the headers in the packet, and calls the
+ * application. If the remote host has sent data to the application,
+ * this data is present in the uip_buf and the application read the
+ * data from there. It is up to the application to put this data into
+ * a byte stream if needed. The application will not be fed with data
+ * that is out of sequence.
+ *
+ * If the application whishes to send data to the peer, it should put
+ * its data into the uip_buf. The uip_appdata pointer points to the
+ * first available byte. The TCP/IP stack will calculate the
+ * checksums, and fill in the necessary header fields and finally send
+ * the packet back to the peer.
+ */
+
+#include "net/uip.h"
+#include "net/uipopt.h"
+#include "net/uip_arp.h"
+#include "uip_arch.h"
+#include <print.h>
+#include <xclib.h>
+
+#if !UIP_CONF_IPV6 /* If UIP_CONF_IPV6 is defined, we compile the
+                      uip6.c file instead of this one. Therefore
+                      this #ifndef removes the entire compilation
+                      output of the uip.c file */
+
+
+#if UIP_CONF_IPV6
+#include "net/uip-neighbor.h"
+#endif /* UIP_CONF_IPV6 */
+
+#if UIP_IGMP
+#include "igmp.h"
+#endif
+#include <string.h>
+#define ACTUAL_UIP_PACKET_SPLIT_THRESHOLD (UIP_PACKET_SPLIT_THRESHOLD > 4 ? UIP_PACKET_SPLIT_THRESHOLD : 4)
+/*---------------------------------------------------------------------------*/
+/* Variable definitions. */
+
+
+/* The IP address of this host. If it is defined to be fixed (by
+   setting UIP_FIXEDADDR to 1 in uipopt.h), the address is set
+   here. Otherwise, the address */
+#if UIP_FIXEDADDR > 0
+const uip_ipaddr_t uip_hostaddr =
+  { UIP_IPADDR0, UIP_IPADDR1, UIP_IPADDR2, UIP_IPADDR3 };
+const uip_ipaddr_t uip_draddr =
+  { UIP_DRIPADDR0, UIP_DRIPADDR1, UIP_DRIPADDR2, UIP_DRIPADDR3 };
+const uip_ipaddr_t uip_netmask =
+  { UIP_NETMASK0, UIP_NETMASK1, UIP_NETMASK2, UIP_NETMASK3 };
+#else
+uip_ipaddr_t uip_hostaddr, uip_draddr, uip_netmask;
+#endif /* UIP_FIXEDADDR */
+
+const uip_ipaddr_t uip_broadcast_addr =
+#if UIP_CONF_IPV6
+  { { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+      0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff } };
+#else /* UIP_CONF_IPV6 */
+  { { 0xff, 0xff, 0xff, 0xff } };
+#endif /* UIP_CONF_IPV6 */
+const uip_ipaddr_t uip_all_zeroes_addr = { { 0x0, /* rest is 0 */ } };
+
+#if UIP_FIXEDETHADDR
+const uip_lladdr_t uip_lladdr = {{UIP_ETHADDR0,
+                                  UIP_ETHADDR1,
+                                  UIP_ETHADDR2,
+                                  UIP_ETHADDR3,
+                                  UIP_ETHADDR4,
+                                  UIP_ETHADDR5}};
+#else
+uip_lladdr_t uip_lladdr = {{0,0,0,0,0,0}};
+#endif
+
+#ifndef UIP_CONF_EXTERNAL_BUFFER
+uint8_t uip_buf[UIP_BUFSIZE + 2]; /* The packet buffer that contains
+ incoming packets. */
+#endif /* UIP_CONF_EXTERNAL_BUFFER */
+
+void *uip_appdata; /* The uip_appdata pointer points to
+                      application data. */
+void *uip_sappdata; /* The uip_appdata pointer points to
+                       the application data which is to 
+                       be sent. */
+#if UIP_URGDATA > 0
+void *uip_urgdata; /* The uip_urgdata pointer points to
+                      urgent data (out-of-band data), if
+                      present. */
+uint16_t uip_urglen, uip_surglen;
+#endif /* UIP_URGDATA > 0 */
+
+uint16_t uip_len, uip_slen;
+/* The uip_len is either 8 or 16 bits,
+ depending on the maximum packet
+ size. */
+
+#if UIP_SLIDING_WINDOW
+int uip_do_split;
+#endif
+
+uint32_t uip_flags; /* The uip_flags variable is used for
+                      communication between the TCP/IP stack
+                      and the application program. */
+struct uip_conn *uip_conn; /* uip_conn always points to the current
+                              connection. */
+
+struct uip_conn uip_conns[UIP_CONNS];
+/* The uip_conns array holds all TCP
+ connections. */
+uint16_t uip_listenports[UIP_LISTENPORTS];
+/* The uip_listenports list all currently 
+   listning ports. */
+
+uint16_t uip_udp_listenports[UIP_LISTENPORTS];
+/* The uip_listenports list all currently
+   listning ports. */
+#if UIP_UDP
+struct uip_udp_conn *uip_udp_conn;
+struct uip_udp_conn uip_udp_conns[UIP_UDP_CONNS];
+#endif /* UIP_UDP */
+
+static uint16_t ipid; /* Ths ipid variable is an increasing
+ number that is used for the IP ID
+ field. */
+
+void uip_setipid(uint16_t id) { ipid = id; }
+
+static uint8_t iss[4];          /* The iss variable is used for the TCP
+                                   initial sequence number. */
+
+#if UIP_ACTIVE_OPEN || UIP_UDP
+static uint16_t lastport;       /* Keeps track of the last port used for
+                                   a new connection. */
+#endif /* UIP_ACTIVE_OPEN || UIP_UDP */
+
+/* Temporary variables. */
+uint8_t uip_acc32[4];
+static uint8_t c, opt;
+static uint16_t tmp16;
+
+/* Structures and definitions. */
+#define TCP_FIN 0x01
+#define TCP_SYN 0x02
+#define TCP_RST 0x04
+#define TCP_PSH 0x08
+#define TCP_ACK 0x10
+#define TCP_URG 0x20
+#define TCP_CTL 0x3f
+
+#define TCP_OPT_END     0   /* End of TCP options list */
+#define TCP_OPT_NOOP    1   /* "No-operation" TCP option */
+#define TCP_OPT_MSS     2   /* Maximum segment size TCP option */
+
+#define TCP_OPT_MSS_LEN 4   /* Length of TCP MSS option. */
+
+#define ICMP_ECHO_REPLY 0
+#define ICMP_ECHO       8
+
+#define ICMP_DEST_UNREACHABLE        3
+#define ICMP_PORT_UNREACHABLE        3
+
+#define ICMP6_ECHO_REPLY             129
+#define ICMP6_ECHO                   128
+#define ICMP6_NEIGHBOR_SOLICITATION  135
+#define ICMP6_NEIGHBOR_ADVERTISEMENT 136
+
+#define ICMP6_FLAG_S (1 << 6)
+
+#define ICMP6_OPTION_SOURCE_LINK_ADDRESS 1
+#define ICMP6_OPTION_TARGET_LINK_ADDRESS 2
+
+
+/* Macros. */
+#if !BUF_32BIT_ALIGN
+#define BUF                 ((struct uip_tcpip_hdr *)&uip_buf[UIP_LLH_LEN])
+#define FBUF                ((struct uip_tcpip_hdr *)&uip_reassbuf[0])
+#define ICMPBUF            ((struct uip_icmpip_hdr *)&uip_buf[UIP_LLH_LEN])
+#define UDPBUF              ((struct uip_udpip_hdr *)&uip_buf[UIP_LLH_LEN])
+#else
+#define BUF                 ((struct uip_tcpip_hdr *)&uip_buf16(UIP_LLH_LEN))
+#define FBUF                ((struct uip_tcpip_hdr *)&uip_reassbuf[0])
+#define ICMPBUF            ((struct uip_icmpip_hdr *)&uip_buf16(UIP_LLH_LEN))
+#define UDPBUF              ((struct uip_udpip_hdr *)&uip_buf16(UIP_LLH_LEN))
+#endif
+
+#if UIP_STATISTICS == 1
+struct uip_stats uip_stat;
+#define UIP_STAT(s) s
+#else
+#define UIP_STAT(s)
+#endif /* UIP_STATISTICS == 1 */
+
+#if UIP_LOGGING == 0
+#include <stdio.h>
+void uip_log(char *msg);
+#define UIP_LOG(m) uip_log(m)
+#else
+#define UIP_LOG(m)
+#endif /* UIP_LOGGING == 1 */
+
+/*---------------------------------------------------------------------------*/
+uint16_t
+uip_chksum(uint16_t *data, uint16_t len)
+{
+  return uip_htons(chksum(0, (uint8_t *)data, len));
+}
+/*---------------------------------------------------------------------------*/
+#ifndef UIP_ARCH_IPCHKSUM
+uint16_t
+uip_ipchksum(void)
+{
+  uint16_t sum;
+
+  sum = chksum(0, &uip_buf[UIP_LLH_LEN], UIP_IPH_LEN);
+  DEBUG_PRINTF("uip_ipchksum: sum 0x%04x\n", sum);
+  return (sum == 0) ? 0xffff : uip_htons(sum);
+}
+#endif
+/*---------------------------------------------------------------------------*/
+static uint16_t
+upper_layer_chksum(uint8_t proto)
+{
+  uint16_t upper_layer_len;
+  uint16_t sum;
+
+#if UIP_CONF_IPV6
+  upper_layer_len = (((uint16_t)(BUF->len[0]) << 8) + BUF->len[1]);
+#else /* UIP_CONF_IPV6 */
+  upper_layer_len = (((uint16_t)(BUF->len[0]) << 8) + BUF->len[1]) - UIP_IPH_LEN;
+#endif /* UIP_CONF_IPV6 */
+
+  /* First sum pseudoheader. */
+
+  /* IP protocol and length fields. This addition cannot carry. */
+  sum = upper_layer_len + proto;
+  /* Sum IP source and destination addresses. */
+  sum = chksum(sum, (uint8_t *)&BUF->srcipaddr.u8[0], 2 * sizeof(uip_ipaddr_t));
+
+  /* Sum TCP header and data. */
+  sum = chksum(sum, &uip_buf[UIP_IPH_LEN + UIP_LLH_LEN], 
+               upper_layer_len);
+
+  return (sum == 0) ? 0xffff : uip_htons(sum);
+}
+/*---------------------------------------------------------------------------*/
+#if UIP_CONF_IPV6
+uint16_t
+uip_icmp6chksum(void)
+{
+  return upper_layer_chksum(UIP_PROTO_ICMP6);
+
+}
+#endif /* UIP_CONF_IPV6 */
+/*---------------------------------------------------------------------------*/
+uint16_t
+uip_tcpchksum(void)
+{
+  return upper_layer_chksum(UIP_PROTO_TCP);
+}
+/*---------------------------------------------------------------------------*/
+#if UIP_UDP_CHECKSUMS
+uint16_t
+uip_udpchksum(void)
+{
+  return upper_layer_chksum(UIP_PROTO_UDP);
+}
+#endif /* UIP_UDP_CHECKSUMS */
+
+/*---------------------------------------------------------------------------*/
+void
+uip_init(void)
+{
+  memset(uip_listenports, 0, sizeof(uip_listenports));
+  memset(uip_udp_listenports, 0, sizeof(uip_listenports));
+  memset(uip_conns, 0, sizeof(uip_conns));
+#if UIP_ACTIVE_OPEN
+  lastport = 1024;
+#endif /* UIP_ACTIVE_OPEN */
+
+#if UIP_UDP
+  memset(uip_udp_conns, 0, sizeof(uip_udp_conns));
+#endif /* UIP_UDP */
+}
+/*---------------------------------------------------------------------------*/
+#if UIP_ACTIVE_OPEN
+struct uip_conn *
+uip_connect(uip_ipaddr_t *ripaddr, uint16_t rport)
+{
+  register struct uip_conn *conn, *cconn;
+
+  /* Find an unused local port. */
+ again:
+  ++lastport;
+
+  if(lastport >= 32000) {
+    lastport = 4096;
+  }
+
+  /* Check if this port is already in use, and if so try to find another one. */
+  for(c = 0; c < UIP_CONNS; ++c) {
+    conn = &uip_conns[c];
+    if(conn->tcpstateflags != UIP_CLOSED &&
+       conn->lport == uip_htons(lastport)) {
+      goto again;
+    }
+  }
+
+  conn = 0;
+  for(c = 0; c < UIP_CONNS; ++c) {
+    cconn = &uip_conns[c];
+    if(cconn->tcpstateflags == UIP_CLOSED) {
+      conn = cconn;
+      break;
+    }
+    if(cconn->tcpstateflags == UIP_TIME_WAIT) {
+      if(conn == 0 ||
+         cconn->tmr > conn->tmr) {
+        conn = cconn;
+      }
+    }
+  }
+
+  if(conn == 0) {
+    // max tcp connections reached
+    return 0;
+  }
+
+  conn->tcpstateflags = UIP_SYN_SENT;
+
+  conn->snd_nxt[0] = iss[0];
+  conn->snd_nxt[1] = iss[1];
+  conn->snd_nxt[2] = iss[2];
+  conn->snd_nxt[3] = iss[3];
+
+  conn->initialmss = conn->mss = UIP_TCP_MSS;
+
+  conn->len = 1;   /* TCP length of the SYN is one. */
+  conn->nrtx = 0;
+  conn->tmr = 1; /* Send the SYN next time around. */
+  conn->rto = UIP_RTO;
+  conn->sa = 0;
+  conn->sv = 16;   /* Initial value of the RTT variance. */
+  conn->lport = uip_htons(lastport);
+  conn->rport = rport;
+  uip_ipaddr_copy(&conn->ripaddr, ripaddr);
+#if UIP_SLIDING_WINDOW
+        conn->midpoint = 0;
+#endif
+  return conn;
+}
+#endif /* UIP_ACTIVE_OPEN */
+/*---------------------------------------------------------------------------*/
+#if UIP_UDP
+struct uip_udp_conn *
+uip_udp_new(uip_ipaddr_t *ripaddr, uint16_t rport)
+{
+  register struct uip_udp_conn *conn;
+
+  /* Find an unused local port. */
+ again:
+  ++lastport;
+
+  if(lastport >= 32000) {
+    lastport = 4096;
+  }
+
+  for(c = 0; c < UIP_UDP_CONNS; ++c) {
+    if(uip_udp_conns[c].lport == uip_htons(lastport)) {
+      goto again;
+    }
+  }
+
+
+  conn = 0;
+  for(c = 0; c < UIP_UDP_CONNS; ++c) {
+    if(uip_udp_conns[c].lport == 0) {
+      conn = &uip_udp_conns[c];
+      break;
+    }
+  }
+
+  if(conn == 0) {
+    return 0;
+  }
+
+  conn->lport = UIP_HTONS(lastport);
+  conn->rport = rport;
+  if(ripaddr == NULL) {
+    memset(&conn->ripaddr, 0, sizeof(uip_ipaddr_t));
+  } else {
+    uip_ipaddr_copy(&conn->ripaddr, ripaddr);
+  }
+  conn->ttl = UIP_TTL;
+  conn->udpflags = 0;
+  return conn;
+}
+#endif /* UIP_UDP */
+/*---------------------------------------------------------------------------*/
+void
+uip_unlisten(uint16_t port)
+{
+  for(c = 0; c < UIP_LISTENPORTS; ++c) {
+    if(uip_listenports[c] == port) {
+      uip_listenports[c] = 0;
+      return;
+    }
+  }
+}
+
+void 
+uip_udp_unlisten(uint16_t port) {
+  for(c = 0; c < UIP_LISTENPORTS; ++c) {
+    if(uip_udp_listenports[c] == port) {
+      uip_udp_listenports[c] = 0;
+      return;
+    }
+  }
+}
+/*---------------------------------------------------------------------------*/
+void
+uip_listen(uint16_t port)
+{
+  for(c = 0; c < UIP_LISTENPORTS; ++c) {
+    if(uip_listenports[c] == 0) {
+      uip_listenports[c] = port;
+      return;
+    }
+  }
+}
+
+void uip_udp_listen(uint16_t port) {
+  for(c = 0; c < UIP_LISTENPORTS; ++c) {
+    if(uip_udp_listenports[c] == 0) {
+      uip_udp_listenports[c] = port;
+      return;
+    }
+  }
+}
+
+/*---------------------------------------------------------------------------*/
+/* XXX: IP fragment reassembly: not well-tested. */
+
+#if UIP_REASSEMBLY && !UIP_CONF_IPV6
+#define UIP_REASS_BUFSIZE (UIP_BUFSIZE - UIP_LLH_LEN)
+static uint8_t uip_reassbuf[UIP_REASS_BUFSIZE];
+static uint8_t uip_reassbitmap[UIP_REASS_BUFSIZE / (8 * 8)];
+static const uint8_t bitmap_bits[8] = {0xff, 0x7f, 0x3f, 0x1f,
+                                       0x0f, 0x07, 0x03, 0x01};
+static uint16_t uip_reasslen;
+static uint8_t uip_reassflags;
+#define UIP_REASS_FLAG_LASTFRAG 0x01
+static uint8_t uip_reasstmr;
+
+#define IP_MF   0x20
+
+static uint8_t
+uip_reass(void)
+{
+  uint16_t offset, len;
+  uint16_t i;
+
+  /* If ip_reasstmr is zero, no packet is present in the buffer, so we
+     write the IP header of the fragment into the reassembly
+     buffer. The timer is updated with the maximum age. */
+  if(uip_reasstmr == 0) {
+    memcpy(uip_reassbuf, &BUF->vhl, UIP_IPH_LEN);
+    uip_reasstmr = UIP_REASS_MAXAGE;
+    uip_reassflags = 0;
+    /* Clear the bitmap. */
+    memset(uip_reassbitmap, 0, sizeof(uip_reassbitmap));
+  }
+
+  /* Check if the incoming fragment matches the one currently present
+     in the reasembly buffer. If so, we proceed with copying the
+     fragment into the buffer. */
+  if(BUF->srcipaddr[0] == FBUF->srcipaddr[0] &&
+     BUF->srcipaddr[1] == FBUF->srcipaddr[1] &&
+     BUF->destipaddr[0] == FBUF->destipaddr[0] &&
+     BUF->destipaddr[1] == FBUF->destipaddr[1] &&
+     BUF->ipid[0] == FBUF->ipid[0] &&
+     BUF->ipid[1] == FBUF->ipid[1]) {
+
+    len = (BUF->len[0] << 8) + BUF->len[1] - (BUF->vhl & 0x0f) * 4;
+    offset = (((BUF->ipoffset[0] & 0x3f) << 8) + BUF->ipoffset[1]) * 8;
+
+    /* If the offset or the offset + fragment length overflows the
+       reassembly buffer, we discard the entire packet. */
+    if(offset > UIP_REASS_BUFSIZE ||
+       offset + len > UIP_REASS_BUFSIZE) {
+      uip_reasstmr = 0;
+      goto nullreturn;
+    }
+
+    /* Copy the fragment into the reassembly buffer, at the right
+       offset. */
+    memcpy(&uip_reassbuf[UIP_IPH_LEN + offset],
+           (char *)BUF + (int)((BUF->vhl & 0x0f) * 4),
+           len);
+
+    /* Update the bitmap. */
+    if(offset / (8 * 8) == (offset + len) / (8 * 8)) {
+    /* If the two endpoints are in the same byte, we only update
+       that byte. */
+
+      uip_reassbitmap[offset / (8 * 8)] |=
+         bitmap_bits[(offset / 8 ) & 7] &
+         ~bitmap_bits[((offset + len) / 8 ) & 7];
+    } else {
+      /* If the two endpoints are in different bytes, we update the
+         bytes in the endpoints and fill the stuff inbetween with
+         0xff. */
+      uip_reassbitmap[offset / (8 * 8)] |= bitmap_bits[(offset / 8 ) & 7];
+      for(i = 1 + offset / (8 * 8); i < (offset + len) / (8 * 8); ++i) {
+        uip_reassbitmap[i] = 0xff;
+      }
+      uip_reassbitmap[(offset + len) / (8 * 8)] |=
+      ~bitmap_bits[((offset + len) / 8 ) & 7];
+    }
+
+    /* If this fragment has the More Fragments flag set to zero, we
+       know that this is the last fragment, so we can calculate the
+       size of the entire packet. We also set the
+       IP_REASS_FLAG_LASTFRAG flag to indicate that we have received
+       the final fragment. */
+
+    if((BUF->ipoffset[0] & IP_MF) == 0) {
+      uip_reassflags |= UIP_REASS_FLAG_LASTFRAG;
+      uip_reasslen = offset + len;
+    }
+
+    /* Finally, we check if we have a full packet in the buffer. We do
+       this by checking if we have the last fragment and if all bits
+       in the bitmap are set. */
+    if(uip_reassflags & UIP_REASS_FLAG_LASTFRAG) {
+      /* Check all bytes up to and including all but the last byte in
+         the bitmap. */
+      for(i = 0; i < uip_reasslen / (8 * 8) - 1; ++i) {
+        if(uip_reassbitmap[i] != 0xff) {
+          goto nullreturn;
+        }
+      }
+      /* Check the last byte in the bitmap. It should contain just the
+       right amount of bits. */
+      if(uip_reassbitmap[uip_reasslen / (8 * 8)] !=
+          (uint8_t)~bitmap_bits[uip_reasslen / 8 & 7]) {
+        goto nullreturn;
+      }
+
+      /* If we have come this far, we have a full packet in the
+         buffer, so we allocate a pbuf and copy the packet into it. We
+         also reset the timer. */
+      uip_reasstmr = 0;
+      memcpy(BUF, FBUF, uip_reasslen);
+
+      /* Pretend to be a "normal" (i.e., not fragmented) IP packet
+         from now on. */
+      BUF->ipoffset[0] = BUF->ipoffset[1] = 0;
+      BUF->len[0] = uip_reasslen >> 8;
+      BUF->len[1] = uip_reasslen & 0xff;
+      BUF->ipchksum = 0;
+      BUF->ipchksum = ~(uip_ipchksum());
+
+      return uip_reasslen;
+    }
+  }
+
+ nullreturn:
+  return 0;
+}
+#endif /* UIP_REASSEMBLY */
+/*---------------------------------------------------------------------------*/
+static void
+uip_add_rcv_nxt(uint16_t n)
+{
+  uip_add32(uip_conn->rcv_nxt, n);
+#if NO_XMOS_PROJECT
+  uip_conn->rcv_nxt[0] = uip_acc32[0];
+  uip_conn->rcv_nxt[1] = uip_acc32[1];
+  uip_conn->rcv_nxt[2] = uip_acc32[2];
+  uip_conn->rcv_nxt[3] = uip_acc32[3];
+#else
+  xtcp_copy_word(uip_conn->rcv_nxt, uip_acc32);
+#endif /* NO_XMOS_PROJECT */
+}
+/*---------------------------------------------------------------------------*/
+void
+xtcpd_init_send_from_uip(struct uip_conn *conn);
+
+void
+uip_process(uint8_t flag)
+{
+  register struct uip_conn *uip_connr = uip_conn;
+
+#if UIP_SLIDING_WINDOW
+  uip_do_split = 0;
+  uip_slen = 0;
+#endif
+
+#if UIP_UDP
+  if(flag == UIP_UDP_SEND_CONN) {
+    goto udp_send;
+  }
+#endif /* UIP_UDP */
+
+  uip_sappdata = uip_appdata = &uip_buf[UIP_IPTCPH_LEN + UIP_LLH_LEN];
+
+  /* Check if we were invoked because of a poll request for a
+     particular connection. */
+  if(flag == UIP_POLL_REQUEST) {
+    if((uip_connr->tcpstateflags & UIP_TS_MASK) == UIP_ESTABLISHED
+#if UIP_SLIDING_WINDOW
+                    && ((!uip_outstanding(uip_connr)) || uip_connr->midpoint)
+#else
+                    && !uip_outstanding(uip_connr)
+#endif
+                    ) {
+      uip_flags = UIP_POLL;
+                        uip_len = 0;
+                        uip_slen = 0;
+      UIP_APPCALL();
+      goto appsend;
+    }
+    goto drop;
+
+    /* Check if we were invoked because of the perodic timer fireing. */
+  } else if(flag == UIP_TIMER) {
+#if UIP_REASSEMBLY
+    if(uip_reasstmr != 0) {
+      --uip_reasstmr;
+    }
+#endif /* UIP_REASSEMBLY */
+    /* Increase the initial sequence number. */
+#if NO_XMOS_PROJECT
+    if(++iss[3] == 0) {
+      if(++iss[2] == 0) {
+	if(++iss[1] == 0) {
+	  ++iss[0];
+	}
+      }
+    }
+#else
+    xtcp_increment_word(iss);
+#endif/* NO_XMOS_PROJECT */
+    /* Reset the length variables. */
+    uip_len = 0;
+    uip_slen = 0;
+
+    /* Check if the connection is in a state in which we simply wait
+       for the connection to time out. If so, we increase the
+       connection's timer and remove the connection if it times
+       out. */
+    if(uip_connr->tcpstateflags == UIP_TIME_WAIT ||
+       uip_connr->tcpstateflags == UIP_FIN_WAIT_2) {
+      ++(uip_connr->tmr);
+      if(uip_connr->tmr == UIP_TIME_WAIT_TIMEOUT) {
+        uip_connr->tcpstateflags = UIP_CLOSED;
+      }
+    } else if(uip_connr->tcpstateflags != UIP_CLOSED) {
+      /* If the connection has outstanding data, we increase the
+         connection's timer and see if it has reached the RTO value
+         in which case we retransmit. */
+
+      if(uip_outstanding(uip_connr)) {
+        if(uip_connr->tmr-- == 0) {
+          if(uip_connr->nrtx == UIP_MAXRTX ||
+              ((uip_connr->tcpstateflags == UIP_SYN_SENT ||
+                uip_connr->tcpstateflags == UIP_SYN_RCVD) &&
+                uip_connr->nrtx == UIP_MAXSYNRTX)) {
+            uip_connr->tcpstateflags = UIP_CLOSED;
+
+            /* We call UIP_APPCALL() with uip_flags set to
+             UIP_TIMEDOUT to inform the application that the
+             connection has timed out. */
+            uip_flags = UIP_TIMEDOUT;
+            UIP_APPCALL();
+
+            /* We also send a reset packet to the remote host. */
+            BUF->flags = TCP_RST | TCP_ACK;
+            goto tcp_send_nodata;
+          }
+
+          /* Exponential backoff. */
+          uip_connr->tmr = UIP_RTO << (uip_connr->nrtx > 4 ? 4 : uip_connr->nrtx);
+          ++(uip_connr->nrtx);
+
+          /* Ok, so we need to retransmit. We do this differently
+             depending on which state we are in. In ESTABLISHED, we
+             call upon the application so that it may prepare the
+             data for the retransmit. In SYN_RCVD, we resend the
+             SYNACK that we sent earlier and in LAST_ACK we have to
+             retransmit our FINACK. */
+          UIP_STAT(++uip_stat.tcp.rexmit);
+          switch(uip_connr->tcpstateflags & UIP_TS_MASK) {
+          case UIP_SYN_RCVD:
+            /* In the SYN_RCVD state, we should retransmit our
+               SYNACK. */
+            goto tcp_send_synack;
+
+#if UIP_ACTIVE_OPEN
+          case UIP_SYN_SENT:
+            /* In the SYN_SENT state, we retransmit out SYN. */
+            BUF->flags = 0;
+            goto tcp_send_syn;
+#endif /* UIP_ACTIVE_OPEN */
+
+          case UIP_ESTABLISHED:
+            /* In the ESTABLISHED state, we call upon the application
+               to do the actual retransmit after which we jump into
+               the code for sending out the packet (the apprexmit
+               label). */
+            uip_flags = UIP_REXMIT;
+            UIP_APPCALL();
+            goto apprexmit;
+
+          case UIP_FIN_WAIT_1:
+          case UIP_CLOSING:
+          case UIP_LAST_ACK:
+            /* In all these states we should retransmit a FINACK. */
+            goto tcp_send_finack;
+
+          }
+        }
+      } else if((uip_connr->tcpstateflags & UIP_TS_MASK) == UIP_ESTABLISHED) {
+        /* If there was no need for a retransmission, we poll the
+           application for new data. */
+        uip_flags = UIP_POLL;
+        UIP_APPCALL();
+        goto appsend;
+      }
+    }
+    goto drop;
+  }
+#if UIP_UDP
+  if(flag == UIP_UDP_TIMER || flag == UIP_UDP_ACKDATA) {
+    if(uip_udp_conn->lport != 0) {
+      uip_conn = NULL;
+      uip_sappdata = uip_appdata = &uip_buf[UIP_LLH_LEN + UIP_IPUDPH_LEN];
+      uip_len = uip_slen = 0;
+      if(flag == UIP_UDP_ACKDATA) {
+        uip_flags = UIP_ACKDATA;
+        uip_udp_conn->udpflags ^= UDP_SENT;
+      }
+      else
+      uip_flags = UIP_POLL;
+      UIP_UDP_APPCALL();
+      goto udp_send;
+    } else {
+      goto drop;
+    }
+  }
+  else if(flag == UIP_UDP_ARP_EVENT) {
+    if(uip_udp_conn->lport != 0 &&
+        (uip_udp_conn->udpflags & UDP_PENDING_ARP)) {
+      uip_conn = NULL;
+      uip_sappdata = uip_appdata = &uip_buf[UIP_LLH_LEN + UIP_IPUDPH_LEN];
+      uip_len = uip_slen = 0;
+      uip_flags = UIP_REXMIT;
+      uip_udp_conn->udpflags ^= UDP_PENDING_ARP;
+      UIP_UDP_APPCALL();
+      goto udp_send;
+    } else {
+      goto drop;
+    }
+  }
+
+#endif
+
+  /* This is where the input processing starts. */
+  UIP_STAT(++uip_stat.ip.recv);
+
+  /* Start of IP input header processing code. */
+
+#if UIP_CONF_IPV6
+  /* Check validity of the IP header. */
+  if((BUF->vtc & 0xf0) != 0x60) { /* IP version and header length. */
+    UIP_STAT(++uip_stat.ip.drop);
+    UIP_STAT(++uip_stat.ip.vhlerr);
+    UIP_LOG("ipv6: invalid version.");
+    goto drop;
+  }
+#else /* UIP_CONF_IPV6 */
+  /* Check validity of the IP header. */
+  if(BUF->vhl != 0x45) { /* IP version and header length. */
+    UIP_STAT(++uip_stat.ip.drop);
+    UIP_STAT(++uip_stat.ip.vhlerr);
+    UIP_LOG("ip: invalid version or header length: ");
+#if UIP_CONF_LOGGING
+    printhexln(BUF->vhl);
+#endif
+    goto drop;
+  }
+#endif /* UIP_CONF_IPV6 */
+
+  /* Check the size of the packet. If the size reported to us in
+     uip_len is smaller the size reported in the IP header, we assume
+     that the packet has been corrupted in transit. If the size of
+     uip_len is larger than the size reported in the IP packet header,
+     the packet has been padded and we set uip_len to the correct
+     value.. */
+
+  if((BUF->len[0] << 8) + BUF->len[1] <= uip_len) {
+    uip_len = (BUF->len[0] << 8) + BUF->len[1];
+#if UIP_CONF_IPV6
+    uip_len += 40; /* The length reported in the IPv6 header is the
+                      length of the payload that follows the
+                      header. However, uIP uses the uip_len variable
+                      for holding the size of the entire packet,
+                      including the IP header. For IPv4 this is not a
+                      problem as the length field in the IPv4 header
+                      contains the length of the entire packet. But
+                      for IPv6 we need to add the size of the IPv6
+                      header (40 bytes). */
+#endif /* UIP_CONF_IPV6 */
+  } else {
+    UIP_LOG("ip: packet shorter than reported in IP header.");
+    goto drop;
+  }
+
+#if !UIP_CONF_IPV6
+  /* Check the fragment flag. */
+  if((BUF->ipoffset[0] & 0x3f) != 0 || BUF->ipoffset[1] != 0) {
+#if UIP_REASSEMBLY
+    uip_len = uip_reass();
+    if(uip_len == 0) {
+      goto drop;
+    }
+#else /* UIP_REASSEMBLY */
+    UIP_STAT(++uip_stat.ip.drop);
+    UIP_STAT(++uip_stat.ip.fragerr);
+    UIP_LOG("ip: fragment dropped.");
+    goto drop;
+#endif /* UIP_REASSEMBLY */
+  }
+#endif /* UIP_CONF_IPV6 */
+
+  if(uip_ipaddr_cmp(&uip_hostaddr, &uip_all_zeroes_addr)) {
+    /* If we are configured to use ping IP address configuration and
+       hasn't been assigned an IP address yet, we accept all ICMP
+       packets. */
+#if UIP_PINGADDRCONF && !UIP_CONF_IPV6
+    if(BUF->proto == UIP_PROTO_ICMP) {
+      UIP_LOG("ip: possible ping config packet received.");
+      goto icmp_input;
+    } else {
+      UIP_LOG("ip: packet dropped since no address assigned.");
+      goto drop;
+    }
+#endif /* UIP_PINGADDRCONF */
+
+  } else {
+    /* If IP broadcast support is configured, we check for a broadcast
+       UDP packet, which may be destined to us. */
+#if UIP_BROADCAST
+    DEBUG_PRINTF("UDP IP checksum 0x%04x\n", uip_ipchksum());
+    if(BUF->proto == UIP_PROTO_UDP &&
+        (uip_ipaddr_cmp(&BUF->destipaddr, &uip_broadcast_addr) ||
+                uip_ipaddr_is_multicast(BUF->destipaddr)) // Fix for UDP multicast traffic
+        /*&&
+         uip_ipchksum() == 0xffff*/) {
+      goto udp_input;
+    }
+#endif /* UIP_BROADCAST */
+
+    /* Check if the packet is destined for our IP address. */
+#if !UIP_CONF_IPV6
+    if(!uip_ipaddr_cmp(&BUF->destipaddr, &uip_hostaddr)
+#if UIP_IGMP
+        && !igmp_check_addr(BUF->destipaddr)
+#endif
+        ) {
+      UIP_STAT(++uip_stat.ip.drop);
+      goto drop;
+    }
+#else /* UIP_CONF_IPV6 */
+    /* For IPv6, packet reception is a little trickier as we need to
+       make sure that we listen to certain multicast addresses (all
+       hosts multicast address, and the solicited-node multicast
+       address) as well. However, we will cheat here and accept all
+       multicast packets that are sent to the ff02::/16 addresses. */
+    if(!uip_ipaddr_cmp(&BUF->destipaddr, &uip_hostaddr) &&
+       BUF->destipaddr.u16[0] != UIP_HTONS(0xff02)) {
+      UIP_STAT(++uip_stat.ip.drop);
+      goto drop;
+    }
+#endif /* UIP_CONF_IPV6 */
+  }
+
+#if !UIP_CONF_IPV6
+  if(uip_ipchksum() != 0xffff) { /* Compute and check the IP header
+                                    checksum. */
+    UIP_STAT(++uip_stat.ip.drop);
+    UIP_STAT(++uip_stat.ip.chkerr);
+    UIP_LOG("ip: bad checksum.");
+    goto drop;
+  }
+#endif /* UIP_CONF_IPV6 */
+
+  if(BUF->proto == UIP_PROTO_TCP) { /* Check for TCP packet. If so,
+                                       proceed with TCP input
+                                       processing. */
+    goto tcp_input;
+  }
+
+#if UIP_UDP
+  if(BUF->proto == UIP_PROTO_UDP) {
+    goto udp_input;
+  }
+#endif /* UIP_UDP */
+
+#if !UIP_CONF_IPV6
+
+#if UIP_IGMP
+  if(BUF->proto == UIP_PROTO_IGMP) {
+    igmp_in();
+    return;
+  }
+#endif
+
+  /* ICMPv4 processing code follows. */
+  if(BUF->proto != UIP_PROTO_ICMP) { /* We only allow ICMP packets from
+                                        here. */
+    UIP_STAT(++uip_stat.ip.drop);
+    UIP_STAT(++uip_stat.ip.protoerr);
+    UIP_LOG("ip: neither tcp nor icmp.");
+    goto drop;
+  }
+
+#if UIP_PINGADDRCONF
+ icmp_input:
+#endif /* UIP_PINGADDRCONF */
+  UIP_STAT(++uip_stat.icmp.recv);
+
+  /* ICMP echo (i.e., ping) processing. This is simple, we only change
+     the ICMP type from ECHO to ECHO_REPLY and adjust the ICMP
+     checksum before we return the packet. */
+  if(ICMPBUF->type != ICMP_ECHO) {
+    UIP_STAT(++uip_stat.icmp.drop);
+    UIP_STAT(++uip_stat.icmp.typeerr);
+    UIP_LOG("icmp: not icmp echo.");
+    goto drop;
+  }
+
+  /* If we are configured to use ping IP address assignment, we use
+     the destination IP address of this ping packet and assign it to
+     ourself. */
+#if UIP_PINGADDRCONF
+  if(uip_ipaddr_cmp(&uip_hostaddr, &uip_all_zeroes_addr)) {
+    uip_hostaddr = BUF->destipaddr;
+  }
+#endif /* UIP_PINGADDRCONF */
+
+  ICMPBUF->type = ICMP_ECHO_REPLY;
+
+  if(ICMPBUF->icmpchksum >= UIP_HTONS(0xffff - (ICMP_ECHO << 8))) {
+    ICMPBUF->icmpchksum += UIP_HTONS(ICMP_ECHO << 8) + 1;
+  } else {
+    ICMPBUF->icmpchksum += UIP_HTONS(ICMP_ECHO << 8);
+  }
+
+  /* Swap IP addresses. */
+  uip_ipaddr_copy(&BUF->destipaddr, &BUF->srcipaddr);
+  uip_ipaddr_copy(&BUF->srcipaddr, &uip_hostaddr);
+
+  UIP_STAT(++uip_stat.icmp.sent);
+  goto send;
+
+  /* End of IPv4 input header processing code. */
+#else /* !UIP_CONF_IPV6 */
+
+  /* This is IPv6 ICMPv6 processing code. */
+  DEBUG_PRINTF("icmp6_input: length %d\n", uip_len);
+
+  if(BUF->proto != UIP_PROTO_ICMP6) { /* We only allow ICMPv6 packets from
+                                         here. */
+    UIP_STAT(++uip_stat.ip.drop);
+    UIP_STAT(++uip_stat.ip.protoerr);
+    UIP_LOG("ip: neither tcp nor icmp6.");
+    goto drop;
+  }
+
+  UIP_STAT(++uip_stat.icmp.recv);
+
+  /* If we get a neighbor solicitation for our address we should send
+     a neighbor advertisement message back. */
+  if(ICMPBUF->type == ICMP6_NEIGHBOR_SOLICITATION) {
+    if(uip_ipaddr_cmp(&ICMPBUF->icmp6data, &uip_hostaddr)) {
+
+      if(ICMPBUF->options[0] == ICMP6_OPTION_SOURCE_LINK_ADDRESS) {
+        /* Save the sender's address in our neighbor list. */
+        uip_neighbor_add(&ICMPBUF->srcipaddr, &(ICMPBUF->options[2]));
+      }
+
+      /* We should now send a neighbor advertisement back to where the
+         neighbor solicication came from. */
+      ICMPBUF->type = ICMP6_NEIGHBOR_ADVERTISEMENT;
+      ICMPBUF->flags = ICMP6_FLAG_S; /* Solicited flag. */
+
+      ICMPBUF->reserved1 = ICMPBUF->reserved2 = ICMPBUF->reserved3 = 0;
+
+      uip_ipaddr_copy(&ICMPBUF->destipaddr, &ICMPBUF->srcipaddr);
+      uip_ipaddr_copy(&ICMPBUF->srcipaddr, &uip_hostaddr);
+      ICMPBUF->options[0] = ICMP6_OPTION_TARGET_LINK_ADDRESS;
+      ICMPBUF->options[1] = 1;  /* Options length, 1 = 8 bytes. */
+      memcpy(&(ICMPBUF->options[2]), &uip_ethaddr, sizeof(uip_ethaddr));
+      ICMPBUF->icmpchksum = 0;
+      ICMPBUF->icmpchksum = ~uip_icmp6chksum();
+      
+      goto send;
+
+    }
+    goto drop;
+  } else if(ICMPBUF->type == ICMP6_ECHO) {
+    /* ICMP echo (i.e., ping) processing. This is simple, we only
+       change the ICMP type from ECHO to ECHO_REPLY and update the
+       ICMP checksum before we return the packet. */
+
+    ICMPBUF->type = ICMP6_ECHO_REPLY;
+
+    uip_ipaddr_copy(&BUF->destipaddr, &BUF->srcipaddr);
+    uip_ipaddr_copy(&BUF->srcipaddr, &uip_hostaddr);
+    ICMPBUF->icmpchksum = 0;
+    ICMPBUF->icmpchksum = ~uip_icmp6chksum();
+
+    UIP_STAT(++uip_stat.icmp.sent);
+    goto send;
+  } else {
+    DEBUG_PRINTF("Unknown icmp6 message type %d\n", ICMPBUF->type);
+    UIP_STAT(++uip_stat.icmp.drop);
+    UIP_STAT(++uip_stat.icmp.typeerr);
+    UIP_LOG("icmp: unknown ICMP message.");
+    goto drop;
+  }
+
+  /* End of IPv6 ICMP processing. */
+
+#endif /* !UIP_CONF_IPV6 */
+
+#if UIP_UDP
+  /* UDP input processing. */
+ udp_input:
+  /* UDP processing is really just a hack. We don't do anything to the
+     UDP/IP headers, but let the UDP application do all the hard
+     work. If the application sets uip_slen, it has a packet to
+     send. */
+#if UIP_UDP_CHECKSUMS
+  uip_len = uip_len - UIP_IPUDPH_LEN;
+  uip_appdata = &uip_buf[UIP_LLH_LEN + UIP_IPUDPH_LEN];
+  if(UDPBUF->udpchksum != 0 && uip_udpchksum() != 0xffff) {
+    UIP_STAT(++uip_stat.udp.drop);
+    UIP_STAT(++uip_stat.udp.chkerr);
+    UIP_LOG("udp: bad checksum.");
+    goto drop;
+  }
+#else /* UIP_UDP_CHECKSUMS */
+  uip_len = uip_len - UIP_IPUDPH_LEN;
+#endif /* UIP_UDP_CHECKSUMS */
+
+  /* Demultiplex this UDP packet between the UDP "connections". */
+  for(uip_udp_conn = &uip_udp_conns[0];
+      uip_udp_conn < &uip_udp_conns[UIP_UDP_CONNS];
+      ++uip_udp_conn) {
+    /* If the local UDP port is non-zero, the connection is considered
+       to be used. If so, the local port number is checked against the
+       destination port number in the received packet. If the two port
+       numbers match, the remote port number is checked if the
+       connection is bound to a remote port. Finally, if the
+       connection is bound to a remote IP address, the source IP
+       address of the packet is checked. */
+
+#if 0
+    if(uip_udp_conn->lport != 0 &&
+        UDPBUF->destport == uip_udp_conn->lport &&
+        (uip_udp_conn->rport == 0 ||
+            (uip_udp_conn->udpflags & UDP_IS_SERVER_CONN) ||
+            UDPBUF->srcport == uip_udp_conn->rport) &&
+        ((uip_udp_conn->udpflags & UDP_IS_SERVER_CONN) ||
+            uip_ipaddr_cmp(uip_udp_conn->ripaddr, all_zeroes_addr) ||
+            uip_ipaddr_cmp(uip_udp_conn->ripaddr, all_ones_addr) ||
+            uip_ipaddr_cmp(BUF->srcipaddr, uip_udp_conn->ripaddr) ||
+            uip_ipaddr_is_multicast(uip_udp_conn->ripaddr))) {
+
+      goto udp_found;
+    }
+#endif
+
+    if(uip_udp_conn->lport != 0 &&
+        UDPBUF->destport == uip_udp_conn->lport &&
+        UDPBUF->srcport == uip_udp_conn->rport &&
+        (uip_ipaddr_cmp(&UDPBUF->srcipaddr, &uip_udp_conn->ripaddr)
+                || (UDPBUF->destport == 0x4400) // Fix for DHCP
+                || (uip_ipaddr_is_multicast(uip_udp_conn->ripaddr)))
+          )
+    {
+      goto udp_found;
+    }
+  }
+
+  tmp16 = BUF->destport;
+  /* Next, check listening connections. */
+  for(c = 0; c < UIP_LISTENPORTS; ++c) {
+    if(tmp16 == uip_udp_listenports[c]) {
+      uip_udp_conn = 0;
+      for(c = 0; c < UIP_UDP_CONNS; ++c) {
+        if(uip_udp_conns[c].lport == 0) {
+          uip_udp_conn = &uip_udp_conns[c];
+          break;
+        }
+      }
+      if(uip_udp_conn != 0) {
+        uip_udp_conn->lport = tmp16;
+        uip_udp_conn->rport = UDPBUF->srcport;
+        uip_udp_conn->ttl = UIP_TTL;
+        uip_udp_conn->udpflags = 0;
+        uip_flags = UIP_CONNECTED | UIP_NEWDATA;
+        uip_ipaddr_copy(&uip_udp_conn->ripaddr, &UDPBUF->srcipaddr);
+        goto udp_found_listener;
+      }
+    }
+  }
+
+  // No matching connection found
+  goto drop;
+
+ udp_found:
+  uip_conn = NULL;
+  uip_flags = UIP_NEWDATA;
+ udp_found_listener:
+  uip_sappdata = uip_appdata = &uip_buf[UIP_LLH_LEN + UIP_IPUDPH_LEN];
+  uip_slen = 0;
+  UIP_UDP_APPCALL();
+
+ udp_send:
+  if(uip_slen == 0) {
+    goto drop;
+  }
+  uip_len = uip_slen + UIP_IPUDPH_LEN;
+
+#if UIP_CONF_IPV6
+  /* For IPv6, the IP length field does not include the IPv6 IP header
+     length. */
+  BUF->len[0] = ((uip_len - UIP_IPH_LEN) >> 8);
+  BUF->len[1] = ((uip_len - UIP_IPH_LEN) & 0xff);
+#else /* UIP_CONF_IPV6 */
+  BUF->len[0] = (uip_len >> 8);
+  BUF->len[1] = (uip_len & 0xff);
+#endif /* UIP_CONF_IPV6 */
+
+  BUF->ttl = uip_udp_conn->ttl;
+  BUF->proto = UIP_PROTO_UDP;
+
+  UDPBUF->udplen = UIP_HTONS(uip_slen + UIP_UDPH_LEN);
+  UDPBUF->udpchksum = 0;
+
+  BUF->srcport  = uip_udp_conn->lport;
+  BUF->destport = uip_udp_conn->rport;
+
+  uip_ipaddr_copy(&BUF->srcipaddr, &uip_hostaddr);
+  uip_ipaddr_copy(&BUF->destipaddr, &uip_udp_conn->ripaddr);
+
+  uip_appdata = &uip_buf[UIP_LLH_LEN + UIP_IPTCPH_LEN];
+
+#if UIP_UDP_CHECKSUMS
+  /* Calculate UDP checksum. */
+  UDPBUF->udpchksum = ~(uip_udpchksum());
+  if(UDPBUF->udpchksum == 0) {
+    UDPBUF->udpchksum = 0xffff;
+  }
+#endif /* UIP_UDP_CHECKSUMS */
+
+  goto ip_send_nolen;
+#endif /* UIP_UDP */
+
+  /* TCP input processing. */
+ tcp_input:
+  UIP_STAT(++uip_stat.tcp.recv);
+
+  /* Start of TCP input header processing code. */
+
+  if(uip_tcpchksum() != 0xffff) {   /* Compute and check the TCP
+                                       checksum. */
+    UIP_STAT(++uip_stat.tcp.drop);
+    UIP_STAT(++uip_stat.tcp.chkerr);
+    UIP_LOG("tcp: bad checksum.");
+    goto drop;
+  }
+
+  /* Demultiplex this segment. */
+  /* First check any active connections. */
+  for(uip_connr = &uip_conns[0]; uip_connr <= &uip_conns[UIP_CONNS - 1];
+      ++uip_connr) {
+    if(uip_connr->tcpstateflags != UIP_CLOSED &&
+       BUF->destport == uip_connr->lport &&
+       BUF->srcport == uip_connr->rport &&
+       uip_ipaddr_cmp(&BUF->srcipaddr, &uip_connr->ripaddr)) {
+      goto found;
+    }
+  }
+
+  /* If we didn't find and active connection that expected the packet,
+     either this packet is an old duplicate, or this is a SYN packet
+     destined for a connection in LISTEN. If the SYN flag isn't set,
+     it is an old packet and we send a RST. */
+  if((BUF->flags & TCP_CTL) != TCP_SYN) {
+    goto reset;
+  }
+
+  tmp16 = BUF->destport;
+  /* Next, check listening connections. */
+  for(c = 0; c < UIP_LISTENPORTS; ++c) {
+    if(tmp16 == uip_listenports[c]) {
+      goto found_listen;
+    }
+  }
+
+  /* No matching connection found, so we send a RST packet. */
+  UIP_STAT(++uip_stat.tcp.synrst);
+
+ reset:
+  /* We do not send resets in response to resets. */
+  if(BUF->flags & TCP_RST) {
+    goto drop;
+  }
+
+  UIP_STAT(++uip_stat.tcp.rst);
+
+  BUF->flags = TCP_RST | TCP_ACK;
+  uip_len = UIP_IPTCPH_LEN;
+  BUF->tcpoffset = 5 << 4;
+
+  /* Flip the seqno and ackno fields in the TCP header. */
+#if NO_XMOS_PROJECT
+  c = BUF->seqno[3];
+  BUF->seqno[3] = BUF->ackno[3];
+  BUF->ackno[3] = c;
+  
+  c = BUF->seqno[2];
+  BUF->seqno[2] = BUF->ackno[2];
+  BUF->ackno[2] = c;
+  
+  c = BUF->seqno[1];
+  BUF->seqno[1] = BUF->ackno[1];
+  BUF->ackno[1] = c;
+  
+  c = BUF->seqno[0];
+  BUF->seqno[0] = BUF->ackno[0];
+  BUF->ackno[0] = c;
+#else
+  xtcp_swap_words(BUF->seqno, BUF->ackno);
+#endif /* NO_XMOS_PROJECT */
+  /* We also have to increase the sequence number we are
+     acknowledging. If the least significant byte overflowed, we need
+     to propagate the carry to the other bytes as well. */
+#if NO_XMOS_PROJECT
+  if(++BUF->ackno[3] == 0) {
+    if(++BUF->ackno[2] == 0) {
+      if(++BUF->ackno[1] == 0) {
+	++BUF->ackno[0];
+      }
+    }
+  }
+#else
+  xtcp_increment_word(BUF->ackno);
+#endif /* NO_XMOS_PROJECT */
+
+  /* Swap port numbers. */
+  tmp16 = BUF->srcport;
+  BUF->srcport = BUF->destport;
+  BUF->destport = tmp16;
+
+  /* Swap IP addresses. */
+  uip_ipaddr_copy(&BUF->destipaddr, &BUF->srcipaddr);
+  uip_ipaddr_copy(&BUF->srcipaddr, &uip_hostaddr);
+
+  /* And send out the RST packet! */
+  goto tcp_send_noconn;
+
+  /* This label will be jumped to if we matched the incoming packet
+     with a connection in LISTEN. In that case, we should create a new
+     connection and send a SYNACK in return. */
+ found_listen:
+  /* First we check if there are any connections avaliable. Unused
+     connections are kept in the same table as used connections, but
+     unused ones have the tcpstate set to CLOSED. Also, connections in
+     TIME_WAIT are kept track of and we'll use the oldest one if no
+     CLOSED connections are found. Thanks to Eddie C. Dost for a very
+     nice algorithm for the TIME_WAIT search. */
+  uip_connr = 0;
+  for(c = 0; c < UIP_CONNS; ++c) {
+    if(uip_conns[c].tcpstateflags == UIP_CLOSED) {
+      uip_connr = &uip_conns[c];
+      break;
+    }
+    if(uip_conns[c].tcpstateflags == UIP_TIME_WAIT) {
+      if(uip_connr == 0 || uip_conns[c].tmr > uip_connr->tmr) {
+        uip_connr = &uip_conns[c];
+      }
+    }
+  }
+
+  if(uip_connr == 0) {
+    /* All connections are used already, we drop packet and hope that
+       the remote end will retransmit the packet at a time when we
+       have more spare connections. */
+    UIP_STAT(++uip_stat.tcp.syndrop);
+    UIP_LOG("tcp: found no unused connections.");
+    goto drop;
+  }
+  uip_conn = uip_connr;
+
+  /* Fill in the necessary fields for the new connection. */
+  uip_connr->rto = uip_connr->tmr = UIP_RTO;
+  uip_connr->sa = 0;
+  uip_connr->sv = 4;
+  uip_connr->nrtx = 0;
+  uip_connr->lport = BUF->destport;
+  uip_connr->rport = BUF->srcport;
+  uip_ipaddr_copy(&uip_connr->ripaddr, &BUF->srcipaddr);
+  uip_connr->tcpstateflags = UIP_SYN_RCVD;
+
+#if NO_XMOS_PROJECT
+  uip_connr->snd_nxt[0] = iss[0];
+  uip_connr->snd_nxt[1] = iss[1];
+  uip_connr->snd_nxt[2] = iss[2];
+  uip_connr->snd_nxt[3] = iss[3];
+#else
+  xtcp_copy_word(uip_connr->snd_nxt, iss);
+#endif /* NO_XMOS_PROJECT */
+  uip_connr->len = 1;
+
+  /* rcv_nxt should be the seqno from the incoming packet + 1. */
+#if NO_XMOS_PROJECT
+  uip_connr->rcv_nxt[3] = BUF->seqno[3];
+  uip_connr->rcv_nxt[2] = BUF->seqno[2];
+  uip_connr->rcv_nxt[1] = BUF->seqno[1];
+  uip_connr->rcv_nxt[0] = BUF->seqno[0];
+#else
+  xtcp_copy_word(uip_connr->rcv_nxt, BUF->seqno);
+#endif /* NO_XMOS_PROJECT */
+  uip_add_rcv_nxt(1);
+
+  /* Parse the TCP MSS option, if present. */
+  if((BUF->tcpoffset & 0xf0) > 0x50) {
+    for(c = 0; c < ((BUF->tcpoffset >> 4) - 5) << 2;) {
+      opt = uip_buf[UIP_TCPIP_HLEN + UIP_LLH_LEN + c];
+      if(opt == TCP_OPT_END) {
+        /* End of options. */
+           break;
+      } else if(opt == TCP_OPT_NOOP) {
+        ++c;
+        /* NOP option. */
+      } else if(opt == TCP_OPT_MSS &&
+        uip_buf[UIP_TCPIP_HLEN + UIP_LLH_LEN + 1 + c] == TCP_OPT_MSS_LEN) {
+        /* An MSS option with the right option length. */
+        tmp16 = ((uint16_t)uip_buf[UIP_TCPIP_HLEN + UIP_LLH_LEN + 2 + c] << 8) |
+         (uint16_t)uip_buf[UIP_IPTCPH_LEN + UIP_LLH_LEN + 3 + c];
+        uip_connr->initialmss = uip_connr->mss =
+          tmp16 > UIP_TCP_MSS ? UIP_TCP_MSS : tmp16;
+
+        /* And we are done processing options. */
+        break;
+      } else {
+        /* All other options have a length field, so that we easily
+           can skip past them. */
+        if(uip_buf[UIP_TCPIP_HLEN + UIP_LLH_LEN + 1 + c] == 0) {
+          /* If the length field is zero, the options are malformed
+             and we don't process them further. */
+          break;
+        }
+        c += uip_buf[UIP_TCPIP_HLEN + UIP_LLH_LEN + 1 + c];
+      }
+    }
+  }
+
+  /* Our response will be a SYNACK. */
+#if UIP_ACTIVE_OPEN
+ tcp_send_synack:
+  BUF->flags = TCP_ACK;
+
+ tcp_send_syn:
+  BUF->flags |= TCP_SYN;
+#else /* UIP_ACTIVE_OPEN */
+ tcp_send_synack:
+  BUF->flags = TCP_SYN | TCP_ACK;
+#endif /* UIP_ACTIVE_OPEN */
+
+  /* We send out the TCP Maximum Segment Size option with our
+     SYNACK. */
+  BUF->optdata[0] = TCP_OPT_MSS;
+  BUF->optdata[1] = TCP_OPT_MSS_LEN;
+  BUF->optdata[2] = (UIP_TCP_MSS) / 256;
+  BUF->optdata[3] = (UIP_TCP_MSS) & 255;
+  uip_len = UIP_IPTCPH_LEN + TCP_OPT_MSS_LEN;
+  BUF->tcpoffset = ((UIP_TCPH_LEN + TCP_OPT_MSS_LEN) / 4) << 4;
+  goto tcp_send;
+
+  /* This label will be jumped to if we found an active connection. */
+ found:
+  uip_conn = uip_connr;
+  uip_flags = 0;
+  /* We do a very naive form of TCP reset processing; we just accept
+     any RST and kill our connection. We should in fact check if the
+     sequence number of this reset is wihtin our advertised window
+     before we accept the reset. */
+  if(BUF->flags & TCP_RST) {
+    uip_connr->tcpstateflags = UIP_CLOSED;
+    UIP_LOG("tcp: got reset, aborting connection.");
+    uip_flags = UIP_ABORT;
+    UIP_APPCALL();
+    goto drop;
+  }
+  /* Calculate the length of the data, if the application has sent
+     any data to us. */
+  c = (BUF->tcpoffset >> 4) << 2;
+  /* uip_len will contain the length of the actual TCP data. This is
+     calculated by subtracing the length of the TCP header (in
+     c) and the length of the IP header (20 bytes). */
+  uip_len = uip_len - c - UIP_IPH_LEN;
+
+  /* First, check if the sequence number of the incoming packet is
+     what we're expecting next. If not, we send out an ACK with the
+     correct numbers in. */
+  if(!(((uip_connr->tcpstateflags & UIP_TS_MASK) == UIP_SYN_SENT)
+      && ((BUF->flags & TCP_CTL) == (TCP_SYN | TCP_ACK)))) {
+    if((uip_len > 0 || ((BUF->flags & (TCP_SYN | TCP_FIN)) != 0))
+                    && (!xtcp_compare_words(BUF->seqno, uip_connr->rcv_nxt))) {
+      goto tcp_send_ack;
+    }
+  }
+
+  /* Next, check if the incoming segment acknowledges any outstanding
+     data. If so, we update the sequence number, reset the length of
+     the outstanding data, calculate RTT estimations, and reset the
+     retransmission timer. */
+  if((BUF->flags & TCP_ACK) && uip_outstanding(uip_connr)) {
+    uip_add32(uip_connr->snd_nxt, uip_connr->len);
+#if UIP_SLIDING_WINDOW
+    unsigned int ackno = xtcp_get_word(BUF->ackno);
+    int diff = xtcp_get_word(uip_acc32) - ackno;
+
+    if(diff >= 0 && diff < uip_connr->len)
+#else
+    if((xtcp_compare_words(BUF->ackno, uip_acc32)))
+#endif
+    {
+      /* Update sequence number. */
+#if UIP_SLIDING_WINDOW
+      xtcp_copy_word(uip_connr->snd_nxt, BUF->ackno);
+#else
+      xtcp_copy_word(uip_connr->snd_nxt, uip_acc32);
+#endif
+
+      /* Do RTT estimation, unless we have done retransmissions. */
+      if(uip_connr->nrtx == 0) {
+        signed char m;
+        m = uip_connr->rto - uip_connr->tmr;
+        /* This is taken directly from VJs original code in his paper */
+        m = m - (uip_connr->sa >> 3);
+        uip_connr->sa += m;
+        if(m < 0) {
+          m = -m;
+        }
+        m = m - (uip_connr->sv >> 2);
+        uip_connr->sv += m;
+        uip_connr->rto = (uip_connr->sa >> 3) + uip_connr->sv;
+      }
+      /* Set the acknowledged flag. */
+      uip_flags = UIP_ACKDATA;
+      /* Reset the retransmission timer. */
+      uip_connr->tmr = uip_connr->rto;
+
+      /* Reset length of outstanding data. */
+#if UIP_SLIDING_WINDOW
+      uip_connr->midpoint = diff;
+      uip_connr->len = diff;
+
+#else
+      uip_connr->len = 0;
+#endif
+    }
+  }
+
+  if(BUF->flags & TCP_PSH) {
+    uip_flags |= UIP_TCP_PUSH;
+  }
+
+  /* Do different things depending on in what state the connection is. */
+  switch(uip_connr->tcpstateflags & UIP_TS_MASK) {
+    /* CLOSED and LISTEN are not handled here. CLOSE_WAIT is not
+       implemented, since we force the application to close when the
+       peer sends a FIN (hence the application goes directly from
+       ESTABLISHED to LAST_ACK). */
+  case UIP_SYN_RCVD:
+    /* In SYN_RCVD we have sent out a SYNACK in response to a SYN, and
+       we are waiting for an ACK that acknowledges the data we sent
+       out the last time. Therefore, we want to have the UIP_ACKDATA
+       flag set. If so, we enter the ESTABLISHED state. */
+    if(uip_flags & UIP_ACKDATA) {
+      uip_connr->tcpstateflags = UIP_ESTABLISHED;
+      uip_flags = UIP_CONNECTED;
+      uip_connr->len = 0;
+      if(uip_len > 0) {
+        uip_flags |= UIP_NEWDATA;
+        uip_add_rcv_nxt(uip_len);
+      }
+      uip_slen = 0;
+      UIP_APPCALL();
+      goto appsend;
+    }
+    goto drop;
+#if UIP_ACTIVE_OPEN
+  case UIP_SYN_SENT:
+    /* In SYN_SENT, we wait for a SYNACK that is sent in response to
+       our SYN. The rcv_nxt is set to sequence number in the SYNACK
+       plus one, and we send an ACK. We move into the ESTABLISHED
+       state. */
+    if((uip_flags & UIP_ACKDATA) &&
+       (BUF->flags & TCP_CTL) == (TCP_SYN | TCP_ACK)) {
+
+      /* Parse the TCP MSS option, if present. */
+      if((BUF->tcpoffset & 0xf0) > 0x50) {
+        for(c = 0; c < ((BUF->tcpoffset >> 4) - 5) << 2;) {
+          opt = uip_buf[UIP_IPTCPH_LEN + UIP_LLH_LEN + c];
+          if(opt == TCP_OPT_END) {
+            /* End of options. */
+            break;
+          } else if(opt == TCP_OPT_NOOP) {
+            ++c;
+            /* NOP option. */
+          } else if(opt == TCP_OPT_MSS &&
+                           uip_buf[UIP_TCPIP_HLEN + UIP_LLH_LEN + 1 + c] == TCP_OPT_MSS_LEN) {
+            /* An MSS option with the right option length. */
+            tmp16 = (uip_buf[UIP_TCPIP_HLEN + UIP_LLH_LEN + 2 + c] << 8) |
+                     uip_buf[UIP_TCPIP_HLEN + UIP_LLH_LEN + 3 + c];
+            uip_connr->initialmss =
+              uip_connr->mss = tmp16 > UIP_TCP_MSS? UIP_TCP_MSS: tmp16;
+
+            /* And we are done processing options. */
+            break;
+          } else {
+            /* All other options have a length field, so that we easily
+               can skip past them. */
+            if(uip_buf[UIP_TCPIP_HLEN + UIP_LLH_LEN + 1 + c] == 0) {
+              /* If the length field is zero, the options are malformed
+                 and we don't process them further. */
+              break;
+            }
+            c += uip_buf[UIP_TCPIP_HLEN + UIP_LLH_LEN + 1 + c];
+          }
+        }
+      }
+      uip_connr->tcpstateflags = UIP_ESTABLISHED;
+#if NO_XMOS_PROJECT
+      uip_connr->rcv_nxt[0] = BUF->seqno[0];
+      uip_connr->rcv_nxt[1] = BUF->seqno[1];
+      uip_connr->rcv_nxt[2] = BUF->seqno[2];
+      uip_connr->rcv_nxt[3] = BUF->seqno[3];
+#else
+      xtcp_copy_word(uip_connr->rcv_nxt, BUF->seqno);
+#endif /* NO_XMOS_PROJECT */
+      uip_add_rcv_nxt(1);
+      uip_flags = UIP_CONNECTED | UIP_NEWDATA;
+      uip_connr->len = 0;
+      uip_len = 0;
+      uip_slen = 0;
+      UIP_APPCALL();
+      goto appsend;
+    }
+    /* Inform the application that the connection failed */
+    uip_flags = UIP_ABORT;
+    UIP_APPCALL();
+    /* The connection is closed after we send the RST */
+    uip_conn->tcpstateflags = UIP_CLOSED;
+    goto reset;
+#endif /* UIP_ACTIVE_OPEN */
+
+  case UIP_ESTABLISHED:
+    /* In the ESTABLISHED state, we call upon the application to feed
+       data into the uip_buf. If the UIP_ACKDATA flag is set, the
+       application should put new data into the buffer, otherwise we are
+       retransmitting an old segment, and the application should put that
+       data into the buffer.
+
+       If the incoming packet is a FIN, we should close the connection on
+       this side as well, and we send out a FIN and enter the LAST_ACK
+       state. We require that there is no outstanding data; otherwise the
+       sequence numbers will be screwed up. */
+
+    if(BUF->flags & TCP_FIN && !(uip_connr->tcpstateflags & UIP_STOPPED)) {
+      if(uip_outstanding(uip_connr)) {
+        goto drop;
+      }
+      uip_add_rcv_nxt(1 + uip_len);
+      uip_flags |= UIP_CLOSE;
+      if(uip_len > 0) {
+        uip_flags |= UIP_NEWDATA;
+      }
+      UIP_APPCALL();
+      uip_connr->len = 1;
+      uip_connr->tcpstateflags = UIP_LAST_ACK;
+      uip_connr->nrtx = 0;
+    tcp_send_finack:
+      BUF->flags = TCP_FIN | TCP_ACK;
+      goto tcp_send_nodata;
+    }
+
+    /* Check the URG flag. If this is set, the segment carries urgent
+       data that we must pass to the application. */
+    if((BUF->flags & TCP_URG) != 0) {
+#if UIP_URGDATA > 0
+      uip_urglen = (BUF->urgp[0] << 8) | BUF->urgp[1];
+      if(uip_urglen > uip_len) {
+        /* There is more urgent data in the next segment to come. */
+        uip_urglen = uip_len;
+      }
+      uip_add_rcv_nxt(uip_urglen);
+      uip_len -= uip_urglen;
+      uip_urgdata = uip_appdata;
+      uip_appdata += uip_urglen;
+    } else {
+      uip_urglen = 0;
+#else /* UIP_URGDATA > 0 */
+      uip_appdata = ((char *)uip_appdata) + ((BUF->urgp[0] << 8) | BUF->urgp[1]);
+      uip_len -= (BUF->urgp[0] << 8) | BUF->urgp[1];
+#endif /* UIP_URGDATA > 0 */
+    }
+
+    /* If uip_len > 0 we have TCP data in the packet, and we flag this
+       by setting the UIP_NEWDATA flag and update the sequence number
+       we acknowledge. If the application has stopped the dataflow
+       using uip_stop(), we must not accept any data packets from the
+       remote host. */
+    if(uip_len > 0
+         #ifndef UIP_ACCEPT_PACKETS_AFTER_PAUSE
+         && !(uip_connr->tcpstateflags & UIP_STOPPED)
+        #endif
+       ) {
+      uip_flags |= UIP_NEWDATA;
+      uip_add_rcv_nxt(uip_len);
+    }
+
+    /* Check if the available buffer space advertised by the other end
+       is smaller than the initial MSS for this connection. If so, we
+       set the current MSS to the window size to ensure that the
+       application does not send more data than the other end can
+       handle.
+
+       If the remote host advertises a zero window, we set the MSS to
+       the initial MSS so that the application will send an entire MSS
+       of data. This data will not be acknowledged by the receiver,
+       and the application will retransmit it. This is called the
+       "persistent timer" and uses the retransmission mechanim.
+    */
+    tmp16 = ((uint16_t)BUF->wnd[0] << 8) + (uint16_t)BUF->wnd[1];
+    if(tmp16 > uip_connr->initialmss ||
+       tmp16 == 0) {
+      tmp16 = uip_connr->initialmss;
+    }
+    uip_connr->mss = tmp16;
+
+    /* If this packet constitutes an ACK for outstanding data (flagged
+       by the UIP_ACKDATA flag, we should call the application since it
+       might want to send more data. If the incoming packet had data
+       from the peer (as flagged by the UIP_NEWDATA flag), the
+       application must also be notified.
+
+       When the application is called, the global variable uip_len
+       contains the length of the incoming data. The application can
+       access the incoming data through the global pointer
+       uip_appdata, which usually points UIP_IPTCPH_LEN + UIP_LLH_LEN
+       bytes into the uip_buf array.
+
+       If the application wishes to send any data, this data should be
+       put into the uip_appdata and the length of the data should be
+       put into uip_len. If the application don't have any data to
+       send, uip_len must be set to 0. */
+    if(uip_flags & (UIP_NEWDATA | UIP_ACKDATA)) {
+      uip_slen = 0;
+      UIP_APPCALL();
+
+    appsend:
+
+      if(uip_flags & UIP_ABORT) {
+        uip_slen = 0;
+        uip_connr->tcpstateflags = UIP_CLOSED;
+        BUF->flags = TCP_RST | TCP_ACK;
+        goto tcp_send_nodata;
+      }
+
+      if(uip_flags & UIP_CLOSE) {
+        uip_slen = 0;
+        uip_connr->len = 1;
+        uip_connr->tcpstateflags = UIP_FIN_WAIT_1;
+        uip_connr->nrtx = 0;
+        BUF->flags = TCP_FIN | TCP_ACK;
+        goto tcp_send_nodata;
+      }
+
+      uip_connr->nrtx = 0;
+
+      /* If uip_slen > 0, the application has data to be sent. */
+      if(uip_slen > 0) {
+
+#if UIP_SLIDING_WINDOW
+        if(uip_connr->midpoint) {
+          uip_do_split = 0;
+          uip_connr->len += uip_slen;
+          uip_len = uip_slen + UIP_TCPIP_HLEN;
+          BUF->flags = TCP_ACK | TCP_PSH;
+          goto tcp_send_noopts;
+        }
+        else {
+          /* Decide whether to split this packet and record the fact in the connection data */
+          uip_do_split = (uip_slen > ACTUAL_UIP_PACKET_SPLIT_THRESHOLD);
+          uip_connr->midpoint = 0;
+        }
+#endif
+        /* If the connection has acknowledged data, the contents of
+           the ->len variable should be discarded. */
+        if((uip_flags & UIP_ACKDATA) != 0) {
+          uip_connr->len = 0;
+        }
+
+        /* If the ->len variable is non-zero the connection has
+           already data in transit and cannot send anymore right
+           now. */
+        if(uip_connr->len == 0) {
+
+          /* The application cannot send more than what is allowed by
+             the mss (the minumum of the MSS and the available
+             window). */
+          if(uip_slen > uip_connr->mss) {
+            uip_slen = uip_connr->mss;
+          }
+
+          /* Remember how much data we send out now so that we know
+             when everything has been acknowledged. */
+          uip_connr->len = uip_slen;
+        } else {
+
+          /* If the application already had unacknowledged data, we
+             make sure that the application does not send (i.e.,
+             retransmit) out more than it previously sent out. */
+          uip_slen = uip_connr->len;
+        }
+      }
+
+    apprexmit:
+      uip_appdata = uip_sappdata;
+
+      /* If the application has data to be sent, or if the incoming
+         packet had new data in it, we must send out a packet. */
+      if(uip_slen > 0 && uip_connr->len > 0) {
+        /* Add the length of the IP and TCP headers. */
+        uip_len = uip_connr->len + UIP_TCPIP_HLEN;
+        /* We always set the ACK flag in response packets. */
+        BUF->flags = TCP_ACK | TCP_PSH;
+        /* Send the packet. */
+        goto tcp_send_noopts;
+      }
+      /* If there is no data to send, just send out a pure ACK if
+         there is newdata. */
+      if(uip_flags & UIP_NEWDATA) {
+        uip_len = UIP_TCPIP_HLEN;
+        BUF->flags = TCP_ACK;
+        goto tcp_send_noopts;
+      }
+    }
+    goto drop;
+  case UIP_LAST_ACK:
+    /* We can close this connection if the peer has acknowledged our
+       FIN. This is indicated by the UIP_ACKDATA flag. */
+    if(uip_flags & UIP_ACKDATA) {
+      uip_connr->tcpstateflags = UIP_CLOSED;
+      uip_flags = UIP_CLOSE;
+      UIP_APPCALL();
+    }
+    break;
+
+  case UIP_FIN_WAIT_1:
+    /* The application has closed the connection, but the remote host
+       hasn't closed its end yet. Thus we do nothing but wait for a
+       FIN from the other side. */
+    if(uip_len > 0) {
+      uip_add_rcv_nxt(uip_len);
+    }
+    if(BUF->flags & TCP_FIN) {
+      if(uip_flags & UIP_ACKDATA) {
+        uip_connr->tcpstateflags = UIP_TIME_WAIT;
+        uip_connr->tmr = 0;
+        uip_connr->len = 0;
+      } else {
+        uip_connr->tcpstateflags = UIP_CLOSING;
+      }
+      uip_add_rcv_nxt(1);
+      uip_flags = UIP_CLOSE;
+      UIP_APPCALL();
+      goto tcp_send_ack;
+    } else if(uip_flags & UIP_ACKDATA) {
+      uip_connr->tcpstateflags = UIP_FIN_WAIT_2;
+      uip_connr->len = 0;
+      goto drop;
+    }
+    if(uip_len > 0) {
+      goto tcp_send_ack;
+    }
+    goto drop;
+
+  case UIP_FIN_WAIT_2:
+    if(uip_len > 0) {
+      uip_add_rcv_nxt(uip_len);
+    }
+    if(BUF->flags & TCP_FIN) {
+      uip_connr->tcpstateflags = UIP_TIME_WAIT;
+      uip_connr->tmr = 0;
+      uip_add_rcv_nxt(1);
+      uip_flags = UIP_CLOSE;
+      UIP_APPCALL();
+      goto tcp_send_ack;
+    }
+    if(uip_len > 0) {
+      goto tcp_send_ack;
+    }
+    goto drop;
+
+  case UIP_TIME_WAIT:
+    goto tcp_send_ack;
+
+  case UIP_CLOSING:
+    if(uip_flags & UIP_ACKDATA) {
+      uip_connr->tcpstateflags = UIP_TIME_WAIT;
+      uip_connr->tmr = 0;
+    }
+  }
+  goto drop;
+
+  /* We jump here when we are ready to send the packet, and just want
+     to set the appropriate TCP sequence numbers in the TCP header. */
+ tcp_send_ack:
+  BUF->flags = TCP_ACK;
+
+ tcp_send_nodata:
+  uip_len = UIP_IPTCPH_LEN;
+
+ tcp_send_noopts:
+  BUF->tcpoffset = (UIP_TCPH_LEN / 4) << 4;
+
+  /* We're done with the input processing. We are now ready to send a
+     reply. Our job is to fill in all the fields of the TCP and IP
+     headers before calculating the checksum and finally send the
+     packet. */
+ tcp_send:
+#if NO_XMOS_PROJECT
+  BUF->ackno[0] = uip_connr->rcv_nxt[0];
+  BUF->ackno[1] = uip_connr->rcv_nxt[1];
+  BUF->ackno[2] = uip_connr->rcv_nxt[2];
+  BUF->ackno[3] = uip_connr->rcv_nxt[3];
+  
+  BUF->seqno[0] = uip_connr->snd_nxt[0];
+  BUF->seqno[1] = uip_connr->snd_nxt[1];
+  BUF->seqno[2] = uip_connr->snd_nxt[2];
+  BUF->seqno[3] = uip_connr->snd_nxt[3];
+#else
+  xtcp_copy_word(BUF->ackno, uip_connr->rcv_nxt);
+#endif /* NO_XMOS_PROJECT */
+
+  xtcp_copy_word(BUF->seqno, uip_connr->snd_nxt);
+#if UIP_SLIDING_WINDOW
+  if(uip_connr->midpoint && uip_slen) {
+    ip_add32(BUF->seqno, uip_connr->midpoint);
+    xtcp_copy_word(BUF->seqno, uip_acc32);
+    uip_connr->midpoint = 0;
+  }
+  else if(!uip_do_split && uip_slen) {
+    // This case means we have only sent a half packet, we can send more
+    // if needed
+    uip_connr->midpoint = uip_slen;
+    // A call up to the xtcp stack to initiate a new send request
+    xtcpd_init_send_from_uip(uip_connr);
+  }
+#endif
+  BUF->proto = UIP_PROTO_TCP;
+
+  BUF->srcport  = uip_connr->lport;
+  BUF->destport = uip_connr->rport;
+
+  uip_ipaddr_copy(&BUF->srcipaddr, &uip_hostaddr);
+  uip_ipaddr_copy(&BUF->destipaddr, &uip_connr->ripaddr);
+
+  if(uip_connr->tcpstateflags & UIP_STOPPED) {
+    /* If the connection has issued uip_stop(), we advertise a zero
+       window so that the remote host will stop sending data. */
+    BUF->wnd[0] = BUF->wnd[1] = 0;
+  } else {
+    BUF->wnd[0] = ((UIP_RECEIVE_WINDOW) >> 8);
+    BUF->wnd[1] = ((UIP_RECEIVE_WINDOW) & 0xff);
+  }
+
+ tcp_send_noconn:
+  BUF->ttl = UIP_TTL;
+#if UIP_CONF_IPV6
+  /* For IPv6, the IP length field does not include the IPv6 IP header
+     length. */
+  BUF->len[0] = ((uip_len - UIP_IPH_LEN) >> 8);
+  BUF->len[1] = ((uip_len - UIP_IPH_LEN) & 0xff);
+#else /* UIP_CONF_IPV6 */
+  BUF->len[0] = (uip_len >> 8);
+  BUF->len[1] = (uip_len & 0xff);
+#endif /* UIP_CONF_IPV6 */
+
+  BUF->urgp[0] = BUF->urgp[1] = 0;
+
+  /* The TCP checksum is calculated later, in the uip_split_output function */
+
+ ip_send_nolen:
+#if UIP_CONF_IPV6
+  BUF->vtc = 0x60;
+  BUF->tcflow = 0x00;
+  BUF->flow = 0x00;
+#else /* UIP_CONF_IPV6 */
+  BUF->vhl = 0x45;
+  BUF->tos = 0;
+  BUF->ipoffset[0] = BUF->ipoffset[1] = 0;
+  ++ipid;
+  BUF->ipid[0] = ipid >> 8;
+  BUF->ipid[1] = ipid & 0xff;
+  /* Calculate IP checksum. */
+  BUF->ipchksum = 0;
+  BUF->ipchksum = ~(uip_ipchksum());
+  DEBUG_PRINTF("uip ip_send_nolen: chkecum 0x%04x\n", uip_ipchksum());
+#endif /* UIP_CONF_IPV6 */
+  UIP_STAT(++uip_stat.tcp.sent);
+ send: 
+  DEBUG_PRINTF("Sending packet with length %d (%d)\n", uip_len,
+               (BUF->len[0] << 8) | BUF->len[1]);
+
+  UIP_STAT(++uip_stat.ip.sent);
+  /* Return and let the caller do the actual transmission. */
+  uip_flags = 0;
+  return;
+
+ drop:
+  uip_len = 0;
+  uip_flags = 0;
+  return;
+}
+/*---------------------------------------------------------------------------*/
+uint16_t
+uip_htons(uint16_t val)
+{
+  return UIP_HTONS(val);
+}
+
+uint32_t
+uip_htonl(uint32_t val)
+{
+  return UIP_HTONL(val);
+}
+/*---------------------------------------------------------------------------*/
+void
+uip_send(const void *data, int len)
+{
+  if(len > 0) {
+    uip_slen = len;
+    if(data != uip_sappdata) {
+      memcpy(uip_sappdata, (data), uip_slen);
+    }
+  }
+}
+/*---------------------------------------------------------------------------*/
+/** @} */
+#endif /* UIP_CONF_IPV6 */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/uip.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/uip.h
@@ -1,0 +1,2331 @@
+// Copyright (c) 2011, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+
+
+/**
+ * \addtogroup uip
+ * @{
+ */
+
+/**
+ * \file
+ * Header file for the uIP TCP/IP stack.
+ * \author  Adam Dunkels <adam@dunkels.com>
+ * \author  Julien Abeille <jabeille@cisco.com> (IPv6 related code)
+ * \author  Mathilde Durvy <mdurvy@cisco.com> (IPv6 related code)
+ *
+ * The uIP TCP/IP stack header file contains definitions for a number
+ * of C macros that are used by uIP programs as well as internal uIP
+ * structures, TCP/IP header structures and function declarations.
+ *
+ */
+
+/*
+ * Copyright (c) 2001-2003, Adam Dunkels.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This file is part of the uIP TCP/IP stack.
+ *
+ *
+ */
+
+#ifndef __UIP_H__
+#define __UIP_H__
+
+#include "net/uipopt.h"
+#include "uip_arch.h"
+
+/**
+ * Representation of an IP address.
+ *
+ */
+typedef union uip_ip4addr_t {
+  uint8_t  u8[4];			/* Initializer, must come first. */
+  uint16_t u16[2];
+} uip_ip4addr_t;
+
+typedef union uip_ip6addr_t {
+  uint8_t  u8[16];			/* Initializer, must come first. */
+  uint16_t u16[8];
+} uip_ip6addr_t;
+
+#if UIP_CONF_IPV6
+typedef uip_ip6addr_t uip_ipaddr_t;
+#else /* UIP_CONF_IPV6 */
+typedef uip_ip4addr_t uip_ipaddr_t;
+#endif /* UIP_CONF_IPV6 */
+
+
+/*---------------------------------------------------------------------------*/
+
+/** \brief 16 bit 802.15.4 address */
+typedef struct uip_802154_shortaddr {
+  uint8_t addr[2];
+} uip_802154_shortaddr;
+/** \brief 64 bit 802.15.4 address */
+typedef struct uip_802154_longaddr {
+  uint8_t addr[8];
+} uip_802154_longaddr;
+
+/** \brief 802.11 address */
+typedef struct uip_80211_addr {
+  uint8_t addr[6];
+} uip_80211_addr;
+
+/** \brief 802.3 address */
+typedef struct uip_eth_addr {
+  uint8_t addr[6];
+} uip_eth_addr;
+
+
+#if UIP_CONF_LL_802154
+/** \brief 802.15.4 address */
+typedef uip_802154_longaddr uip_lladdr_t;
+#define UIP_802154_SHORTADDR_LEN 2
+#define UIP_802154_LONGADDR_LEN  8
+#define UIP_LLADDR_LEN UIP_802154_LONGADDR_LEN
+#else /*UIP_CONF_LL_802154*/
+#if UIP_CONF_LL_80211
+/** \brief 802.11 address */
+typedef uip_80211_addr uip_lladdr_t;
+#define UIP_LLADDR_LEN 6
+#else /*UIP_CONF_LL_80211*/
+/** \brief Ethernet address */
+typedef uip_eth_addr uip_lladdr_t;
+#define UIP_LLADDR_LEN 6
+#endif /*UIP_CONF_LL_80211*/
+#endif /*UIP_CONF_LL_802154*/
+
+#ifndef __XC__
+#include "net/tcpip.h"
+
+/*---------------------------------------------------------------------------*/
+/* First, the functions that should be called from the
+ * system. Initialization, the periodic timer, and incoming packets are
+ * handled by the following three functions.
+ */
+/**
+ * \defgroup uipconffunc uIP configuration functions
+ * @{
+ *
+ * The uIP configuration functions are used for setting run-time
+ * parameters in uIP such as IP addresses.
+ */
+
+/**
+ * Set the IP address of this host.
+ *
+ * The IP address is represented as a 4-byte array where the first
+ * octet of the IP address is put in the first member of the 4-byte
+ * array.
+ *
+ * Example:
+ \code
+
+ uip_ipaddr_t addr;
+
+ uip_ipaddr(&addr, 192,168,1,2);
+ uip_sethostaddr(&addr);
+ 
+ \endcode
+ * \param addr A pointer to an IP address of type uip_ipaddr_t;
+ *
+ * \sa uip_ipaddr()
+ *
+ * \hideinitializer
+ */
+#define uip_sethostaddr(addr) uip_ipaddr_copy(&uip_hostaddr, (addr))
+
+/**
+ * Get the IP address of this host.
+ *
+ * The IP address is represented as a 4-byte array where the first
+ * octet of the IP address is put in the first member of the 4-byte
+ * array.
+ *
+ * Example:
+ \code
+ uip_ipaddr_t hostaddr;
+
+ uip_gethostaddr(&hostaddr);
+ \endcode
+ * \param addr A pointer to a uip_ipaddr_t variable that will be
+ * filled in with the currently configured IP address.
+ *
+ * \hideinitializer
+ */
+#define uip_gethostaddr(addr) uip_ipaddr_copy((addr), &uip_hostaddr)
+
+/**
+ * Set the default router's IP address.
+ *
+ * \param addr A pointer to a uip_ipaddr_t variable containing the IP
+ * address of the default router.
+ *
+ * \sa uip_ipaddr()
+ *
+ * \hideinitializer
+ */
+#define uip_setdraddr(addr) uip_ipaddr_copy(&uip_draddr, (addr))
+
+/**
+ * Set the netmask.
+ *
+ * \param addr A pointer to a uip_ipaddr_t variable containing the IP
+ * address of the netmask.
+ *
+ * \sa uip_ipaddr()
+ *
+ * \hideinitializer
+ */
+#define uip_setnetmask(addr) uip_ipaddr_copy(&uip_netmask, (addr))
+
+/**
+ * Get the default router's IP address.
+ *
+ * \param addr A pointer to a uip_ipaddr_t variable that will be
+ * filled in with the IP address of the default router.
+ *
+ * \hideinitializer
+ */
+#define uip_getdraddr(addr) uip_ipaddr_copy((addr), &uip_draddr)
+
+/**
+ * Get the netmask.
+ *
+ * \param addr A pointer to a uip_ipaddr_t variable that will be
+ * filled in with the value of the netmask.
+ *
+ * \hideinitializer
+ */
+#define uip_getnetmask(addr) uip_ipaddr_copy((addr), &uip_netmask)
+
+/** @} */
+
+/**
+ * \defgroup uipinit uIP initialization functions
+ * @{
+ *
+ * The uIP initialization functions are used for booting uIP.
+ */
+
+/**
+ * uIP initialization function.
+ *
+ * This function should be called at boot up to initilize the uIP
+ * TCP/IP stack.
+ */
+void uip_init(void);
+
+/**
+ * uIP initialization function.
+ *
+ * This function may be used at boot time to set the initial ip_id.
+ */
+void uip_setipid(uint16_t id);
+
+/** @} */
+
+/**
+ * \defgroup uipdevfunc uIP device driver functions
+ * @{
+ *
+ * These functions are used by a network device driver for interacting
+ * with uIP.
+ */
+
+/**
+ * Process an incoming packet.
+ *
+ * This function should be called when the device driver has received
+ * a packet from the network. The packet from the device driver must
+ * be present in the uip_buf buffer, and the length of the packet
+ * should be placed in the uip_len variable.
+ *
+ * When the function returns, there may be an outbound packet placed
+ * in the uip_buf packet buffer. If so, the uip_len variable is set to
+ * the length of the packet. If no packet is to be sent out, the
+ * uip_len variable is set to 0.
+ *
+ * The usual way of calling the function is presented by the source
+ * code below.
+ \code
+  uip_len = devicedriver_poll();
+  if(uip_len > 0) {
+    uip_input();
+    if(uip_len > 0) {
+      devicedriver_send();
+    }
+  }
+ \endcode
+ *
+ * \note If you are writing a uIP device driver that needs ARP
+ * (Address Resolution Protocol), e.g., when running uIP over
+ * Ethernet, you will need to call the uIP ARP code before calling
+ * this function:
+ \code
+  #define BUF ((struct uip_eth_hdr *)&uip_buf[0])
+  uip_len = ethernet_devicedrver_poll();
+  if(uip_len > 0) {
+    if(BUF->type == HTONS(UIP_ETHTYPE_IP)) {
+      uip_arp_ipin();
+      uip_input();
+      if(uip_len > 0) {
+        uip_arp_out();
+	ethernet_devicedriver_send();
+      }
+    } else if(BUF->type == HTONS(UIP_ETHTYPE_ARP)) {
+      uip_arp_arpin();
+      if(uip_len > 0) {
+	ethernet_devicedriver_send();
+      }
+    }
+ \endcode
+ *
+ * \hideinitializer
+ */
+#define uip_input()        uip_process(UIP_DATA)
+
+/**
+ * Periodic processing for a connection identified by its number.
+ *
+ * This function does the necessary periodic processing (timers,
+ * polling) for a uIP TCP conneciton, and should be called when the
+ * periodic uIP timer goes off. It should be called for every
+ * connection, regardless of whether they are open of closed.
+ *
+ * When the function returns, it may have an outbound packet waiting
+ * for service in the uIP packet buffer, and if so the uip_len
+ * variable is set to a value larger than zero. The device driver
+ * should be called to send out the packet.
+ *
+ * The usual way of calling the function is through a for() loop like
+ * this:
+ \code
+  for(i = 0; i < UIP_CONNS; ++i) {
+    uip_periodic(i);
+    if(uip_len > 0) {
+      devicedriver_send();
+    }
+  }
+ \endcode
+ *
+ * \note If you are writing a uIP device driver that needs ARP
+ * (Address Resolution Protocol), e.g., when running uIP over
+ * Ethernet, you will need to call the uip_arp_out() function before
+ * calling the device driver:
+ \code
+  for(i = 0; i < UIP_CONNS; ++i) {
+    uip_periodic(i);
+    if(uip_len > 0) {
+      uip_arp_out();
+      ethernet_devicedriver_send();
+    }
+  }
+ \endcode
+ *
+ * \param conn The number of the connection which is to be periodically polled.
+ *
+ * \hideinitializer
+ */
+#if UIP_TCP
+#define uip_periodic(conn) do { uip_conn = &uip_conns[conn]; \
+                                uip_process(UIP_TIMER); } while (0)
+
+/**
+ *
+ *
+ */
+#define uip_conn_active(conn) (uip_conns[conn].tcpstateflags != UIP_CLOSED)
+
+/**
+ * Perform periodic processing for a connection identified by a pointer
+ * to its structure.
+ *
+ * Same as uip_periodic() but takes a pointer to the actual uip_conn
+ * struct instead of an integer as its argument. This function can be
+ * used to force periodic processing of a specific connection.
+ *
+ * \param conn A pointer to the uip_conn struct for the connection to
+ * be processed.
+ *
+ * \hideinitializer
+ */
+#define uip_periodic_conn(conn) do { uip_conn = conn; \
+                                     uip_process(UIP_TIMER); } while (0)
+
+/**
+ * Request that a particular connection should be polled.
+ *
+ * Similar to uip_periodic_conn() but does not perform any timer
+ * processing. The application is polled for new data.
+ *
+ * \param conn A pointer to the uip_conn struct for the connection to
+ * be processed.
+ *
+ * \hideinitializer
+ */
+#define uip_poll_conn(conn) do { uip_conn = conn; \
+                                 uip_process(UIP_POLL_REQUEST); } while (0)
+
+#endif /* UIP_TCP */
+
+#if UIP_UDP
+/**
+ * Periodic processing for a UDP connection identified by its number.
+ *
+ * This function is essentially the same as uip_periodic(), but for
+ * UDP connections. It is called in a similar fashion as the
+ * uip_periodic() function:
+ \code
+  for(i = 0; i < UIP_UDP_CONNS; i++) {
+    uip_udp_periodic(i);
+    if(uip_len > 0) {
+      devicedriver_send();
+    }
+  }
+ \endcode
+ *
+ * \note As for the uip_periodic() function, special care has to be
+ * taken when using uIP together with ARP and Ethernet:
+ \code
+  for(i = 0; i < UIP_UDP_CONNS; i++) {
+    uip_udp_periodic(i);
+    if(uip_len > 0) {
+      uip_arp_out();
+      ethernet_devicedriver_send();
+    }
+  }
+ \endcode
+ *
+ * \param conn The number of the UDP connection to be processed.
+ *
+ * \hideinitializer
+ */
+#define uip_udp_periodic(conn) do { uip_udp_conn = &uip_udp_conns[conn]; \
+                                uip_process(UIP_UDP_TIMER); } while(0)
+
+
+/**
+ * Processing of a UDP connection after an ARP reply.
+ *
+ * This function handles udp connections after an arp reply comes in. Possibly
+ * retransmitting datagrams that were not transmitted due to having to create
+ * an arp request before.
+ *
+ \code
+  uip_arp_arpin();
+  if(uip_len > 0) {
+    devicedriver_send();
+  }
+  for(i = 0; i < UIP_UDP_CONNS; i++) {
+    uip_udp_arp_event(i);
+    if(uip_len > 0) {
+      devicedriver_send();
+    }
+  }
+ \endcode
+ *
+ *
+ * \param conn The number of the UDP connection to be processed.
+ *
+ * \hideinitializer
+ */
+#define uip_udp_arp_event(conn) do { uip_udp_conn = &uip_udp_conns[conn]; \
+                                uip_process(UIP_UDP_ARP_EVENT); } while (0)
+
+
+#define uip_udp_conn_has_ack(conn) ((conn)->udpflags & UDP_SENT)
+
+#define uip_udp_ackdata(conn) do { uip_udp_conn = &uip_udp_conns[conn]; \
+                                uip_process(UIP_UDP_ACKDATA); } while (0)
+
+/**
+ * Periodic processing for a UDP connection identified by a pointer to
+ * its structure.
+ *
+ * Same as uip_udp_periodic() but takes a pointer to the actual
+ * uip_conn struct instead of an integer as its argument. This
+ * function can be used to force periodic processing of a specific
+ * connection.
+ *
+ * \param conn A pointer to the uip_udp_conn struct for the connection
+ * to be processed.
+ *
+ * \hideinitializer
+ */
+#define uip_udp_periodic_conn(conn) do { uip_udp_conn = conn; \
+                                         uip_process(UIP_UDP_TIMER); } while (0)
+
+
+#endif /* UIP_UDP */
+
+/** \brief Abandon the reassembly of the current packet */
+void uip_reass_over(void);
+
+
+
+/*---------------------------------------------------------------------------*/
+/* Functions that are used by the uIP application program. Opening and
+ * closing connections, sending and receiving data, etc. is all
+ * handled by the functions below.
+ */
+/**
+ * \defgroup uipappfunc uIP application functions
+ * @{
+ *
+ * Functions used by an application running of top of uIP.
+ */
+
+/**
+ * Start listening to the specified port.
+ *
+ * \note Since this function expects the port number in network byte
+ * order, a conversion using UIP_HTONS() or uip_htons() is necessary.
+ *
+ \code
+ uip_listen(UIP_HTONS(80));
+ \endcode
+ *
+ * \param port A 16-bit port number in network byte order.
+ */
+void uip_listen(uint16_t port);
+void uip_udp_listen(uint16_t port);
+
+/**
+ * Stop listening to the specified port.
+ *
+ * \note Since this function expects the port number in network byte
+ * order, a conversion using UIP_HTONS() or uip_htons() is necessary.
+ *
+ \code
+ uip_unlisten(UIP_HTONS(80));
+ \endcode
+ *
+ * \param port A 16-bit port number in network byte order.
+ */
+void uip_unlisten(uint16_t port);
+void uip_udp_unlisten(uint16_t port);
+
+/**
+ * Connect to a remote host using TCP.
+ *
+ * This function is used to start a new connection to the specified
+ * port on the specified host. It allocates a new connection identifier,
+ * sets the connection to the SYN_SENT state and sets the
+ * retransmission timer to 0. This will cause a TCP SYN segment to be
+ * sent out the next time this connection is periodically processed,
+ * which usually is done within 0.5 seconds after the call to
+ * uip_connect().
+ *
+ * \note This function is available only if support for active open
+ * has been configured by defining UIP_ACTIVE_OPEN to 1 in uipopt.h.
+ *
+ * \note Since this function requires the port number to be in network
+ * byte order, a conversion using UIP_HTONS() or uip_htons() is necessary.
+ *
+ \code
+ uip_ipaddr_t ipaddr;
+
+ uip_ipaddr(&ipaddr, 192,168,1,2);
+ uip_connect(&ipaddr, UIP_HTONS(80));
+ \endcode
+ *
+ * \param ripaddr The IP address of the remote host.
+ *
+ * \param port A 16-bit port number in network byte order.
+ *
+ * \return A pointer to the uIP connection identifier for the new connection,
+ * or NULL if no connection could be allocated.
+ *
+ */
+struct uip_conn *uip_connect(uip_ipaddr_t *ripaddr, uint16_t port);
+
+
+
+/**
+ * \internal
+ *
+ * Check if a connection has outstanding (i.e., unacknowledged) data.
+ *
+ * \param conn A pointer to the uip_conn structure for the connection.
+ *
+ * \hideinitializer
+ */
+#define uip_outstanding(conn) ((conn)->len)
+
+/**
+ * Send data on the current connection.
+ *
+ * This function is used to send out a single segment of TCP
+ * data. Only applications that have been invoked by uIP for event
+ * processing can send data.
+ *
+ * The amount of data that actually is sent out after a call to this
+ * function is determined by the maximum amount of data TCP allows. uIP
+ * will automatically crop the data so that only the appropriate
+ * amount of data is sent. The function uip_mss() can be used to query
+ * uIP for the amount of data that actually will be sent.
+ *
+ * \note This function does not guarantee that the sent data will
+ * arrive at the destination. If the data is lost in the network, the
+ * application will be invoked with the uip_rexmit() event being
+ * set. The application will then have to resend the data using this
+ * function.
+ *
+ * \param data A pointer to the data which is to be sent.
+ *
+ * \param len The maximum amount of data bytes to be sent.
+ *
+ * \hideinitializer
+ */
+void uip_send(const void *data, int len);
+
+/**
+ * The length of any incoming data that is currently available (if available)
+ * in the uip_appdata buffer.
+ *
+ * The test function uip_data() must first be used to check if there
+ * is any data available at all.
+ *
+ * \hideinitializer
+ */
+/*void uip_datalen(void);*/
+#define uip_datalen()       uip_len
+
+/**
+ * The length of any out-of-band data (urgent data) that has arrived
+ * on the connection.
+ *
+ * \note The configuration parameter UIP_URGDATA must be set for this
+ * function to be enabled.
+ *
+ * \hideinitializer
+ */
+#define uip_urgdatalen()    uip_urglen
+
+/**
+ * Close the current connection.
+ *
+ * This function will close the current connection in a nice way.
+ *
+ * \hideinitializer
+ */
+#define uip_close()         (uip_flags = UIP_CLOSE)
+
+/**
+ * Abort the current connection.
+ *
+ * This function will abort (reset) the current connection, and is
+ * usually used when an error has occurred that prevents using the
+ * uip_close() function.
+ *
+ * \hideinitializer
+ */
+#define uip_abort()         (uip_flags = UIP_ABORT)
+
+/**
+ * Tell the sending host to stop sending data.
+ *
+ * This function will close our receiver's window so that we stop
+ * receiving data for the current connection.
+ *
+ * \hideinitializer
+ */
+#define uip_stop()          (uip_conn->tcpstateflags |= UIP_STOPPED)
+
+/**
+ * Find out if the current connection has been previously stopped with
+ * uip_stop().
+ *
+ * \hideinitializer
+ */
+#define uip_stopped(conn)   ((conn)->tcpstateflags & UIP_STOPPED)
+
+/**
+ * Restart the current connection, if is has previously been stopped
+ * with uip_stop().
+ *
+ * This function will open the receiver's window again so that we
+ * start receiving data for the current connection.
+ *
+ * \hideinitializer
+ */
+#define uip_restart()         do { uip_flags |= UIP_NEWDATA; \
+                                   uip_conn->tcpstateflags &= ~UIP_STOPPED; \
+                              } while(0)
+
+
+/* uIP tests that can be made to determine in what state the current
+   connection is, and what the application function should do. */
+
+/**
+ * Is the current connection a UDP connection?
+ *
+ * This function checks whether the current connection is a UDP connection.
+ *
+ * \hideinitializer
+ *
+ */
+#define uip_udpconnection() (uip_conn == NULL)
+
+/**
+ * Is new incoming data available?
+ *
+ * Will reduce to non-zero if there is new data for the application
+ * present at the uip_appdata pointer. The size of the data is
+ * available through the uip_len variable.
+ *
+ * \hideinitializer
+ */
+#define uip_newdata()   (uip_flags & UIP_NEWDATA)
+
+/**
+ * Has previously sent data been acknowledged?
+ *
+ * Will reduce to non-zero if the previously sent data has been
+ * acknowledged by the remote host. This means that the application
+ * can send new data.
+ *
+ * \hideinitializer
+ */
+#define uip_acked()   (uip_flags & UIP_ACKDATA)
+
+/**
+ * Has the connection just been connected?
+ *
+ * Reduces to non-zero if the current connection has been connected to
+ * a remote host. This will happen both if the connection has been
+ * actively opened (with uip_connect()) or passively opened (with
+ * uip_listen()).
+ *
+ * \hideinitializer
+ */
+#define uip_connected() (uip_flags & UIP_CONNECTED)
+
+/**
+ * Has the connection been closed by the other end?
+ *
+ * Is non-zero if the connection has been closed by the remote
+ * host. The application may then do the necessary clean-ups.
+ *
+ * \hideinitializer
+ */
+#define uip_closed()    (uip_flags & UIP_CLOSE)
+
+
+/**
+ * Has the other end just sent a packet with the PUSH flag sent
+ *
+ * \hideinitializer
+ */
+#define uip_tcp_push()    (uip_flags & UIP_TCP_PUSH)
+
+/**
+ * Has the connection been aborted by the other end?
+ *
+ * Non-zero if the current connection has been aborted (reset) by the
+ * remote host.
+ *
+ * \hideinitializer
+ */
+#define uip_aborted()    (uip_flags & UIP_ABORT)
+
+/**
+ * Has the connection timed out?
+ *
+ * Non-zero if the current connection has been aborted due to too many
+ * retransmissions.
+ *
+ * \hideinitializer
+ */
+#define uip_timedout()    (uip_flags & UIP_TIMEDOUT)
+
+/**
+ * Do we need to retransmit previously data?
+ *
+ * Reduces to non-zero if the previously sent data has been lost in
+ * the network, and the application should retransmit it. The
+ * application should send the exact same data as it did the last
+ * time, using the uip_send() function.
+ *
+ * \hideinitializer
+ */
+#define uip_rexmit()     (uip_flags & UIP_REXMIT)
+
+/**
+ * Is the connection being polled by uIP?
+ *
+ * Is non-zero if the reason the application is invoked is that the
+ * current connection has been idle for a while and should be
+ * polled.
+ *
+ * The polling event can be used for sending data without having to
+ * wait for the remote host to send data.
+ *
+ * \hideinitializer
+ */
+#define uip_poll()       (uip_flags & UIP_POLL)
+
+/**
+ * Get the initial maximum segment size (MSS) of the current
+ * connection.
+ *
+ * \hideinitializer
+ */
+#define uip_initialmss()             (uip_conn->initialmss)
+
+/**
+ * Get the current maximum segment size that can be sent on the current
+ * connection.
+ *
+ * The current maximum segment size that can be sent on the
+ * connection is computed from the receiver's window and the MSS of
+ * the connection (which also is available by calling
+ * uip_initialmss()).
+ *
+ * \hideinitializer
+ */
+#define uip_mss()             (uip_conn->mss)
+
+/**
+ * Set up a new UDP connection.
+ *
+ * This function sets up a new UDP connection. The function will
+ * automatically allocate an unused local port for the new
+ * connection. However, another port can be chosen by using the
+ * uip_udp_bind() call, after the uip_udp_new() function has been
+ * called.
+ *
+ * Example:
+ \code
+ uip_ipaddr_t addr;
+ struct uip_udp_conn *c;
+ 
+ uip_ipaddr(&addr, 192,168,2,1);
+ c = uip_udp_new(&addr, UIP_HTONS(12345));
+ if(c != NULL) {
+   uip_udp_bind(c, UIP_HTONS(12344));
+ }
+ \endcode
+ * \param ripaddr The IP address of the remote host.
+ *
+ * \param rport The remote port number in network byte order.
+ *
+ * \return The uip_udp_conn structure for the new connection, or NULL
+ * if no connection could be allocated.
+ */
+struct uip_udp_conn *uip_udp_new(const uip_ipaddr_t *ripaddr, uint16_t rport);
+
+/**
+ * Remove a UDP connection.
+ *
+ * \param conn A pointer to the uip_udp_conn structure for the connection.
+ *
+ * \hideinitializer
+ */
+#define uip_udp_remove(conn) (conn)->lport = 0
+
+/**
+ * Bind a UDP connection to a local port.
+ *
+ * \param conn A pointer to the uip_udp_conn structure for the
+ * connection.
+ *
+ * \param port The local port number, in network byte order.
+ *
+ * \hideinitializer
+ */
+#define uip_udp_bind(conn, port) (conn)->lport = port
+
+/**
+ * Send a UDP datagram of length len on the current connection.
+ *
+ * This function can only be called in response to a UDP event (poll
+ * or newdata). The data must be present in the uip_buf buffer, at the
+ * place pointed to by the uip_appdata pointer.
+ *
+ * \param len The length of the data in the uip_buf buffer.
+ *
+ * \hideinitializer
+ */
+#define uip_udp_send(len) uip_send((char *)uip_appdata, len)
+
+/** @} */
+
+/* uIP convenience and converting functions. */
+
+/**
+ * \defgroup uipconvfunc uIP conversion functions
+ * @{
+ *
+ * These functions can be used for converting between different data
+ * formats used by uIP.
+ */
+ 
+/**
+ * Convert an IP address to four bytes separated by commas.
+ *
+ * Example:
+ \code
+ uip_ipaddr_t ipaddr;
+ printf("ipaddr=%d.%d.%d.%d\n", uip_ipaddr_to_quad(&ipaddr));
+ \endcode
+ *
+ * \param a A pointer to a uip_ipaddr_t.
+ * \hideinitializer
+ */
+#define uip_ipaddr_to_quad(a) (a)->u8[0],(a)->u8[1],(a)->u8[2],(a)->u8[3]
+
+/**
+ * Construct an IP address from four bytes.
+ *
+ * This function constructs an IP address of the type that uIP handles
+ * internally from four bytes. The function is handy for specifying IP
+ * addresses to use with e.g. the uip_connect() function.
+ *
+ * Example:
+ \code
+ uip_ipaddr_t ipaddr;
+ struct uip_conn *c;
+ 
+ uip_ipaddr(&ipaddr, 192,168,1,2);
+ c = uip_connect(&ipaddr, UIP_HTONS(80));
+ \endcode
+ *
+ * \param addr A pointer to a uip_ipaddr_t variable that will be
+ * filled in with the IP address.
+ *
+ * \param addr0 The first octet of the IP address.
+ * \param addr1 The second octet of the IP address.
+ * \param addr2 The third octet of the IP address.
+ * \param addr3 The forth octet of the IP address.
+ *
+ * \hideinitializer
+ */
+/*#define uip_ipaddr(addr, addr0,addr1,addr2,addr3) do { \
+                     ((u16_t *)(addr))[0] = HTONS(((addr0) << 8) | (addr1)); \
+                     ((u16_t *)(addr))[1] = HTONS(((addr2) << 8) | (addr3)); \
+                  } while(0) // ORIG XMOS*/
+
+#define uip_ipaddr(addr, addr0,addr1,addr2,addr3) do {  \
+    (addr)->u8[0] = addr0;                              \
+    (addr)->u8[1] = addr1;                              \
+    (addr)->u8[2] = addr2;                              \
+    (addr)->u8[3] = addr3;                              \
+  } while(0)
+
+/**
+ * Construct an IPv6 address from eight 16-bit words.
+ *
+ * This function constructs an IPv6 address.
+ *
+ * \hideinitializer
+ */
+#define uip_ip6addr(addr, addr0,addr1,addr2,addr3,addr4,addr5,addr6,addr7) do { \
+    (addr)->u16[0] = UIP_HTONS(addr0);                                      \
+    (addr)->u16[1] = UIP_HTONS(addr1);                                      \
+    (addr)->u16[2] = UIP_HTONS(addr2);                                      \
+    (addr)->u16[3] = UIP_HTONS(addr3);                                      \
+    (addr)->u16[4] = UIP_HTONS(addr4);                                      \
+    (addr)->u16[5] = UIP_HTONS(addr5);                                      \
+    (addr)->u16[6] = UIP_HTONS(addr6);                                      \
+    (addr)->u16[7] = UIP_HTONS(addr7);                                      \
+  } while(0)
+
+/**
+ * Construct an IPv6 address from sixteen 8-bit words.
+ *
+ * This function constructs an IPv6 address.
+ *
+ * \hideinitializer
+ */
+#define uip_ip6addr_u8(addr, addr0,addr1,addr2,addr3,addr4,addr5,addr6,addr7,addr8,addr9,addr10,addr11,addr12,addr13,addr14,addr15) do { \
+    (addr)->u8[0] = addr0;                                       \
+    (addr)->u8[1] = addr1;                                       \
+    (addr)->u8[2] = addr2;                                       \
+    (addr)->u8[3] = addr3;                                       \
+    (addr)->u8[4] = addr4;                                       \
+    (addr)->u8[5] = addr5;                                       \
+    (addr)->u8[6] = addr6;                                       \
+    (addr)->u8[7] = addr7;                                       \
+    (addr)->u8[8] = addr8;                                       \
+    (addr)->u8[9] = addr9;                                       \
+    (addr)->u8[10] = addr10;                                     \
+    (addr)->u8[11] = addr11;                                     \
+    (addr)->u8[12] = addr12;                                     \
+    (addr)->u8[13] = addr13;                                     \
+    (addr)->u8[14] = addr14;                                     \
+    (addr)->u8[15] = addr15;                                     \
+  } while(0)
+
+
+/**
+ * Copy an IP address from one place to another.
+ *
+ * Copies an IP address from one place to another.
+ *
+ * Example:
+ \code
+ uip_ipaddr_t ipaddr1, ipaddr2;
+
+ uip_ipaddr(&ipaddr1, 192,16,1,2);
+ uip_ipaddr_copy(&ipaddr2, &ipaddr1);
+ \endcode
+ *
+ * \param dest The destination for the copy.
+ * \param src The source from where to copy.
+ *
+ * \hideinitializer
+ */
+#if UIP_CONF_IPV4
+extern void xuip_ip4addr_copy(uip_ip4addr_t *src, uip_ip4addr_t *dst);
+#define uip_ipaddr_copy(dest, src)		xuip_ip4addr_copy(dest, src)
+#endif
+
+#ifndef uip_ipaddr_copy
+#define uip_ipaddr_copy(dest, src) (*(dest) = *(src))
+#endif
+#ifndef uip_ip4addr_copy
+#define uip_ip4addr_copy(dest, src) (*(dest) = *(src))
+#endif
+#ifndef uip_ip6addr_copy
+#define uip_ip6addr_copy(dest, src) (*(dest) = *(src))
+#endif
+
+/**
+ * Compare two IP addresses
+ *
+ * Compares two IP addresses.
+ *
+ * Example:
+ \code
+ uip_ipaddr_t ipaddr1, ipaddr2;
+
+ uip_ipaddr(&ipaddr1, 192,16,1,2);
+ if(uip_ipaddr_cmp(&ipaddr2, &ipaddr1)) {
+  printf("They are the same");
+ }
+ \endcode
+ *
+ * \param addr1 The first IP address.
+ * \param addr2 The second IP address.
+ *
+ * \hideinitializer
+ */
+#define uip_ip4addr_cmp(addr1, addr2) ((addr1)->u16[0] == (addr2)->u16[0] && \
+				      (addr1)->u16[1] == (addr2)->u16[1])
+#define uip_ip6addr_cmp(addr1, addr2) (memcmp(addr1, addr2, sizeof(uip_ip6addr_t)) == 0)
+
+#if UIP_CONF_IPV6
+#ifndef uip_ipaddr_cmp
+#define uip_ipaddr_cmp(addr1, addr2) uip_ip6addr_cmp(addr1, addr2)
+#endif
+#else /* UIP_CONF_IPV6 */
+extern int xuip_ipaddr_cmp(uip_ip4addr_t *a, uip_ip4addr_t *b);
+#define uip_ipaddr_cmp(addr1, addr2)	 xuip_ipaddr_cmp(addr1, addr2)
+#define uip_ipaddr_is_multicast(addr) ((addr.u16[0] & 0xff) == 224)
+#ifndef uip_ipaddr_cmp
+#define uip_ipaddr_cmp(addr1, addr2) uip_ip4addr_cmp(addr1, addr2)
+#endif
+#endif /* UIP_CONF_IPV6 */
+
+/**
+ * Compare two IP addresses with netmasks
+ *
+ * Compares two IP addresses with netmasks. The masks are used to mask
+ * out the bits that are to be compared.
+ *
+ * Example:
+ \code
+ uip_ipaddr_t ipaddr1, ipaddr2, mask;
+
+ uip_ipaddr(&mask, 255,255,255,0);
+ uip_ipaddr(&ipaddr1, 192,16,1,2);
+ uip_ipaddr(&ipaddr2, 192,16,1,3);
+ if(uip_ipaddr_maskcmp(&ipaddr1, &ipaddr2, &mask)) {
+ printf("They are the same");
+ }
+ \endcode
+ *
+ * \param addr1 The first IP address.
+ * \param addr2 The second IP address.
+ * \param mask The netmask.
+ *
+ * \hideinitializer
+ */
+
+#define uip_ipaddr_maskcmp(addr1, addr2, mask)          \
+  (((((uint16_t *)addr1)[0] & ((uint16_t *)mask)[0]) ==       \
+    (((uint16_t *)addr2)[0] & ((uint16_t *)mask)[0])) &&      \
+   ((((uint16_t *)addr1)[1] & ((uint16_t *)mask)[1]) ==       \
+    (((uint16_t *)addr2)[1] & ((uint16_t *)mask)[1])))
+
+#define uip_ipaddr_prefixcmp(addr1, addr2, length) (memcmp(addr1, addr2, length>>3) == 0)
+
+
+
+/**
+ * Check if an address is a broadcast address for a network.
+ *
+ * Checks if an address is the broadcast address for a network. The
+ * network is defined by an IP address that is on the network and the
+ * network's netmask.
+ *
+ * \param addr The IP address.
+ * \param netaddr The network's IP address.
+ * \param netmask The network's netmask.
+ *
+ * \hideinitializer
+ */
+/*#define uip_ipaddr_isbroadcast(addr, netaddr, netmask)
+  ((uip_ipaddr_t *)(addr)).u16 & ((uip_ipaddr_t *)(addr)).u16*/
+
+
+
+/**
+ * Mask out the network part of an IP address.
+ *
+ * Masks out the network part of an IP address, given the address and
+ * the netmask.
+ *
+ * Example:
+ \code
+ uip_ipaddr_t ipaddr1, ipaddr2, netmask;
+
+ uip_ipaddr(&ipaddr1, 192,16,1,2);
+ uip_ipaddr(&netmask, 255,255,255,0);
+ uip_ipaddr_mask(&ipaddr2, &ipaddr1, &netmask);
+ \endcode
+ *
+ * In the example above, the variable "ipaddr2" will contain the IP
+ * address 192.168.1.0.
+ *
+ * \param dest Where the result is to be placed.
+ * \param src The IP address.
+ * \param mask The netmask.
+ *
+ * \hideinitializer
+ */
+#define uip_ipaddr_mask(dest, src, mask) do { \
+                     ((uint16_t *)dest)[0] = ((uint16_t *)src)[0] & ((uint16_t *)mask)[0]; \
+                     ((uint16_t *)dest)[1] = ((uint16_t *)src)[1] & ((uint16_t *)mask)[1]; \
+                  } while(0)
+
+/**
+ * Pick the first octet of an IP address.
+ *
+ * Picks out the first octet of an IP address.
+ *
+ * Example:
+ \code
+ uip_ipaddr_t ipaddr;
+ uint8_t octet;
+
+ uip_ipaddr(&ipaddr, 1,2,3,4);
+ octet = uip_ipaddr1(&ipaddr);
+ \endcode
+ *
+ * In the example above, the variable "octet" will contain the value 1.
+ *
+ * \hideinitializer
+ */
+#define uip_ipaddr1(addr) ((addr)->u8[0])
+
+/**
+ * Pick the second octet of an IP address.
+ *
+ * Picks out the second octet of an IP address.
+ *
+ * Example:
+ \code
+ uip_ipaddr_t ipaddr;
+ uint8_t octet;
+
+ uip_ipaddr(&ipaddr, 1,2,3,4);
+ octet = uip_ipaddr2(&ipaddr);
+ \endcode
+ *
+ * In the example above, the variable "octet" will contain the value 2.
+ *
+ * \hideinitializer
+ */
+#define uip_ipaddr2(addr) ((addr)->u8[1])
+
+/**
+ * Pick the third octet of an IP address.
+ *
+ * Picks out the third octet of an IP address.
+ *
+ * Example:
+ \code
+ uip_ipaddr_t ipaddr;
+ uint8_t octet;
+
+ uip_ipaddr(&ipaddr, 1,2,3,4);
+ octet = uip_ipaddr3(&ipaddr);
+ \endcode
+ *
+ * In the example above, the variable "octet" will contain the value 3.
+ *
+ * \hideinitializer
+ */
+#define uip_ipaddr3(addr) ((addr)->u8[2])
+
+/**
+ * Pick the fourth octet of an IP address.
+ *
+ * Picks out the fourth octet of an IP address.
+ *
+ * Example:
+ \code
+ uip_ipaddr_t ipaddr;
+ uint8_t octet;
+
+ uip_ipaddr(&ipaddr, 1,2,3,4);
+ octet = uip_ipaddr4(&ipaddr);
+ \endcode
+ *
+ * In the example above, the variable "octet" will contain the value 4.
+ *
+ * \hideinitializer
+ */
+#define uip_ipaddr4(addr) ((addr)->u8[3])
+
+/**
+ * Convert 16-bit quantity from host byte order to network byte order.
+ *
+ * This macro is primarily used for converting constants from host
+ * byte order to network byte order. For converting variables to
+ * network byte order, use the uip_htons() function instead.
+ *
+ * \hideinitializer
+ */
+#ifndef UIP_HTONS
+#   if UIP_BYTE_ORDER == UIP_BIG_ENDIAN
+#      define UIP_HTONS(n) (n)
+#      define UIP_HTONL(n) (n)
+#      define HTONS		UIP_HTONS
+#      define HTONL		UIP_HTONL
+#   else /* UIP_BYTE_ORDER == UIP_BIG_ENDIAN */
+#      define UIP_HTONS(n) (uint16_t)((((uint16_t) (n)) << 8) | (((uint16_t) (n)) >> 8))
+#      define UIP_HTONL(n) (((uint32_t)UIP_HTONS(n) << 16) | UIP_HTONS((uint32_t)(n) >> 16))
+#      define HTONS		UIP_HTONS
+#      define HTONL		UIP_HTONL
+#   endif /* UIP_BYTE_ORDER == UIP_BIG_ENDIAN */
+#else
+#error "UIP_HTONS already defined!"
+#endif /* UIP_HTONS */
+
+/**
+ * Convert a 16-bit quantity from host byte order to network byte order.
+ *
+ * This function is primarily used for converting variables from host
+ * byte order to network byte order. For converting constants to
+ * network byte order, use the UIP_HTONS() macro instead.
+ */
+#ifndef uip_htons
+	uint16_t uip_htons(uint16_t val);
+#	define htons	uip_htons
+#endif /* uip_htons */
+#ifndef uip_ntohs
+#define uip_ntohs uip_htons
+#endif
+
+#ifndef uip_htonl
+	uint32_t uip_htonl(uint32_t val);
+#endif /* uip_htonl */
+#ifndef uip_ntohl
+#define uip_ntohl uip_htonl
+#define ntohl     uip_htonl
+#endif
+
+/** @} */
+
+/**
+ * Pointer to the application data in the packet buffer.
+ *
+ * This pointer points to the application data when the application is
+ * called. If the application wishes to send data, the application may
+ * use this space to write the data into before calling uip_send().
+ */
+extern void *uip_appdata;
+
+#if UIP_URGDATA > 0
+/* uint8_t *uip_urgdata:
+ *
+ * This pointer points to any urgent data that has been received. Only
+ * present if compiled with support for urgent data (UIP_URGDATA).
+ */
+extern void *uip_urgdata;
+#endif /* UIP_URGDATA > 0 */
+
+#endif /* __XC__ */
+
+/**
+ * \defgroup uipdrivervars Variables used in uIP device drivers
+ * @{
+ *
+ * uIP has a few global variables that are used in device drivers for
+ * uIP.
+ */
+
+/**
+ * The length of the packet in the uip_buf buffer.
+ *
+ * The global variable uip_len holds the length of the packet in the
+ * uip_buf buffer.
+ *
+ * When the network device driver calls the uIP input function,
+ * uip_len should be set to the length of the packet in the uip_buf
+ * buffer.
+ *
+ * When sending packets, the device driver should use the contents of
+ * the uip_len variable to determine the length of the outgoing
+ * packet.
+ *
+ */
+extern uint16_t uip_len;
+
+/**
+ * The length of the extension headers
+ */
+extern uint8_t uip_ext_len;
+/** @} */
+
+#if UIP_URGDATA > 0
+extern uint16_t uip_urglen, uip_surglen;
+#endif /* UIP_URGDATA > 0 */
+
+
+/**
+ * Representation of a uIP TCP connection.
+ *
+ * The uip_conn structure is used for identifying a connection. All
+ * but one field in the structure are to be considered read-only by an
+ * application. The only exception is the appstate field whose purpose
+ * is to let the application store application-specific state (e.g.,
+ * file pointers) for the connection. The type of this field is
+ * configured in the "uipopt.h" header file.
+ */
+struct uip_conn {
+  uip_ipaddr_t ripaddr;   /**< The IP address of the remote host. */
+  
+  uint16_t lport;        /**< The local TCP port, in network byte order. */
+  uint16_t rport;        /**< The local remote TCP port, in network byte
+			 order. */
+  
+  uint8_t rcv_nxt[4];    /**< The sequence number that we expect to
+			 receive next. */
+  uint8_t snd_nxt[4];    /**< The sequence number that was last sent by
+                         us. */
+  uint16_t len;          /**< Length of the data that was previously sent. */
+  uint16_t mss;          /**< Current maximum segment size for the
+			 connection. */
+  uint16_t initialmss;   /**< Initial maximum segment size for the
+			 connection. */
+  uint8_t sa;            /**< Retransmission time-out calculation state
+			 variable. */
+  uint8_t sv;            /**< Retransmission time-out calculation state
+			 variable. */
+  uint8_t rto;           /**< Retransmission time-out. */
+  uint8_t tcpstateflags; /**< TCP state and flags. */
+  uint8_t tmr;         /**< The retransmission timer. */
+  uint8_t nrtx;          /**< The number of retransmissions for the last
+			 segment sent. */
+
+#if UIP_SLIDING_WINDOW
+  uint8_t midpoint;
+#endif
+  /** The application state. */
+  uip_tcp_appstate_t appstate;
+};
+
+#ifndef __XC__
+/**
+ * Pointer to the current TCP connection.
+ *
+ * The uip_conn pointer can be used to access the current TCP
+ * connection.
+ */
+
+extern struct uip_conn *uip_conn;
+#if UIP_TCP
+/* The array containing all uIP connections. */
+extern struct uip_conn uip_conns[UIP_CONNS];
+#endif
+
+/**
+ * \addtogroup uiparch
+ * @{
+ */
+
+/**
+ * 4-byte array used for the 32-bit sequence number calculations.
+ */
+extern uint8_t uip_acc32[4];
+/** @} */
+
+/**
+ * Representation of a uIP UDP connection.
+ */
+struct uip_udp_conn {
+  uip_ipaddr_t ripaddr;   /**< The IP address of the remote peer. */
+  uint16_t lport;        /**< The local port number in network byte order. */
+  uint16_t rport;        /**< The remote port number in network byte order. */
+  uint8_t  ttl;          /**< Default time-to-live. */
+  uint8_t  udpflags;     /**< UDP state flags */
+
+  /** The application state. */
+  uip_udp_appstate_t appstate;
+};
+
+/* This flag is used when a udp packet isn't sent due to an arp request. 
+ */
+#define UDP_PENDING_ARP 1
+
+/* This flag is used when a udp packet is succesfully sent
+ */
+#define UDP_SENT 2
+
+/* This flag is used when a udp connection is a "server" connect i.e.
+   accepts packets from any source
+ */
+#define UDP_IS_SERVER_CONN 4
+
+/**
+ * The current UDP connection.
+ */
+extern struct uip_udp_conn *uip_udp_conn;
+extern struct uip_udp_conn uip_udp_conns[UIP_UDP_CONNS];
+
+struct uip_fallback_interface {
+  void (*init)(void);
+  void (*output)(void);
+};
+
+#if UIP_CONF_ICMP6
+struct uip_icmp6_conn {
+  uip_icmp6_appstate_t appstate;
+};
+extern struct uip_icmp6_conn uip_icmp6_conns;
+#endif /*UIP_CONF_ICMP6*/
+
+/**
+ * The uIP TCP/IP statistics.
+ *
+ * This is the variable in which the uIP TCP/IP statistics are gathered.
+ */
+#if UIP_STATISTICS == 1
+extern struct uip_stats uip_stat;
+#define UIP_STAT(s) s
+#else
+#define UIP_STAT(s)
+#endif /* UIP_STATISTICS == 1 */
+
+/**
+ * The structure holding the TCP/IP statistics that are gathered if
+ * UIP_STATISTICS is set to 1.
+ *
+ */
+struct uip_stats {
+  struct {
+    uip_stats_t recv;     /**< Number of received packets at the IP
+			     layer. */
+    uip_stats_t sent;     /**< Number of sent packets at the IP
+			     layer. */
+    uip_stats_t forwarded;/**< Number of forwarded packets at the IP 
+			     layer. */
+    uip_stats_t drop;     /**< Number of dropped packets at the IP
+			     layer. */
+    uip_stats_t vhlerr;   /**< Number of packets dropped due to wrong
+			     IP version or header length. */
+    uip_stats_t hblenerr; /**< Number of packets dropped due to wrong
+			     IP length, high byte. */
+    uip_stats_t lblenerr; /**< Number of packets dropped due to wrong
+			     IP length, low byte. */
+    uip_stats_t fragerr;  /**< Number of packets dropped because they
+			     were IP fragments. */
+    uip_stats_t chkerr;   /**< Number of packets dropped due to IP
+			     checksum errors. */
+    uip_stats_t protoerr; /**< Number of packets dropped because they
+			     were neither ICMP, UDP nor TCP. */
+  } ip;                   /**< IP statistics. */
+  struct {
+    uip_stats_t recv;     /**< Number of received ICMP packets. */
+    uip_stats_t sent;     /**< Number of sent ICMP packets. */
+    uip_stats_t drop;     /**< Number of dropped ICMP packets. */
+    uip_stats_t typeerr;  /**< Number of ICMP packets with a wrong
+			     type. */
+    uip_stats_t chkerr;   /**< Number of ICMP packets with a bad
+			     checksum. */
+  } icmp;                 /**< ICMP statistics. */
+#if UIP_TCP
+  struct {
+    uip_stats_t recv;     /**< Number of recived TCP segments. */
+    uip_stats_t sent;     /**< Number of sent TCP segments. */
+    uip_stats_t drop;     /**< Number of dropped TCP segments. */
+    uip_stats_t chkerr;   /**< Number of TCP segments with a bad
+			     checksum. */
+    uip_stats_t ackerr;   /**< Number of TCP segments with a bad ACK
+			     number. */
+    uip_stats_t rst;      /**< Number of received TCP RST (reset) segments. */
+    uip_stats_t rexmit;   /**< Number of retransmitted TCP segments. */
+    uip_stats_t syndrop;  /**< Number of dropped SYNs because too few
+			     connections were available. */
+    uip_stats_t synrst;   /**< Number of SYNs for closed ports,
+			     triggering a RST. */
+  } tcp;                  /**< TCP statistics. */
+#endif
+#if UIP_UDP
+  struct {
+    uip_stats_t drop;     /**< Number of dropped UDP segments. */
+    uip_stats_t recv;     /**< Number of recived UDP segments. */
+    uip_stats_t sent;     /**< Number of sent UDP segments. */
+    uip_stats_t chkerr;   /**< Number of UDP segments with a bad
+			     checksum. */
+  } udp;                  /**< UDP statistics. */
+#endif /* UIP_UDP */
+#if UIP_CONF_IPV6
+  struct {
+    uip_stats_t drop;     /**< Number of dropped ND6 packets. */
+    uip_stats_t recv;     /**< Number of recived ND6 packets */
+    uip_stats_t sent;     /**< Number of sent ND6 packets */
+  } nd6;
+#endif /*UIP_CONF_IPV6*/
+};
+
+/**
+ * The uIP TCP/IP statistics.
+ *
+ * This is the variable in which the uIP TCP/IP statistics are gathered.
+ */
+extern struct uip_stats uip_stat;
+#endif /* #ifndef __XC__ */
+
+/*---------------------------------------------------------------------------*/
+/* All the stuff below this point is internal to uIP and should not be
+ * used directly by an application or by a device driver.
+ */
+/*---------------------------------------------------------------------------*/
+/* uint32_t uip_flags:
+ *
+ * When the application is called, uip_flags will contain the flags
+ * that are defined in this file. Please read below for more
+ * infomation.
+ */
+extern uint32_t uip_flags;
+
+/* The following flags may be set in the global variable uip_flags
+   before calling the application callback. The UIP_ACKDATA,
+   UIP_NEWDATA, and UIP_CLOSE flags may both be set at the same time,
+   whereas the others are mutually exclusive. Note that these flags
+   should *NOT* be accessed directly, but only through the uIP
+   functions/macros. */
+
+#define UIP_ACKDATA   1     /* Signifies that the outstanding data was
+			       acked and the application should send
+			       out new data instead of retransmitting
+			       the last data. */
+#define UIP_NEWDATA   2     /* Flags the fact that the peer has sent
+			       us new data. */
+#define UIP_REXMIT    4     /* Tells the application to retransmit the
+			       data that was last sent. */
+#define UIP_POLL      8     /* Used for polling the application, to
+			       check if the application has data that
+			       it wants to send. */
+#define UIP_CLOSE     16    /* The remote host has closed the
+			       connection, thus the connection has
+			       gone away. Or the application signals
+			       that it wants to close the
+			       connection. */
+#define UIP_ABORT     32    /* The remote host has aborted the
+			       connection, thus the connection has
+			       gone away. Or the application signals
+			       that it wants to abort the
+			       connection. */
+#define UIP_CONNECTED 64    /* We have got a connection from a remote
+                               host and have set up a new connection
+                               for it, or an active connection has
+                               been successfully established. */
+
+#define UIP_TIMEDOUT  128   /* The connection has been aborted due to
+			       too many retransmissions. */
+
+#define UIP_TCP_PUSH   256   /* Flags the fact that the other side set the
+                               TCP_PUSH flag. */
+
+/**
+ * \brief process the options within a hop by hop or destination option header
+ * \retval 0: nothing to send,
+ * \retval 1: drop pkt
+ * \retval 2: ICMP error message to send
+*/
+/*static uint8_t
+uip_ext_hdr_options_process(); */
+
+/* uip_process(flag):
+ *
+ * The actual uIP function which does all the work.
+ */
+void uip_process(uint8_t flag);
+  
+  /* The following flags are passed as an argument to the uip_process()
+   function. They are used to distinguish between the two cases where
+   uip_process() is called. It can be called either because we have
+   incoming data that should be processed, or because the periodic
+   timer has fired. These values are never used directly, but only in
+   the macros defined in this file. */
+ 
+#define UIP_DATA          1     /* Tells uIP that there is incoming
+				   data in the uip_buf buffer. The
+				   length of the data is stored in the
+				   global variable uip_len. */
+#define UIP_TIMER         2     /* Tells uIP that the periodic timer
+				   has fired. */
+#define UIP_POLL_REQUEST  3     /* Tells uIP that a connection should
+				   be polled. */
+#define UIP_UDP_SEND_CONN 4     /* Tells uIP that a UDP datagram
+				   should be constructed in the
+				   uip_buf buffer. */
+#if UIP_UDP
+#define UIP_UDP_TIMER         5
+#define UIP_UDP_ARP_EVENT     6
+#define UIP_UDP_ACKDATA       7
+#endif /* UIP_UDP */
+
+/* The TCP states used in the uip_conn->tcpstateflags. */
+#define UIP_CLOSED      0
+#define UIP_SYN_RCVD    1
+#define UIP_SYN_SENT    2
+#define UIP_ESTABLISHED 3
+#define UIP_FIN_WAIT_1  4
+#define UIP_FIN_WAIT_2  5
+#define UIP_CLOSING     6
+#define UIP_TIME_WAIT   7
+#define UIP_LAST_ACK    8
+#define UIP_TS_MASK     15
+  
+#define UIP_STOPPED      16
+
+/* The TCP and IP headers. */
+struct uip_tcpip_hdr {
+#if UIP_CONF_IPV6
+  /* IPv6 header. */
+  uint8_t vtc,
+    tcflow;
+  uint16_t flow;
+  uint8_t len[2];
+  uint8_t proto, ttl;
+  uip_ip6addr_t srcipaddr, destipaddr;
+#else /* UIP_CONF_IPV6 */
+  /* IPv4 header. */
+  uint8_t vhl,
+    tos,
+    len[2],
+    ipid[2],
+    ipoffset[2],
+    ttl,
+    proto;
+  uint16_t ipchksum;
+  uip_ipaddr_t srcipaddr, destipaddr;
+#endif /* UIP_CONF_IPV6 */
+  
+  /* TCP header. */
+  uint16_t srcport,
+    destport;
+  uint8_t seqno[4],
+    ackno[4],
+    tcpoffset,
+    flags,
+    wnd[2];
+  uint16_t tcpchksum;
+  uint8_t urgp[2];
+  uint8_t optdata[4];
+};
+
+/* The ICMP and IP headers. */
+struct uip_icmpip_hdr {
+#if UIP_CONF_IPV6
+  /* IPv6 header. */
+  uint8_t vtc,
+    tcf;
+  uint16_t flow;
+  uint8_t len[2];
+  uint8_t proto, ttl;
+  uip_ip6addr_t srcipaddr, destipaddr;
+#else /* UIP_CONF_IPV6 */
+  /* IPv4 header. */
+  uint8_t vhl,
+    tos,
+    len[2],
+    ipid[2],
+    ipoffset[2],
+    ttl,
+    proto;
+  uint16_t ipchksum;
+  uip_ipaddr_t srcipaddr, destipaddr;
+#endif /* UIP_CONF_IPV6 */
+  
+  /* ICMP header. */
+  uint8_t type, icode;
+  uint16_t icmpchksum;
+#if !UIP_CONF_IPV6
+  uint16_t id, seqno;
+  uint8_t payload[1];
+#endif /* !UIP_CONF_IPV6 */
+};
+
+
+/* The UDP and IP headers. */
+struct uip_udpip_hdr {
+#if UIP_CONF_IPV6
+  /* IPv6 header. */
+  uint8_t vtc,
+    tcf;
+  uint16_t flow;
+  uint8_t len[2];
+  uint8_t proto, ttl;
+  uip_ip6addr_t srcipaddr, destipaddr;
+#else /* UIP_CONF_IPV6 */
+  /* IP header. */
+  uint8_t vhl,
+    tos,
+    len[2],
+    ipid[2],
+    ipoffset[2],
+    ttl,
+    proto;
+  uint16_t ipchksum;
+  uip_ipaddr_t srcipaddr, destipaddr;
+#endif /* UIP_CONF_IPV6 */
+  
+  /* UDP header. */
+  uint16_t srcport,
+    destport;
+  uint16_t udplen;
+  uint16_t udpchksum;
+};
+
+/*
+ * In IPv6 the length of the L3 headers before the transport header is
+ * not fixed, due to the possibility to include extension option headers
+ * after the IP header. hence we split here L3 and L4 headers
+ */
+/* The IP header */
+struct uip_ip_hdr {
+#if UIP_CONF_IPV6
+  /* IPV6 header */
+  uint8_t vtc;
+  uint8_t tcflow;
+  uint16_t flow;
+  uint8_t len[2];
+  uint8_t proto, ttl;
+  uip_ip6addr_t srcipaddr, destipaddr;
+#else /* UIP_CONF_IPV6 */
+  /* IPV4 header */
+  uint8_t vhl,
+    tos,
+    len[2],
+    ipid[2],
+    ipoffset[2],
+    ttl,
+    proto;
+  uint16_t ipchksum;
+  uip_ipaddr_t srcipaddr, destipaddr;
+#endif /* UIP_CONF_IPV6 */
+};
+
+
+/*
+ * IPv6 extension option headers: we are able to process
+ * the 4 extension headers defined in RFC2460 (IPv6):
+ * - Hop by hop option header, destination option header:
+ *   These two are not used by any core IPv6 protocol, hence
+ *   we just read them and go to the next. They convey options,
+ *   the options defined in RFC2460 are Pad1 and PadN, which do
+ *   some padding, and that we do not need to read (the length
+ *   field in the header is enough)
+ * - Routing header: this one is most notably used by MIPv6,
+ *   which we do not implement, hence we just read it and go
+ *   to the next
+ * - Fragmentation header: we read this header and are able to
+ *   reassemble packets
+ *
+ * We do not offer any means to send packets with extension headers
+ *
+ * We do not implement Authentication and ESP headers, which are
+ * used in IPSec and defined in RFC4302,4303,4305,4385
+ */
+/* common header part */
+typedef struct uip_ext_hdr {
+  uint8_t next;
+  uint8_t len;
+} uip_ext_hdr;
+
+/* Hop by Hop option header */
+typedef struct uip_hbho_hdr {
+  uint8_t next;
+  uint8_t len;
+} uip_hbho_hdr;
+
+/* destination option header */
+typedef struct uip_desto_hdr {
+  uint8_t next;
+  uint8_t len;
+} uip_desto_hdr;
+
+/* We do not define structures for PAD1 and PADN options */
+
+/*
+ * routing header
+ * the routing header as 4 common bytes, then routing header type
+ * specific data there are several types of routing header. Type 0 was
+ * deprecated as per RFC5095 most notable other type is 2, used in
+ * RFC3775 (MIPv6) here we do not implement MIPv6, so we just need to
+ * parse the 4 first bytes
+ */
+typedef struct uip_routing_hdr {
+  uint8_t next;
+  uint8_t len;
+  uint8_t routing_type;
+  uint8_t seg_left;
+} uip_routing_hdr;
+
+/* fragmentation header */
+typedef struct uip_frag_hdr {
+  uint8_t next;
+  uint8_t res;
+  uint16_t offsetresmore;
+  uint32_t id;
+} uip_frag_hdr;
+
+/*
+ * an option within the destination or hop by hop option headers
+ * it contains type an length, which is true for all options but PAD1
+ */
+typedef struct uip_ext_hdr_opt {
+  uint8_t type;
+  uint8_t len;
+} uip_ext_hdr_opt;
+
+/* PADN option */
+typedef struct uip_ext_hdr_opt_padn {
+  uint8_t opt_type;
+  uint8_t opt_len;
+} uip_ext_hdr_opt_padn;
+
+/* RPL option */
+typedef struct uip_ext_hdr_opt_rpl {
+  uint8_t opt_type;
+  uint8_t opt_len;
+  uint8_t flags;
+  uint8_t instance;
+  uint16_t senderrank;
+} uip_ext_hdr_opt_rpl;
+
+/* TCP header */
+struct uip_tcp_hdr {
+  uint16_t srcport;
+  uint16_t destport;
+  uint8_t seqno[4];
+  uint8_t ackno[4];
+  uint8_t tcpoffset;
+  uint8_t flags;
+  uint8_t  wnd[2];
+  uint16_t tcpchksum;
+  uint8_t urgp[2];
+  uint8_t optdata[4];
+};
+
+/* The ICMP headers. */
+struct uip_icmp_hdr {
+  uint8_t type, icode;
+  uint16_t icmpchksum;
+#if !UIP_CONF_IPV6
+  uint16_t id, seqno;
+#endif /* !UIP_CONF_IPV6 */
+};
+
+
+/* The UDP headers. */
+struct uip_udp_hdr {
+  uint16_t srcport;
+  uint16_t destport;
+  uint16_t udplen;
+  uint16_t udpchksum;
+};
+
+
+/**
+ * The buffer size available for user data in the \ref uip_buf buffer.
+ *
+ * This macro holds the available size for user data in the \ref
+ * uip_buf buffer. The macro is intended to be used for checking
+ * bounds of available user data.
+ *
+ * Example:
+ \code
+ snprintf(uip_appdata, UIP_APPDATA_SIZE, "%u\n", i);
+ \endcode
+ *
+ * \hideinitializer
+ */
+#define UIP_APPDATA_SIZE (UIP_BUFSIZE - UIP_LLH_LEN - UIP_TCPIP_HLEN)
+#define UIP_APPDATA_PTR (void *)&uip_buf[UIP_LLH_LEN + UIP_TCPIP_HLEN]
+
+#define UIP_PROTO_ICMP     1
+#define UIP_PROTO_IGMP     6
+#define UIP_PROTO_TCP      6
+#define UIP_PROTO_UDP     17
+#define UIP_PROTO_ICMP6   58
+
+
+#if UIP_CONF_IPV6
+/** @{ */
+/** \brief  extension headers types */
+#define UIP_PROTO_HBHO        0
+#define UIP_PROTO_DESTO       60
+#define UIP_PROTO_ROUTING     43
+#define UIP_PROTO_FRAG        44
+#define UIP_PROTO_NONE        59
+/** @} */
+
+/** @{ */
+/** \brief  Destination and Hop By Hop extension headers option types */
+#define UIP_EXT_HDR_OPT_PAD1  0
+#define UIP_EXT_HDR_OPT_PADN  1
+#define UIP_EXT_HDR_OPT_RPL   0x63
+
+/** @} */
+
+/** @{ */
+/**
+ * \brief Bitmaps for extension header processing
+ *
+ * When processing extension headers, we should record somehow which one we
+ * see, because you cannot have twice the same header, except for destination
+ * We store all this in one uint8_t bitmap one bit for each header expected. The
+ * order in the bitmap is the order recommended in RFC2460
+ */
+#define UIP_EXT_HDR_BITMAP_HBHO 0x01
+#define UIP_EXT_HDR_BITMAP_DESTO1 0x02
+#define UIP_EXT_HDR_BITMAP_ROUTING 0x04
+#define UIP_EXT_HDR_BITMAP_FRAG 0x08
+#define UIP_EXT_HDR_BITMAP_AH 0x10
+#define UIP_EXT_HDR_BITMAP_ESP 0x20
+#define UIP_EXT_HDR_BITMAP_DESTO2 0x40
+/** @} */
+
+
+#endif /* UIP_CONF_IPV6 */
+
+
+/* Header sizes. */
+#if UIP_CONF_IPV6
+#define UIP_IPH_LEN    40
+#define UIP_FRAGH_LEN  8
+#else /* UIP_CONF_IPV6 */
+#define UIP_IPH_LEN    20    /* Size of IP header */
+#endif /* UIP_CONF_IPV6 */
+
+#define UIP_UDPH_LEN    8    /* Size of UDP header */
+#define UIP_TCPH_LEN   20    /* Size of TCP header */
+#ifdef UIP_IPH_LEN
+#define UIP_ICMPH_LEN   4    /* Size of ICMP header */
+#endif
+#define UIP_IPUDPH_LEN (UIP_UDPH_LEN + UIP_IPH_LEN)    /* Size of IP +
+							  UDP
+							  header */
+#define UIP_IPTCPH_LEN (UIP_TCPH_LEN + UIP_IPH_LEN)    /* Size of IP +
+							  TCP
+							  header */
+#define UIP_TCPIP_HLEN UIP_IPTCPH_LEN
+#define UIP_IPICMPH_LEN (UIP_IPH_LEN + UIP_ICMPH_LEN) /* size of ICMP
+                                                         + IP header */
+#define UIP_LLIPH_LEN (UIP_LLH_LEN + UIP_IPH_LEN)    /* size of L2
+                                                        + IP header */
+#if UIP_CONF_IPV6
+/**
+ * The sums below are quite used in ND. When used for uip_buf, we
+ * include link layer length when used for uip_len, we do not, hence
+ * we need values with and without LLH_LEN we do not use capital
+ * letters as these values are variable
+ */
+#define uip_l2_l3_hdr_len (UIP_LLH_LEN + UIP_IPH_LEN + uip_ext_len)
+#define uip_l2_l3_icmp_hdr_len (UIP_LLH_LEN + UIP_IPH_LEN + uip_ext_len + UIP_ICMPH_LEN)
+#define uip_l3_hdr_len (UIP_IPH_LEN + uip_ext_len)
+#define uip_l3_icmp_hdr_len (UIP_IPH_LEN + uip_ext_len + UIP_ICMPH_LEN)
+#endif /*UIP_CONF_IPV6*/
+
+
+#if UIP_FIXEDADDR
+extern const uip_ipaddr_t uip_hostaddr, uip_netmask, uip_draddr;
+#else /* UIP_FIXEDADDR */
+extern uip_ipaddr_t uip_hostaddr, uip_netmask, uip_draddr;
+#endif /* UIP_FIXEDADDR */
+extern const uip_ipaddr_t uip_broadcast_addr;
+extern const uip_ipaddr_t uip_all_zeroes_addr;
+
+#if UIP_FIXEDETHADDR
+extern const uip_lladdr_t uip_lladdr;
+#else
+extern uip_lladdr_t uip_lladdr;
+#endif
+
+
+
+
+#if UIP_CONF_IPV6
+/** Length of the link local prefix */
+#define UIP_LLPREF_LEN     10
+
+/**
+ * \brief Is IPv6 address a the unspecified address
+ * a is of type uip_ipaddr_t
+ */
+#define uip_is_addr_loopback(a)                  \
+  ((((a)->u16[0]) == 0) &&                       \
+   (((a)->u16[1]) == 0) &&                       \
+   (((a)->u16[2]) == 0) &&                       \
+   (((a)->u16[3]) == 0) &&                       \
+   (((a)->u16[4]) == 0) &&                       \
+   (((a)->u16[5]) == 0) &&                       \
+   (((a)->u16[6]) == 0) &&                       \
+   (((a)->u8[14]) == 0) &&                       \
+   (((a)->u8[15]) == 0x01))
+/**
+ * \brief Is IPv6 address a the unspecified address
+ * a is of type uip_ipaddr_t
+ */
+#define uip_is_addr_unspecified(a)               \
+  ((((a)->u16[0]) == 0) &&                       \
+   (((a)->u16[1]) == 0) &&                       \
+   (((a)->u16[2]) == 0) &&                       \
+   (((a)->u16[3]) == 0) &&                       \
+   (((a)->u16[4]) == 0) &&                       \
+   (((a)->u16[5]) == 0) &&                       \
+   (((a)->u16[6]) == 0) &&                       \
+   (((a)->u16[7]) == 0))
+
+/** \brief Is IPv6 address a the link local all-nodes multicast address */
+#define uip_is_addr_linklocal_allnodes_mcast(a)     \
+  ((((a)->u8[0]) == 0xff) &&                        \
+   (((a)->u8[1]) == 0x02) &&                        \
+   (((a)->u16[1]) == 0) &&                          \
+   (((a)->u16[2]) == 0) &&                          \
+   (((a)->u16[3]) == 0) &&                          \
+   (((a)->u16[4]) == 0) &&                          \
+   (((a)->u16[5]) == 0) &&                          \
+   (((a)->u16[6]) == 0) &&                          \
+   (((a)->u8[14]) == 0) &&                          \
+   (((a)->u8[15]) == 0x01))
+
+/** \brief Is IPv6 address a the link local all-routers multicast address */
+#define uip_is_addr_linklocal_allrouters_mcast(a)     \
+  ((((a)->u8[0]) == 0xff) &&                        \
+   (((a)->u8[1]) == 0x02) &&                        \
+   (((a)->u16[1]) == 0) &&                          \
+   (((a)->u16[2]) == 0) &&                          \
+   (((a)->u16[3]) == 0) &&                          \
+   (((a)->u16[4]) == 0) &&                          \
+   (((a)->u16[5]) == 0) &&                          \
+   (((a)->u16[6]) == 0) &&                          \
+   (((a)->u8[14]) == 0) &&                          \
+   (((a)->u8[15]) == 0x02))
+
+/**
+ * \brief Checks whether the address a is link local.
+ * a is of type uip_ipaddr_t
+ */
+#define uip_is_addr_linklocal(a)                 \
+  ((a)->u8[0] == 0xfe &&                         \
+   (a)->u8[1] == 0x80)
+
+/** \brief set IP address a to unspecified */
+#define uip_create_unspecified(a) uip_ip6addr(a, 0, 0, 0, 0, 0, 0, 0, 0)
+
+/** \brief set IP address a to the link local all-nodes multicast address */
+#define uip_create_linklocal_allnodes_mcast(a) uip_ip6addr(a, 0xff02, 0, 0, 0, 0, 0, 0, 0x0001)
+
+/** \brief set IP address a to the link local all-routers multicast address */
+#define uip_create_linklocal_allrouters_mcast(a) uip_ip6addr(a, 0xff02, 0, 0, 0, 0, 0, 0, 0x0002)
+#define uip_create_linklocal_prefix(addr) do { \
+    (addr)->u16[0] = UIP_HTONS(0xfe80);            \
+    (addr)->u16[1] = 0;                        \
+    (addr)->u16[2] = 0;                        \
+    (addr)->u16[3] = 0;                        \
+  } while(0)
+
+/**
+ * \brief  is addr (a) a solicited node multicast address, see RFC3513
+ *  a is of type uip_ipaddr_t*
+ */
+#define uip_is_addr_solicited_node(a)          \
+  ((((a)->u8[0])  == 0xFF) &&                  \
+   (((a)->u8[1])  == 0x02) &&                  \
+   (((a)->u16[1]) == 0x00) &&                  \
+   (((a)->u16[2]) == 0x00) &&                  \
+   (((a)->u16[3]) == 0x00) &&                  \
+   (((a)->u16[4]) == 0x00) &&                  \
+   (((a)->u8[10]) == 0x00) &&                  \
+   (((a)->u8[11]) == 0x01) &&                  \
+   (((a)->u8[12]) == 0xFF))
+
+/**
+ * \briefput in b the solicited node address corresponding to address a
+ * both a and b are of type uip_ipaddr_t*
+ * */
+#define uip_create_solicited_node(a, b)    \
+  (((b)->u8[0]) = 0xFF);                        \
+  (((b)->u8[1]) = 0x02);                        \
+  (((b)->u16[1]) = 0);                          \
+  (((b)->u16[2]) = 0);                          \
+  (((b)->u16[3]) = 0);                          \
+  (((b)->u16[4]) = 0);                          \
+  (((b)->u8[10]) = 0);                          \
+  (((b)->u8[11]) = 0x01);                       \
+  (((b)->u8[12]) = 0xFF);                       \
+  (((b)->u8[13]) = ((a)->u8[13]));              \
+  (((b)->u16[7]) = ((a)->u16[7]))
+
+/**
+ * \brief is addr (a) a link local unicast address, see RFC3513
+ *  i.e. is (a) on prefix FE80::/10
+ *  a is of type uip_ipaddr_t*
+ */
+#define uip_is_addr_link_local(a) \
+  ((((a)->u8[0]) == 0xFE) && \
+  (((a)->u8[1]) == 0x80))
+
+/**
+ * \brief was addr (a) forged based on the mac address m
+ * a type is uip_ipaddr_t
+ * m type is uiplladdr_t
+ */
+#if UIP_CONF_LL_802154
+#define uip_is_addr_mac_addr_based(a, m) \
+  ((((a)->u8[8])  == (((m)->addr[0]) ^ 0x02)) &&   \
+   (((a)->u8[9])  == (m)->addr[1]) &&            \
+   (((a)->u8[10]) == (m)->addr[2]) &&            \
+   (((a)->u8[11]) == (m)->addr[3]) &&            \
+   (((a)->u8[12]) == (m)->addr[4]) &&            \
+   (((a)->u8[13]) == (m)->addr[5]) &&            \
+   (((a)->u8[14]) == (m)->addr[6]) &&            \
+   (((a)->u8[15]) == (m)->addr[7]))
+#else
+
+#define uip_is_addr_mac_addr_based(a, m) \
+  ((((a)->u8[8])  == (((m)->addr[0]) | 0x02)) &&   \
+   (((a)->u8[9])  == (m)->addr[1]) &&            \
+   (((a)->u8[10]) == (m)->addr[2]) &&            \
+   (((a)->u8[11]) == 0xff) &&            \
+   (((a)->u8[12]) == 0xfe) &&            \
+   (((a)->u8[13]) == (m)->addr[3]) &&            \
+   (((a)->u8[14]) == (m)->addr[4]) &&            \
+   (((a)->u8[15]) == (m)->addr[5]))
+
+#endif /*UIP_CONF_LL_802154*/
+
+/**
+ * \brief is address a multicast address, see RFC 3513
+ * a is of type uip_ipaddr_t*
+ * */
+#define uip_is_addr_mcast(a)                    \
+  (((a)->u8[0]) == 0xFF)
+
+/**
+ * \brief is group-id of multicast address a
+ * the all nodes group-id
+ */
+#define uip_is_mcast_group_id_all_nodes(a) \
+  ((((a)->u16[1])  == 0) &&                 \
+   (((a)->u16[2])  == 0) &&                 \
+   (((a)->u16[3])  == 0) &&                 \
+   (((a)->u16[4])  == 0) &&                 \
+   (((a)->u16[5])  == 0) &&                 \
+   (((a)->u16[6])  == 0) &&                 \
+   (((a)->u8[14])  == 0) &&                 \
+   (((a)->u8[15])  == 1))
+
+/**
+ * \brief is group-id of multicast address a
+ * the all routers group-id
+ */
+#define uip_is_mcast_group_id_all_routers(a) \
+  ((((a)->u16[1])  == 0) &&                 \
+   (((a)->u16[2])  == 0) &&                 \
+   (((a)->u16[3])  == 0) &&                 \
+   (((a)->u16[4])  == 0) &&                 \
+   (((a)->u16[5])  == 0) &&                 \
+   (((a)->u16[6])  == 0) &&                 \
+   (((a)->u8[14])  == 0) &&                 \
+   (((a)->u8[15])  == 2))
+
+
+/**
+ * \brief are last three bytes of both addresses equal?
+ * This is used to compare solicited node multicast addresses
+ */
+#define uip_are_solicited_bytes_equal(a, b)             \
+  ((((a)->u8[13])  == ((b)->u8[13])) &&                 \
+   (((a)->u8[14])  == ((b)->u8[14])) &&                 \
+   (((a)->u8[15])  == ((b)->u8[15])))
+
+#endif /*UIP_CONF_IPV6*/
+
+
+#ifndef __XC__
+/**
+ * Calculate the Internet checksum over a buffer.
+ *
+ * The Internet checksum is the one's complement of the one's
+ * complement sum of all 16-bit words in the buffer.
+ *
+ * See RFC1071.
+ *
+ * \param buf A pointer to the buffer over which the checksum is to be
+ * computed.
+ *
+ * \param len The length of the buffer over which the checksum is to
+ * be computed.
+ *
+ * \return The Internet checksum of the buffer.
+ */
+uint16_t uip_chksum(uint16_t *buf, uint16_t len);
+#endif /* #ifndef __XC__ */
+/**
+ * Calculate the IP header checksum of the packet header in uip_buf.
+ *
+ * The IP header checksum is the Internet checksum of the 20 bytes of
+ * the IP header.
+ *
+ * \return The IP header checksum of the IP header in the uip_buf
+ * buffer.
+ */
+uint16_t uip_ipchksum(void);
+
+/**
+ * Calculate the TCP checksum of the packet in uip_buf and uip_appdata.
+ *
+ * The TCP checksum is the Internet checksum of data contents of the
+ * TCP segment, and a pseudo-header as defined in RFC793.
+ *
+ * \return The TCP checksum of the TCP segment in uip_buf and pointed
+ * to by uip_appdata.
+ */
+uint16_t uip_tcpchksum(void);
+
+/**
+ * Calculate the UDP checksum of the packet in uip_buf and uip_appdata.
+ *
+ * The UDP checksum is the Internet checksum of data contents of the
+ * UDP segment, and a pseudo-header as defined in RFC768.
+ *
+ * \return The UDP checksum of the UDP segment in uip_buf and pointed
+ * to by uip_appdata.
+ */
+uint16_t uip_udpchksum(void);
+
+/**
+ * Calculate the ICMP checksum of the packet in uip_buf.
+ *
+ * \return The ICMP checksum of the ICMP packet in uip_buf
+ */
+uint16_t uip_icmp6chksum(void);
+
+
+/**
+ * The uIP packet buffer.
+ *
+ * The uip_buf array is used to hold incoming and outgoing
+ * packets. The device driver should place incoming data into this
+ * buffer. When sending data, the device driver should read the link
+ * level headers and the TCP/IP headers from this buffer. The size of
+ * the link level headers is configured by the UIP_LLH_LEN define.
+ *
+ * \note The application data need not be placed in this buffer, so
+ * the device driver must read it from the place pointed to by the
+ * uip_appdata pointer as illustrated by the following example:
+ \code
+ void
+ devicedriver_send(void)
+ {
+    hwsend(&uip_buf[0], UIP_LLH_LEN);
+    if(uip_len <= UIP_LLH_LEN + UIP_TCPIP_HLEN) {
+      hwsend(&uip_buf[UIP_LLH_LEN], uip_len - UIP_LLH_LEN);
+    } else {
+      hwsend(&uip_buf[UIP_LLH_LEN], UIP_TCPIP_HLEN);
+      hwsend(uip_appdata, uip_len - UIP_TCPIP_HLEN - UIP_LLH_LEN);
+    }
+ }
+ \endcode
+ */
+//extern u8_t uip_buf[UIP_BUFSIZE+2];
+//extern u8_t *uip_buf;
+#if ORIGINAL
+typedef union {
+  uint32_t u32[(UIP_BUFSIZE + 3) / 4];
+  uint8_t u8[UIP_BUFSIZE];
+} uip_buf_t;
+
+extern uip_buf_t uip_aligned_buf;
+#define uip_buf (uip_aligned_buf.u8)
+#endif
+
+/*
+ * Pico]OS: Add padding before link-level header to
+ *          adjust tcpip headers to 32-bit boundary.
+ *          Add u16 field to access data with 16-bit alignment.
+ */
+typedef union {
+  uint32_t u32[(UIP_LLH_PAD + UIP_BUFSIZE + 3) / 4];
+  uint16_t u16[(UIP_LLH_PAD + UIP_BUFSIZE + 1) / 2];
+  uint8_t u8[UIP_LLH_PAD + UIP_BUFSIZE];
+} uip_buf_t;
+
+extern uip_buf_t uip_aligned_buf;
+//#define uip_buf (&uip_aligned_buf)
+#define uip_buf (uip_aligned_buf.u8 + UIP_LLH_PAD)
+
+/*
+ * Pico]OS: Macros for accessing uip_buf contens with
+ *          16-bit or 32-bit alignment.
+ */
+
+#define uip_buf32(i) (uip_aligned_buf.u32[(UIP_LLH_PAD + i) / 4])
+#define uip_buf16(i) (uip_aligned_buf.u16[(UIP_LLH_PAD + i) / 2])
+
+/** @} */
+
+#endif /* __UIP_H__ */
+
+
+/** @} */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/uip6.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/uip6.c
@@ -1,0 +1,2381 @@
+/**
+ * \addtogroup uip6
+ * @{
+ */
+
+/**
+ * \file
+ *         The uIP TCP/IPv6 stack code.
+ *
+ * \author Adam Dunkels <adam@sics.se>
+ * \author Julien Abeille <jabeille@cisco.com> (IPv6 related code)
+ * \author Mathilde Durvy <mdurvy@cisco.com> (IPv6 related code)
+ */
+/*
+ * Copyright (c) 2001-2003, Adam Dunkels.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This file is part of the uIP TCP/IP stack.
+ *
+ *
+ */
+
+/*
+ * uIP is a small implementation of the IP, UDP and TCP protocols (as
+ * well as some basic ICMP stuff). The implementation couples the IP,
+ * UDP, TCP and the application layers very tightly. To keep the size
+ * of the compiled code down, this code frequently uses the goto
+ * statement. While it would be possible to break the uip_process()
+ * function into many smaller functions, this would increase the code
+ * size because of the overhead of parameter passing and the fact that
+ * the optimizer would not be as efficient.
+ *
+ * The principle is that we have a small buffer, called the uip_buf,
+ * in which the device driver puts an incoming packet. The TCP/IP
+ * stack parses the headers in the packet, and calls the
+ * application. If the remote host has sent data to the application,
+ * this data is present in the uip_buf and the application read the
+ * data from there. It is up to the application to put this data into
+ * a byte stream if needed. The application will not be fed with data
+ * that is out of sequence.
+ *
+ * If the application wishes to send data to the peer, it should put
+ * its data into the uip_buf. The uip_appdata pointer points to the
+ * first available byte. The TCP/IP stack will calculate the
+ * checksums, and fill in the necessary header fields and finally send
+ * the packet back to the peer.
+ */
+
+#include "net/uip.h"
+#include "net/uipopt.h"
+#include "net/uip-icmp6.h"
+#include "net/uip-nd6.h"
+#include "net/uip-ds6.h"
+
+#include <string.h>
+
+#if UIP_CONF_IPV6
+/*---------------------------------------------------------------------------*/
+/* For Debug, logging, statistics                                            */
+/*---------------------------------------------------------------------------*/
+
+#define DEBUG DEBUG_NONE
+#include "net/uip-debug.h"
+
+#if UIP_CONF_IPV6_RPL
+#include "rpl/rpl.h"
+#endif /* UIP_CONF_IPV6_RPL */
+
+#if UIP_LOGGING == 1
+#include <stdio.h>
+void uip_log(char *msg);
+#define UIP_LOG(m) uip_log(m)
+#else
+#define UIP_LOG(m)
+#endif /* UIP_LOGGING == 1 */
+
+#if UIP_STATISTICS == 1
+struct uip_stats uip_stat;
+#endif /* UIP_STATISTICS == 1 */
+ 
+
+/*---------------------------------------------------------------------------*/
+/** @{ \name Layer 2 variables */
+/*---------------------------------------------------------------------------*/
+/** Host L2 address */
+#if UIP_CONF_LL_802154
+uip_lladdr_t uip_lladdr;
+#else /*UIP_CONF_LL_802154*/
+uip_lladdr_t uip_lladdr = {{0x00,0x06,0x98,0x00,0x02,0x32}};
+#endif /*UIP_CONF_LL_802154*/
+/** @} */
+
+/*---------------------------------------------------------------------------*/
+/** @{ \name Layer 3 variables */
+/*---------------------------------------------------------------------------*/
+/**
+ * \brief Type of the next header in IPv6 header or extension headers
+ *
+ * Can be the next header field in the IPv6 header or in an extension header.
+ * When doing fragment reassembly, we must change the value of the next header
+ * field in the header before the fragmentation header, hence we need a pointer
+ * to this field.
+ */
+uint8_t *uip_next_hdr;
+/** \brief bitmap we use to record which IPv6 headers we have already seen */
+uint8_t uip_ext_bitmap = 0;
+/**
+ * \brief length of the extension headers read. updated each time we process
+ * a header
+ */
+uint8_t uip_ext_len = 0;
+/** \brief length of the header options read */
+uint8_t uip_ext_opt_offset = 0;
+/** @} */
+
+/*---------------------------------------------------------------------------*/
+/* Buffers                                                                   */
+/*---------------------------------------------------------------------------*/
+/** \name Buffer defines
+ *  @{
+ */
+#if !BUF_32BIT_ALIGN
+#define FBUF                           ((struct uip_tcpip_hdr *)&uip_reassbuf[0])
+#define UIP_IP_BUF                     ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN])
+#define UIP_ICMP_BUF                   ((struct uip_icmp_hdr *)&uip_buf[uip_l2_l3_hdr_len])
+#define UIP_UDP_BUF                    ((struct uip_udp_hdr *)&uip_buf[UIP_LLH_LEN + UIP_IPH_LEN])
+#define UIP_TCP_BUF                    ((struct uip_tcp_hdr *)&uip_buf[UIP_LLH_LEN + UIP_IPH_LEN])
+#define UIP_EXT_BUF                    ((struct uip_ext_hdr *)&uip_buf[uip_l2_l3_hdr_len])
+#define UIP_ROUTING_BUF                ((struct uip_routing_hdr *)&uip_buf[uip_l2_l3_hdr_len])
+#define UIP_FRAG_BUF                   ((struct uip_frag_hdr *)&uip_buf[uip_l2_l3_hdr_len])
+#define UIP_HBHO_BUF                   ((struct uip_hbho_hdr *)&uip_buf[uip_l2_l3_hdr_len])
+#define UIP_DESTO_BUF                  ((struct uip_desto_hdr *)&uip_buf[uip_l2_l3_hdr_len])
+#define UIP_EXT_HDR_OPT_BUF            ((struct uip_ext_hdr_opt *)&uip_buf[uip_l2_l3_hdr_len + uip_ext_opt_offset])
+#define UIP_EXT_HDR_OPT_PADN_BUF       ((struct uip_ext_hdr_opt_padn *)&uip_buf[uip_l2_l3_hdr_len + uip_ext_opt_offset])
+#if UIP_CONF_IPV6_RPL
+#define UIP_EXT_HDR_OPT_RPL_BUF        ((struct uip_ext_hdr_opt_rpl *)&uip_buf[uip_l2_l3_hdr_len + uip_ext_opt_offset])
+#endif /* UIP_CONF_IPV6_RPL */
+#define UIP_ICMP6_ERROR_BUF            ((struct uip_icmp6_error *)&uip_buf[uip_l2_l3_icmp_hdr_len])
+#else
+/* Macros. */
+
+/*
+ * Pico]OS: Use uip_buf16 macro to ensure 16-bit alignment.
+ *          Allows compiling with gcc -Wcast-align.
+ */
+/*
+ * Pico]OS: Use uip_buf32 macro to ensure 16/32-bit alignment.
+ *          Allows compiling with gcc -Wcast-align.
+ */
+#define FBUF                             ((struct uip_tcpip_hdr *)&uip_reassbuf[0])
+#define UIP_IP_BUF                          ((struct uip_ip_hdr *)&uip_buf16(UIP_LLH_LEN))
+#define UIP_ICMP_BUF                      ((struct uip_icmp_hdr *)&uip_buf16(uip_l2_l3_hdr_len))
+#define UIP_UDP_BUF                        ((struct uip_udp_hdr *)&uip_buf16((UIP_LLH_LEN + UIP_IPH_LEN)))
+#define UIP_TCP_BUF                        ((struct uip_tcp_hdr *)&uip_buf16((UIP_LLH_LEN + UIP_IPH_LEN)))
+#define UIP_EXT_BUF                        ((struct uip_ext_hdr *)&uip_buf16(uip_l2_l3_hdr_len))
+#define UIP_ROUTING_BUF                ((struct uip_routing_hdr *)&uip_buf16(uip_l2_l3_hdr_len))
+#define UIP_FRAG_BUF                      ((struct uip_frag_hdr *)&uip_buf32(uip_l2_l3_hdr_len))
+#define UIP_HBHO_BUF                      ((struct uip_hbho_hdr *)&uip_buf16(uip_l2_l3_hdr_len))
+#define UIP_DESTO_BUF                    ((struct uip_desto_hdr *)&uip_buf16(uip_l2_l3_hdr_len))
+#define UIP_EXT_HDR_OPT_BUF            ((struct uip_ext_hdr_opt *)&uip_buf16(uip_l2_l3_hdr_len + uip_ext_opt_offset))
+#define UIP_EXT_HDR_OPT_PADN_BUF  ((struct uip_ext_hdr_opt_padn *)&uip_buf16(uip_l2_l3_hdr_len + uip_ext_opt_offset))
+#if UIP_CONF_IPV6_RPL
+#define UIP_EXT_HDR_OPT_RPL_BUF    ((struct uip_ext_hdr_opt_rpl *)&uip_buf16(uip_l2_l3_hdr_len + uip_ext_opt_offset))
+#endif /* UIP_CONF_IPV6_RPL */
+#define UIP_ICMP6_ERROR_BUF            ((struct uip_icmp6_error *)&uip_buf16(uip_l2_l3_icmp_hdr_len))
+#endif
+
+
+/** @} */
+/** \name Buffer variables
+ *  @{
+ */
+/** Packet buffer for incoming and outgoing packets */
+#ifndef UIP_CONF_EXTERNAL_BUFFER
+uip_buf_t uip_aligned_buf;
+#endif /* UIP_CONF_EXTERNAL_BUFFER */
+
+/* The uip_appdata pointer points to application data. */
+void *uip_appdata;
+/* The uip_appdata pointer points to the application data which is to be sent*/
+void *uip_sappdata;
+
+#if UIP_URGDATA > 0
+/* The uip_urgdata pointer points to urgent data (out-of-band data), if present */
+void *uip_urgdata;
+uint16_t uip_urglen, uip_surglen;
+#endif /* UIP_URGDATA > 0 */
+
+/* The uip_len is either 8 or 16 bits, depending on the maximum packet size.*/
+uint16_t uip_len, uip_slen;
+/** @} */
+
+/*---------------------------------------------------------------------------*/
+/** @{ \name General variables                                               */
+/*---------------------------------------------------------------------------*/
+
+/* The uip_flags variable is used for communication between the TCP/IP stack
+and the application program. */
+uint32_t uip_flags;
+
+/* uip_conn always points to the current connection (set to NULL for UDP). */
+struct uip_conn *uip_conn;
+
+/* Temporary variables. */
+#if (UIP_TCP || UIP_UDP)
+static uint8_t c;
+#endif
+
+#if UIP_ACTIVE_OPEN || UIP_UDP
+/* Keeps track of the last port used for a new connection. */
+static uint16_t lastport;
+#endif /* UIP_ACTIVE_OPEN || UIP_UDP */
+/** @} */
+
+/*---------------------------------------------------------------------------*/
+/* TCP                                                                       */
+/*---------------------------------------------------------------------------*/
+/** \name TCP defines
+ *@{
+ */
+/* Structures and definitions. */
+#define TCP_FIN 0x01
+#define TCP_SYN 0x02
+#define TCP_RST 0x04
+#define TCP_PSH 0x08
+#define TCP_ACK 0x10
+#define TCP_URG 0x20
+#define TCP_CTL 0x3f
+
+#define TCP_OPT_END     0   /* End of TCP options list */
+#define TCP_OPT_NOOP    1   /* "No-operation" TCP option */
+#define TCP_OPT_MSS     2   /* Maximum segment size TCP option */
+
+#define TCP_OPT_MSS_LEN 4   /* Length of TCP MSS option. */
+/** @} */
+/** \name TCP variables
+ *@{
+ */
+#if UIP_TCP
+/* The uip_conns array holds all TCP connections. */
+struct uip_conn uip_conns[UIP_CONNS];
+
+/* The uip_listenports list all currently listning ports. */
+uint16_t uip_listenports[UIP_LISTENPORTS];
+uint16_t uip_udp_listenports[UIP_LISTENPORTS];
+
+/* The iss variable is used for the TCP initial sequence number. */
+static uint8_t iss[4];
+
+/* Temporary variables. */
+uint8_t uip_acc32[4];
+static uint8_t opt;
+static uint16_t tmp16;
+#endif /* UIP_TCP */
+/** @} */
+
+/*---------------------------------------------------------------------------*/
+/** @{ \name UDP variables                                                   */
+/*---------------------------------------------------------------------------*/
+#if UIP_UDP
+struct uip_udp_conn *uip_udp_conn;
+struct uip_udp_conn uip_udp_conns[UIP_UDP_CONNS];
+#endif /* UIP_UDP */
+/** @} */
+
+/*---------------------------------------------------------------------------*/
+/** @{ \name ICMPv6 variables                                                */
+/*---------------------------------------------------------------------------*/
+#if UIP_CONF_ICMP6
+/** single possible icmpv6 "connection" */
+struct uip_icmp6_conn uip_icmp6_conns;
+#endif /*UIP_CONF_ICMP6*/
+/** @} */
+
+/*---------------------------------------------------------------------------*/
+/* Functions                                                                 */
+/*---------------------------------------------------------------------------*/
+#if (!UIP_ARCH_ADD32 && UIP_TCP)
+void
+uip_add32(uint8_t *op32, uint16_t op16)
+{
+  uip_acc32[3] = op32[3] + (op16 & 0xff);
+  uip_acc32[2] = op32[2] + (op16 >> 8);
+  uip_acc32[1] = op32[1];
+  uip_acc32[0] = op32[0];
+  
+  if(uip_acc32[2] < (op16 >> 8)) {
+    ++uip_acc32[1];
+    if(uip_acc32[1] == 0) {
+      ++uip_acc32[0];
+    }
+  }
+  
+  
+  if(uip_acc32[3] < (op16 & 0xff)) {
+    ++uip_acc32[2];
+    if(uip_acc32[2] == 0) {
+      ++uip_acc32[1];
+      if(uip_acc32[1] == 0) {
+        ++uip_acc32[0];
+      }
+    }
+  }
+}
+
+#endif /* UIP_ARCH_ADD32 && UIP_TCP */
+
+#if ! UIP_ARCH_CHKSUM
+/*---------------------------------------------------------------------------*/
+static uint16_t
+chksum(uint16_t sum, const uint8_t *data, uint16_t len)
+{
+  uint16_t t;
+  const uint8_t *dataptr;
+  const uint8_t *last_byte;
+
+  dataptr = data;
+  last_byte = data + len - 1;
+  
+  while(dataptr < last_byte) {   /* At least two more bytes */
+    t = (dataptr[0] << 8) + dataptr[1];
+    sum += t;
+    if(sum < t) {
+      sum++;      /* carry */
+    }
+    dataptr += 2;
+  }
+  
+  if(dataptr == last_byte) {
+    t = (dataptr[0] << 8) + 0;
+    sum += t;
+    if(sum < t) {
+      sum++;      /* carry */
+    }
+  }
+
+  /* Return sum in host byte order. */
+  return sum;
+}
+#endif /* UIP_ARCH_CHKSUM */
+/*---------------------------------------------------------------------------*/
+uint16_t
+uip_chksum(uint16_t *data, uint16_t len)
+{
+  return uip_htons(chksum(0, (uint8_t *)data, len));
+}
+/*---------------------------------------------------------------------------*/
+#ifndef UIP_ARCH_IPCHKSUM
+uint16_t
+uip_ipchksum(void)
+{
+  uint16_t sum;
+
+  sum = chksum(0, &uip_buf[UIP_LLH_LEN], UIP_IPH_LEN);
+  PRINTF("uip_ipchksum: sum 0x%04x\n", sum);
+  return (sum == 0) ? 0xffff : uip_htons(sum);
+}
+#endif
+/*---------------------------------------------------------------------------*/
+static uint16_t
+upper_layer_chksum(uint8_t proto)
+{
+/* gcc 4.4.0 - 4.6.1 (maybe 4.3...) with -Os on 8 bit CPUS incorrectly compiles:
+ * int bar (int);
+ * int foo (unsigned char a, unsigned char b) {
+ *   int len = (a << 8) + b; //len becomes 0xff00&<random>+b
+ *   return len + bar (len);
+ * }
+ * upper_layer_len triggers this bug unless it is declared volatile.
+ * See https://sourceforge.net/apps/mantisbt/contiki/view.php?id=3
+ */
+  volatile uint16_t upper_layer_len;
+  uint16_t sum;
+  
+  upper_layer_len = (((uint16_t)(UIP_IP_BUF->len[0]) << 8) + UIP_IP_BUF->len[1] - uip_ext_len);
+  
+  PRINTF("Upper layer checksum len: %d from: %d\n", upper_layer_len,
+	 UIP_IPH_LEN + UIP_LLH_LEN + uip_ext_len);
+
+  /* First sum pseudoheader. */
+  /* IP protocol and length fields. This addition cannot carry. */
+  sum = upper_layer_len + proto;
+  /* Sum IP source and destination addresses. */
+  sum = chksum(sum, (uint8_t *)&UIP_IP_BUF->srcipaddr, 2 * sizeof(uip_ipaddr_t));
+
+  /* Sum TCP header and data. */
+  sum = chksum(sum, &uip_buf[UIP_IPH_LEN + UIP_LLH_LEN + uip_ext_len],
+               upper_layer_len);
+    
+  return (sum == 0) ? 0xffff : uip_htons(sum);
+}
+/*---------------------------------------------------------------------------*/
+uint16_t
+uip_icmp6chksum(void)
+{
+  return upper_layer_chksum(UIP_PROTO_ICMP6);
+  
+}
+/*---------------------------------------------------------------------------*/
+#if UIP_TCP
+uint16_t
+uip_tcpchksum(void)
+{
+  return upper_layer_chksum(UIP_PROTO_TCP);
+}
+#endif /* UIP_TCP */
+/*---------------------------------------------------------------------------*/
+#if UIP_UDP && UIP_UDP_CHECKSUMS
+uint16_t
+uip_udpchksum(void)
+{
+  return upper_layer_chksum(UIP_PROTO_UDP);
+}
+#endif /* UIP_UDP && UIP_UDP_CHECKSUMS */
+
+/*---------------------------------------------------------------------------*/
+void
+uip_init(void)
+{
+   
+  uip_ds6_init();
+
+#if UIP_TCP
+  for(c = 0; c < UIP_LISTENPORTS; ++c) {
+    uip_listenports[c] = 0;
+  }
+  for(c = 0; c < UIP_CONNS; ++c) {
+    uip_conns[c].tcpstateflags = UIP_CLOSED;
+  }
+#endif /* UIP_TCP */
+
+#if UIP_ACTIVE_OPEN || UIP_UDP
+  lastport = 1024;
+#endif /* UIP_ACTIVE_OPEN || UIP_UDP */
+
+#if UIP_UDP
+  for(c = 0; c < UIP_UDP_CONNS; ++c) {
+    uip_udp_conns[c].lport = 0;
+  }
+#endif /* UIP_UDP */
+}
+/*---------------------------------------------------------------------------*/
+#if UIP_TCP && UIP_ACTIVE_OPEN
+struct uip_conn *
+uip_connect(uip_ipaddr_t *ripaddr, uint16_t rport)
+{
+  register struct uip_conn *conn, *cconn;
+  
+  /* Find an unused local port. */
+ again:
+  ++lastport;
+
+  if(lastport >= 32000) {
+    lastport = 4096;
+  }
+
+  /* Check if this port is already in use, and if so try to find
+     another one. */
+  for(c = 0; c < UIP_CONNS; ++c) {
+    conn = &uip_conns[c];
+    if(conn->tcpstateflags != UIP_CLOSED &&
+       conn->lport == uip_htons(lastport)) {
+      goto again;
+    }
+  }
+
+  conn = 0;
+  for(c = 0; c < UIP_CONNS; ++c) {
+    cconn = &uip_conns[c];
+    if(cconn->tcpstateflags == UIP_CLOSED) {
+      conn = cconn;
+      break;
+    }
+    if(cconn->tcpstateflags == UIP_TIME_WAIT) {
+      if(conn == 0 ||
+         cconn->tmr > conn->tmr) {
+        conn = cconn;
+      }
+    }
+  }
+
+  if(conn == 0) {
+    return 0;
+  }
+  
+  conn->tcpstateflags = UIP_SYN_SENT;
+
+  conn->snd_nxt[0] = iss[0];
+  conn->snd_nxt[1] = iss[1];
+  conn->snd_nxt[2] = iss[2];
+  conn->snd_nxt[3] = iss[3];
+
+  conn->rcv_nxt[0] = 0;
+  conn->rcv_nxt[1] = 0;
+  conn->rcv_nxt[2] = 0;
+  conn->rcv_nxt[3] = 0;
+
+  conn->initialmss = conn->mss = UIP_TCP_MSS;
+  
+  conn->len = 1;   /* TCP length of the SYN is one. */
+  conn->nrtx = 0;
+  conn->tmr = 1; /* Send the SYN next time around. */
+  conn->rto = UIP_RTO;
+  conn->sa = 0;
+  conn->sv = 16;   /* Initial value of the RTT variance. */
+  conn->lport = uip_htons(lastport);
+  conn->rport = rport;
+  uip_ipaddr_copy(&conn->ripaddr, ripaddr);
+  
+  return conn;
+}
+#endif /* UIP_TCP && UIP_ACTIVE_OPEN */
+/*---------------------------------------------------------------------------*/
+void
+remove_ext_hdr(void)
+{
+  /* Remove ext header before TCP/UDP processing. */
+  if(uip_ext_len > 0) {
+    PRINTF("Cutting ext-header before processing (extlen: %d, uiplen: %d)\n",
+	   uip_ext_len, uip_len);
+    if(uip_len < UIP_IPH_LEN + uip_ext_len) {
+      PRINTF("ERROR: uip_len too short compared to ext len\n");
+      uip_ext_len = 0;
+      uip_len = 0;
+      return;
+    }
+    memmove(((uint8_t *)UIP_TCP_BUF), (uint8_t *)UIP_TCP_BUF + uip_ext_len,
+	    uip_len - UIP_IPH_LEN - uip_ext_len);
+
+    uip_len -= uip_ext_len;
+
+    /* Update the IP length. */
+    UIP_IP_BUF->len[0] = (uip_len - UIP_IPH_LEN) >> 8;
+    UIP_IP_BUF->len[1] = (uip_len - UIP_IPH_LEN) & 0xff;
+    uip_ext_len = 0;
+  }
+}
+/*---------------------------------------------------------------------------*/
+#if UIP_UDP
+struct uip_udp_conn *
+uip_udp_new(const uip_ipaddr_t *ripaddr, uint16_t rport)
+{
+  register struct uip_udp_conn *conn;
+  
+  /* Find an unused local port. */
+ again:
+  ++lastport;
+
+  if(lastport >= 32000) {
+    lastport = 4096;
+  }
+  
+  for(c = 0; c < UIP_UDP_CONNS; ++c) {
+    if(uip_udp_conns[c].lport == uip_htons(lastport)) {
+      goto again;
+    }
+  }
+
+  conn = 0;
+  for(c = 0; c < UIP_UDP_CONNS; ++c) {
+    if(uip_udp_conns[c].lport == 0) {
+      conn = &uip_udp_conns[c];
+      break;
+    }
+  }
+
+  if(conn == 0) {
+    return 0;
+  }
+  
+  conn->lport = UIP_HTONS(lastport);
+  conn->rport = rport;
+  if(ripaddr == NULL) {
+    memset(&conn->ripaddr, 0, sizeof(uip_ipaddr_t));
+  } else {
+    uip_ipaddr_copy(&conn->ripaddr, ripaddr);
+  }
+  conn->ttl = uip_ds6_if.cur_hop_limit;
+  
+  return conn;
+}
+#endif /* UIP_UDP */
+/*---------------------------------------------------------------------------*/
+#if UIP_TCP
+void
+uip_unlisten(uint16_t port)
+{
+  for(c = 0; c < UIP_LISTENPORTS; ++c) {
+    if(uip_listenports[c] == port) {
+      uip_listenports[c] = 0;
+      return;
+    }
+  }
+}
+
+void uip_udp_unlisten(uint16_t port) {
+	for (c = 0; c < UIP_LISTENPORTS; ++c) {
+		if (uip_udp_listenports[c] == port) {
+			uip_udp_listenports[c] = 0;
+			return;
+		}
+	}
+}
+
+/*---------------------------------------------------------------------------*/
+void
+uip_listen(uint16_t port)
+{
+  for(c = 0; c < UIP_LISTENPORTS; ++c) {
+    if(uip_listenports[c] == 0) {
+      uip_listenports[c] = port;
+      return;
+    }
+  }
+}
+
+void uip_udp_listen(uint16_t port) {
+	for (c = 0; c < UIP_LISTENPORTS; ++c) {
+		if (uip_udp_listenports[c] == 0) {
+			uip_udp_listenports[c] = port;
+			return;
+		}
+	}
+}
+#endif
+/*---------------------------------------------------------------------------*/
+
+#if UIP_CONF_IPV6_REASSEMBLY
+#define UIP_REASS_BUFSIZE (UIP_BUFSIZE - UIP_LLH_LEN)
+
+static uint8_t uip_reassbuf[UIP_REASS_BUFSIZE];
+
+static uint8_t uip_reassbitmap[UIP_REASS_BUFSIZE / (8 * 8)];
+/*the first byte of an IP fragment is aligned on an 8-byte boundary */
+
+static const uint8_t bitmap_bits[8] = {0xff, 0x7f, 0x3f, 0x1f,
+                                    0x0f, 0x07, 0x03, 0x01};
+static uint16_t uip_reasslen;
+static uint8_t uip_reassflags;
+
+#define UIP_REASS_FLAG_LASTFRAG 0x01
+#define UIP_REASS_FLAG_FIRSTFRAG 0x02
+#define UIP_REASS_FLAG_ERROR_MSG 0x04
+
+
+/*
+ * See RFC 2460 for a description of fragmentation in IPv6
+ * A typical Ipv6 fragment
+ *  +------------------+--------+--------------+
+ *  |  Unfragmentable  |Fragment|    first     |
+ *  |       Part       | Header |   fragment   |
+ *  +------------------+--------+--------------+
+ */
+
+
+struct etimer uip_reass_timer; /* timer for reassembly */
+uint8_t uip_reass_on; /* equal to 1 if we are currently reassembling a packet */
+
+static uint32_t uip_id; /* For every packet that is to be fragmented, the source
+                        node generates an Identification value that is present
+                        in all the fragments */
+#define IP_MF   0x0001
+
+static uint16_t
+uip_reass(void)
+{
+  uint16_t offset=0;
+  uint16_t len;
+  uint16_t i;
+  
+  /* If ip_reasstmr is zero, no packet is present in the buffer */
+  /* We first write the unfragmentable part of IP header into the reassembly
+     buffer. The reset the other reassembly variables. */
+  if(uip_reass_on == 0) {
+    PRINTF("Starting reassembly\n");
+    memcpy(FBUF, UIP_IP_BUF, uip_ext_len + UIP_IPH_LEN);
+    /* temporary in case we do not receive the fragment with offset 0 first */
+    etimer_set(&uip_reass_timer, UIP_REASS_MAXAGE*CLOCK_SECOND);
+    uip_reass_on = 1;
+    uip_reassflags = 0;
+    uip_id = UIP_FRAG_BUF->id;
+    /* Clear the bitmap. */
+    memset(uip_reassbitmap, 0, sizeof(uip_reassbitmap));
+  }
+  /*
+   * Check if the incoming fragment matches the one currently present
+   * in the reasembly buffer. If so, we proceed with copying the fragment
+   * into the buffer.
+   */
+  if(uip_ipaddr_cmp(&FBUF->srcipaddr, &UIP_IP_BUF->srcipaddr) &&
+     uip_ipaddr_cmp(&FBUF->destipaddr, &UIP_IP_BUF->destipaddr) &&
+     UIP_FRAG_BUF->id == uip_id) {
+    len = uip_len - uip_ext_len - UIP_IPH_LEN - UIP_FRAGH_LEN;
+    offset = (uip_ntohs(UIP_FRAG_BUF->offsetresmore) & 0xfff8);
+    /* in byte, originaly in multiple of 8 bytes*/
+    PRINTF("len %d\n", len);
+    PRINTF("offset %d\n", offset);
+    if(offset == 0){
+      uip_reassflags |= UIP_REASS_FLAG_FIRSTFRAG;
+      /*
+       * The Next Header field of the last header of the Unfragmentable
+       * Part is obtained from the Next Header field of the first
+       * fragment's Fragment header.
+       */
+      *uip_next_hdr = UIP_FRAG_BUF->next;
+      memcpy(FBUF, UIP_IP_BUF, uip_ext_len + UIP_IPH_LEN);
+      PRINTF("src ");
+      PRINT6ADDR(&FBUF->srcipaddr);
+      PRINTF("dest ");
+      PRINT6ADDR(&FBUF->destipaddr);
+      PRINTF("next %d\n", UIP_IP_BUF->proto);
+      
+    }
+    
+    /* If the offset or the offset + fragment length overflows the
+       reassembly buffer, we discard the entire packet. */
+    if(offset > UIP_REASS_BUFSIZE ||
+       offset + len > UIP_REASS_BUFSIZE) {
+      uip_reass_on = 0;
+      etimer_stop(&uip_reass_timer);
+      return 0;
+    }
+
+    /* If this fragment has the More Fragments flag set to zero, it is the
+       last fragment*/
+    if((uip_ntohs(UIP_FRAG_BUF->offsetresmore) & IP_MF) == 0) {
+      uip_reassflags |= UIP_REASS_FLAG_LASTFRAG;
+      /*calculate the size of the entire packet*/
+      uip_reasslen = offset + len;
+      PRINTF("LAST FRAGMENT reasslen %d\n", uip_reasslen);
+    } else {
+      /* If len is not a multiple of 8 octets and the M flag of that fragment
+         is 1, then that fragment must be discarded and an ICMP Parameter
+         Problem, Code 0, message should be sent to the source of the fragment,
+         pointing to the Payload Length field of the fragment packet. */
+      if(len % 8 != 0){
+        uip_icmp6_error_output(ICMP6_PARAM_PROB, ICMP6_PARAMPROB_HEADER, 4);
+        uip_reassflags |= UIP_REASS_FLAG_ERROR_MSG;
+        /* not clear if we should interrupt reassembly, but it seems so from
+           the conformance tests */
+        uip_reass_on = 0;
+        etimer_stop(&uip_reass_timer);
+        return uip_len;
+      }
+    }
+    
+    /* Copy the fragment into the reassembly buffer, at the right
+       offset. */
+    memcpy((uint8_t *)FBUF + UIP_IPH_LEN + uip_ext_len + offset,
+           (uint8_t *)UIP_FRAG_BUF + UIP_FRAGH_LEN, len);
+    
+    /* Update the bitmap. */
+    if(offset >> 6 == (offset + len) >> 6) {
+      uip_reassbitmap[offset >> 6] |=
+        bitmap_bits[(offset >> 3) & 7] &
+        ~bitmap_bits[((offset + len) >> 3)  & 7];
+    } else {
+      /* If the two endpoints are in different bytes, we update the
+         bytes in the endpoints and fill the stuff inbetween with
+         0xff. */
+      uip_reassbitmap[offset >> 6] |= bitmap_bits[(offset >> 3) & 7];
+ 
+      for(i = (1 + (offset >> 6)); i < ((offset + len) >> 6); ++i) {
+        uip_reassbitmap[i] = 0xff;
+      }
+      uip_reassbitmap[(offset + len) >> 6] |=
+        ~bitmap_bits[((offset + len) >> 3) & 7];
+    }
+  
+    /* Finally, we check if we have a full packet in the buffer. We do
+       this by checking if we have the last fragment and if all bits
+       in the bitmap are set. */
+    
+    if(uip_reassflags & UIP_REASS_FLAG_LASTFRAG) {
+      /* Check all bytes up to and including all but the last byte in
+         the bitmap. */
+      for(i = 0; i < (uip_reasslen >> 6); ++i) {
+        if(uip_reassbitmap[i] != 0xff) {
+          return 0;
+        }
+      }
+      /* Check the last byte in the bitmap. It should contain just the
+         right amount of bits. */
+      if(uip_reassbitmap[uip_reasslen >> 6] !=
+         (uint8_t)~bitmap_bits[(uip_reasslen >> 3) & 7]) {
+        return 0;
+      }
+
+     /* If we have come this far, we have a full packet in the
+         buffer, so we copy it to uip_buf. We also reset the timer. */
+      uip_reass_on = 0;
+      etimer_stop(&uip_reass_timer);
+
+      uip_reasslen += UIP_IPH_LEN + uip_ext_len;
+      memcpy(UIP_IP_BUF, FBUF, uip_reasslen);
+      UIP_IP_BUF->len[0] = ((uip_reasslen - UIP_IPH_LEN) >> 8);
+      UIP_IP_BUF->len[1] = ((uip_reasslen - UIP_IPH_LEN) & 0xff);
+      PRINTF("REASSEMBLED PAQUET %d (%d)\n", uip_reasslen,
+             (UIP_IP_BUF->len[0] << 8) | UIP_IP_BUF->len[1]);
+   
+      return uip_reasslen;
+      
+    }
+  } else {
+    PRINTF("Already reassembling another paquet\n");
+  }
+  return 0;
+}
+
+void
+uip_reass_over(void)
+{
+   /* to late, we abandon the reassembly of the packet */
+
+  uip_reass_on = 0;
+  etimer_stop(&uip_reass_timer);
+
+  if(uip_reassflags & UIP_REASS_FLAG_FIRSTFRAG){
+    PRINTF("FRAG INTERRUPTED TOO LATE\n");
+    /* If the first fragment has been received, an ICMP Time Exceeded
+       -- Fragment Reassembly Time Exceeded message should be sent to the
+       source of that fragment. */
+    /** \note
+     * We don't have a complete packet to put in the error message.
+     * We could include the first fragment but since its not mandated by
+     * any RFC, we decided not to include it as it reduces the size of
+     * the packet.
+     */
+    uip_len = 0;
+    uip_ext_len = 0;
+    memcpy(UIP_IP_BUF, FBUF, UIP_IPH_LEN); /* copy the header for src
+                                              and dest address*/
+    uip_icmp6_error_output(ICMP6_TIME_EXCEEDED, ICMP6_TIME_EXCEED_REASSEMBLY, 0);
+    
+    UIP_STAT(++uip_stat.ip.sent);
+    uip_flags = 0;
+  }
+}
+
+#endif /* UIP_CONF_IPV6_REASSEMBLY */
+
+/*---------------------------------------------------------------------------*/
+#if UIP_TCP
+static void
+uip_add_rcv_nxt(uint16_t n)
+{
+  uip_add32(uip_conn->rcv_nxt, n);
+  uip_conn->rcv_nxt[0] = uip_acc32[0];
+  uip_conn->rcv_nxt[1] = uip_acc32[1];
+  uip_conn->rcv_nxt[2] = uip_acc32[2];
+  uip_conn->rcv_nxt[3] = uip_acc32[3];
+}
+#endif
+/*---------------------------------------------------------------------------*/
+
+/**
+ * \brief Process the options in Destination and Hop By Hop extension headers
+ */
+static uint8_t
+ext_hdr_options_process(void)
+{
+ /*
+  * Length field in the extension header: length of the header in units of
+  * 8 bytes, excluding the first 8 bytes
+  * length field in an option : the length of data in the option
+  */
+  uip_ext_opt_offset = 2;
+  while(uip_ext_opt_offset < ((UIP_EXT_BUF->len << 3) + 8)) {
+    switch(UIP_EXT_HDR_OPT_BUF->type) {
+      /*
+       * for now we do not support any options except padding ones
+       * PAD1 does not make sense as the header must be 8bytes aligned,
+       * hence we can only have
+       */
+      case UIP_EXT_HDR_OPT_PAD1:
+        PRINTF("Processing PAD1 option\n");
+        uip_ext_opt_offset += 1;
+        break;
+      case UIP_EXT_HDR_OPT_PADN:
+        PRINTF("Processing PADN option\n");
+        uip_ext_opt_offset += UIP_EXT_HDR_OPT_PADN_BUF->opt_len + 2;
+        break;
+      case UIP_EXT_HDR_OPT_RPL:
+		/* Fixes situation when a node that is not using RPL
+		 * joins a network which does. The received packages will include the
+		 * RPL header and processed by the "default" case of the switch
+		 * (0x63 & 0xC0 = 0x40). Hence, the packet is discarded as the header
+		 * is considered invalid.
+		 * Using this fix, the header is ignored, and the next header (if
+		 * present) is processed.
+		 */
+#if UIP_CONF_IPV6_RPL
+        PRINTF("Processing RPL option\n");
+        if(rpl_verify_header(uip_ext_opt_offset)) {
+          PRINTF("RPL Option Error: Dropping Packet\n");
+          return 1;
+        }
+#endif /* UIP_CONF_IPV6_RPL */
+        uip_ext_opt_offset += (UIP_EXT_HDR_OPT_BUF->len) + 2;
+        return 0;
+      default:
+        /*
+         * check the two highest order bits of the option
+         * - 00 skip over this option and continue processing the header.
+         * - 01 discard the packet.
+         * - 10 discard the packet and, regardless of whether or not the
+         *   packet's Destination Address was a multicast address, send an
+         *   ICMP Parameter Problem, Code 2, message to the packet's
+         *   Source Address, pointing to the unrecognized Option Type.
+         * - 11 discard the packet and, only if the packet's Destination
+         *   Address was not a multicast address, send an ICMP Parameter
+         *   Problem, Code 2, message to the packet's Source Address,
+         *   pointing to the unrecognized Option Type.
+         */
+        PRINTF("MSB %x\n", UIP_EXT_HDR_OPT_BUF->type);
+        switch(UIP_EXT_HDR_OPT_BUF->type & 0xC0) {
+          case 0:
+            break;
+          case 0x40:
+            return 1;
+          case 0xC0:
+            if(uip_is_addr_mcast(&UIP_IP_BUF->destipaddr)) {
+              return 1;
+            }
+          case 0x80:
+            uip_icmp6_error_output(ICMP6_PARAM_PROB, ICMP6_PARAMPROB_OPTION,
+                             (uint32_t)UIP_IPH_LEN + uip_ext_len + uip_ext_opt_offset);
+            return 2;
+        }
+        /* in the cases were we did not discard, update ext_opt* */
+        uip_ext_opt_offset += UIP_EXT_HDR_OPT_BUF->len + 2;
+        break;
+    }
+  }
+  return 0;
+}
+
+
+/*---------------------------------------------------------------------------*/
+void
+uip_process(uint8_t flag)
+{
+#if UIP_TCP
+  register struct uip_conn *uip_connr = uip_conn;
+#endif /* UIP_TCP */
+#if UIP_UDP
+  if(flag == UIP_UDP_SEND_CONN) {
+    goto udp_send;
+  }
+#endif /* UIP_UDP */
+  uip_sappdata = uip_appdata = &uip_buf[UIP_IPTCPH_LEN + UIP_LLH_LEN];
+   
+  /* Check if we were invoked because of a poll request for a
+     particular connection. */
+  if(flag == UIP_POLL_REQUEST) {
+#if UIP_TCP
+    if((uip_connr->tcpstateflags & UIP_TS_MASK) == UIP_ESTABLISHED &&
+       !uip_outstanding(uip_connr)) {
+      uip_flags = UIP_POLL;
+      UIP_APPCALL();
+      goto appsend;
+#if UIP_ACTIVE_OPEN
+    } else if((uip_connr->tcpstateflags & UIP_TS_MASK) == UIP_SYN_SENT) {
+      /* In the SYN_SENT state, we retransmit out SYN. */
+      UIP_TCP_BUF->flags = 0;
+      goto tcp_send_syn;
+#endif /* UIP_ACTIVE_OPEN */
+    }
+    goto drop;
+#endif /* UIP_TCP */
+    /* Check if we were invoked because of the perodic timer fireing. */
+  } else if(flag == UIP_TIMER) {
+    /* Reset the length variables. */
+#if UIP_TCP
+    uip_len = 0;
+    uip_slen = 0;
+    
+    /* Increase the initial sequence number. */
+    if(++iss[3] == 0) {
+      if(++iss[2] == 0) {
+        if(++iss[1] == 0) {
+          ++iss[0];
+        }
+      }
+    }
+    
+    /*
+     * Check if the connection is in a state in which we simply wait
+     * for the connection to time out. If so, we increase the
+     * connection's timer and remove the connection if it times
+     * out.
+     */
+    if(uip_connr->tcpstateflags == UIP_TIME_WAIT ||
+       uip_connr->tcpstateflags == UIP_FIN_WAIT_2) {
+      ++(uip_connr->tmr);
+      if(uip_connr->tmr == UIP_TIME_WAIT_TIMEOUT) {
+        uip_connr->tcpstateflags = UIP_CLOSED;
+      }
+    } else if(uip_connr->tcpstateflags != UIP_CLOSED) {
+      /*
+       * If the connection has outstanding data, we increase the
+       * connection's timer and see if it has reached the RTO value
+       * in which case we retransmit.
+       */
+      if(uip_outstanding(uip_connr)) {
+        if(uip_connr->tmr-- == 0) {
+          if(uip_connr->nrtx == UIP_MAXRTX ||
+             ((uip_connr->tcpstateflags == UIP_SYN_SENT ||
+               uip_connr->tcpstateflags == UIP_SYN_RCVD) &&
+              uip_connr->nrtx == UIP_MAXSYNRTX)) {
+            uip_connr->tcpstateflags = UIP_CLOSED;
+                  
+            /*
+             * We call UIP_APPCALL() with uip_flags set to
+             * UIP_TIMEDOUT to inform the application that the
+             * connection has timed out.
+             */
+            uip_flags = UIP_TIMEDOUT;
+            UIP_APPCALL();
+                  
+            /* We also send a reset packet to the remote host. */
+            UIP_TCP_BUF->flags = TCP_RST | TCP_ACK;
+            goto tcp_send_nodata;
+          }
+               
+          /* Exponential backoff. */
+          uip_connr->tmr = UIP_RTO << (uip_connr->nrtx > 4?
+                                         4:
+                                         uip_connr->nrtx);
+          ++(uip_connr->nrtx);
+               
+          /*
+           * Ok, so we need to retransmit. We do this differently
+           * depending on which state we are in. In ESTABLISHED, we
+           * call upon the application so that it may prepare the
+           * data for the retransmit. In SYN_RCVD, we resend the
+           * SYNACK that we sent earlier and in LAST_ACK we have to
+           * retransmit our FINACK.
+           */
+          UIP_STAT(++uip_stat.tcp.rexmit);
+          switch(uip_connr->tcpstateflags & UIP_TS_MASK) {
+            case UIP_SYN_RCVD:
+              /* In the SYN_RCVD state, we should retransmit our SYNACK. */
+              goto tcp_send_synack;
+                     
+#if UIP_ACTIVE_OPEN
+            case UIP_SYN_SENT:
+              /* In the SYN_SENT state, we retransmit out SYN. */
+              UIP_TCP_BUF->flags = 0;
+              goto tcp_send_syn;
+#endif /* UIP_ACTIVE_OPEN */
+                     
+            case UIP_ESTABLISHED:
+              /*
+               * In the ESTABLISHED state, we call upon the application
+               * to do the actual retransmit after which we jump into
+               * the code for sending out the packet (the apprexmit
+               * label).
+               */
+              uip_flags = UIP_REXMIT;
+              UIP_APPCALL();
+              goto apprexmit;
+                     
+            case UIP_FIN_WAIT_1:
+            case UIP_CLOSING:
+            case UIP_LAST_ACK:
+              /* In all these states we should retransmit a FINACK. */
+              goto tcp_send_finack;
+          }
+        }
+      } else if((uip_connr->tcpstateflags & UIP_TS_MASK) == UIP_ESTABLISHED) {
+        /*
+         * If there was no need for a retransmission, we poll the
+         * application for new data.
+         */
+        uip_flags = UIP_POLL;
+        UIP_APPCALL();
+        goto appsend;
+      }
+    }
+    goto drop;
+#endif /* UIP_TCP */
+  }
+#if UIP_UDP
+  if(flag == UIP_UDP_TIMER) {
+    if(uip_udp_conn->lport != 0) {
+      uip_conn = NULL;
+      uip_sappdata = uip_appdata = &uip_buf[UIP_IPUDPH_LEN + UIP_LLH_LEN];
+      uip_len = uip_slen = 0;
+      uip_flags = UIP_POLL;
+      UIP_UDP_APPCALL();
+      goto udp_send;
+    } else {
+      goto drop;
+    }
+  }
+#endif /* UIP_UDP */
+
+  
+  /* This is where the input processing starts. */
+  UIP_STAT(++uip_stat.ip.recv);
+   
+  /* Start of IP input header processing code. */
+   
+  /* Check validity of the IP header. */
+  if((UIP_IP_BUF->vtc & 0xf0) != 0x60)  { /* IP version and header length. */
+    UIP_STAT(++uip_stat.ip.drop);
+    UIP_STAT(++uip_stat.ip.vhlerr);
+    UIP_LOG("ipv6: invalid version!");
+    goto drop;
+  }
+  /*
+   * Check the size of the packet. If the size reported to us in
+   * uip_len is smaller the size reported in the IP header, we assume
+   * that the packet has been corrupted in transit. If the size of
+   * uip_len is larger than the size reported in the IP packet header,
+   * the packet has been padded and we set uip_len to the correct
+   * value..
+   */
+   
+  if((UIP_IP_BUF->len[0] << 8) + UIP_IP_BUF->len[1] <= uip_len) {
+    uip_len = (UIP_IP_BUF->len[0] << 8) + UIP_IP_BUF->len[1] + UIP_IPH_LEN;
+    /*
+     * The length reported in the IPv6 header is the
+     * length of the payload that follows the
+     * header. However, uIP uses the uip_len variable
+     * for holding the size of the entire packet,
+     * including the IP header. For IPv4 this is not a
+     * problem as the length field in the IPv4 header
+     * contains the length of the entire packet. But
+     * for IPv6 we need to add the size of the IPv6
+     * header (40 bytes).
+     */
+  } else {
+    UIP_LOG("ip: packet shorter than reported in IP header.");
+    goto drop;
+  }
+  
+  PRINTF("IPv6 packet received from ");
+  PRINT6ADDR(&UIP_IP_BUF->srcipaddr);
+  PRINTF(" to ");
+  PRINT6ADDR(&UIP_IP_BUF->destipaddr);
+  PRINTF("\n");
+
+  if(uip_is_addr_mcast(&UIP_IP_BUF->srcipaddr)){
+    UIP_STAT(++uip_stat.ip.drop);
+    PRINTF("Dropping packet, src is mcast\n");
+    goto drop;
+  }
+
+#if UIP_CONF_ROUTER
+  /*
+   * Next header field processing. In IPv6, we can have extension headers,
+   * if present, the Hop-by-Hop Option must be processed before forwarding
+   * the packet.
+   */
+  uip_next_hdr = &UIP_IP_BUF->proto;
+  uip_ext_len = 0;
+  uip_ext_bitmap = 0;
+  if(*uip_next_hdr == UIP_PROTO_HBHO) {
+#if UIP_CONF_IPV6_CHECKS
+    uip_ext_bitmap |= UIP_EXT_HDR_BITMAP_HBHO;
+#endif /* UIP_CONF_IPV6_CHECKS */
+    switch(ext_hdr_options_process()) {
+      case 0:
+        /* continue */
+        uip_next_hdr = &UIP_EXT_BUF->next;
+        uip_ext_len += (UIP_EXT_BUF->len << 3) + 8;
+        break;
+      case 1:
+	PRINTF("Dropping packet after extension header processing\n");
+        /* silently discard */
+        goto drop;
+      case 2:
+	PRINTF("Sending error message after extension header processing\n");
+        /* send icmp error message (created in ext_hdr_options_process)
+         * and discard*/
+        goto send;
+    }
+  }
+
+
+  /* TBD Some Parameter problem messages */
+  if(!uip_ds6_is_my_addr(&UIP_IP_BUF->destipaddr) &&
+     !uip_ds6_is_my_maddr(&UIP_IP_BUF->destipaddr)) {
+    if(!uip_is_addr_mcast(&UIP_IP_BUF->destipaddr) &&
+       !uip_is_addr_link_local(&UIP_IP_BUF->destipaddr) &&
+       !uip_is_addr_link_local(&UIP_IP_BUF->srcipaddr) &&
+       !uip_is_addr_unspecified(&UIP_IP_BUF->srcipaddr) &&
+       !uip_is_addr_loopback(&UIP_IP_BUF->destipaddr)) {
+
+
+      /* Check MTU */
+      if(uip_len > UIP_LINK_MTU) {
+        uip_icmp6_error_output(ICMP6_PACKET_TOO_BIG, 0, UIP_LINK_MTU);
+        UIP_STAT(++uip_stat.ip.drop);
+        goto send;
+      }
+      /* Check Hop Limit */
+      if(UIP_IP_BUF->ttl <= 1) {
+        uip_icmp6_error_output(ICMP6_TIME_EXCEEDED,
+                               ICMP6_TIME_EXCEED_TRANSIT, 0);
+        UIP_STAT(++uip_stat.ip.drop);
+        goto send;
+      }
+
+#if UIP_CONF_IPV6_RPL
+      rpl_update_header_empty();
+#endif /* UIP_CONF_IPV6_RPL */
+
+      UIP_IP_BUF->ttl = UIP_IP_BUF->ttl - 1;
+      PRINTF("Forwarding packet to ");
+      PRINT6ADDR(&UIP_IP_BUF->destipaddr);
+      PRINTF("\n");
+      UIP_STAT(++uip_stat.ip.forwarded);
+      goto send;
+    } else {
+      if((uip_is_addr_link_local(&UIP_IP_BUF->srcipaddr)) &&
+         (!uip_is_addr_unspecified(&UIP_IP_BUF->srcipaddr)) &&
+         (!uip_is_addr_loopback(&UIP_IP_BUF->destipaddr)) &&
+         (!uip_is_addr_mcast(&UIP_IP_BUF->destipaddr)) &&
+         (!uip_ds6_is_addr_onlink((&UIP_IP_BUF->destipaddr)))) {
+        PRINTF("LL source address with off link destination, dropping\n");
+        uip_icmp6_error_output(ICMP6_DST_UNREACH,
+                               ICMP6_DST_UNREACH_NOTNEIGHBOR, 0);
+        goto send;
+      }
+      PRINTF("Dropping packet, not for me and link local or multicast\n");
+      UIP_STAT(++uip_stat.ip.drop);
+      goto drop;
+    }
+  }
+#else /* UIP_CONF_ROUTER */
+  if(!uip_ds6_is_my_addr(&UIP_IP_BUF->destipaddr) &&
+     !uip_ds6_is_my_maddr(&UIP_IP_BUF->destipaddr) &&
+     !uip_is_addr_mcast(&UIP_IP_BUF->destipaddr)) {
+    PRINTF("Dropping packet, not for me\n");
+    UIP_STAT(++uip_stat.ip.drop);
+    goto drop;
+  }
+
+  /*
+   * Next header field processing. In IPv6, we can have extension headers,
+   * they are processed here
+   */
+  uip_next_hdr = &UIP_IP_BUF->proto;
+  uip_ext_len = 0;
+  uip_ext_bitmap = 0;
+#endif /* UIP_CONF_ROUTER */
+
+  while(1) {
+    switch(*uip_next_hdr){
+#if UIP_TCP
+      case UIP_PROTO_TCP:
+        /* TCP, for both IPv4 and IPv6 */
+        goto tcp_input;
+#endif /* UIP_TCP */
+#if UIP_UDP
+      case UIP_PROTO_UDP:
+        /* UDP, for both IPv4 and IPv6 */
+        goto udp_input;
+#endif /* UIP_UDP */
+      case UIP_PROTO_ICMP6:
+        /* ICMPv6 */
+        goto icmp6_input;
+      case UIP_PROTO_HBHO:
+        PRINTF("Processing hbh header\n");
+        /* Hop by hop option header */
+#if UIP_CONF_IPV6_CHECKS
+        /* Hop by hop option header. If we saw one HBH already, drop */
+        if(uip_ext_bitmap & UIP_EXT_HDR_BITMAP_HBHO) {
+          goto bad_hdr;
+        } else {
+          uip_ext_bitmap |= UIP_EXT_HDR_BITMAP_HBHO;
+        }
+#endif /*UIP_CONF_IPV6_CHECKS*/
+        switch(ext_hdr_options_process()) {
+          case 0:
+            /*continue*/
+            uip_next_hdr = &UIP_EXT_BUF->next;
+            uip_ext_len += (UIP_EXT_BUF->len << 3) + 8;
+            break;
+          case 1:
+            /*silently discard*/
+            goto drop;
+          case 2:
+            /* send icmp error message (created in ext_hdr_options_process)
+             * and discard*/
+            goto send;
+        }
+        break;
+      case UIP_PROTO_DESTO:
+#if UIP_CONF_IPV6_CHECKS
+        /* Destination option header. if we saw two already, drop */
+        PRINTF("Processing desto header\n");
+        if(uip_ext_bitmap & UIP_EXT_HDR_BITMAP_DESTO1) {
+          if(uip_ext_bitmap & UIP_EXT_HDR_BITMAP_DESTO2) {
+            goto bad_hdr;
+          } else{
+            uip_ext_bitmap |= UIP_EXT_HDR_BITMAP_DESTO2;
+          }
+        } else {
+          uip_ext_bitmap |= UIP_EXT_HDR_BITMAP_DESTO1;
+        }
+#endif /*UIP_CONF_IPV6_CHECKS*/
+        switch(ext_hdr_options_process()) {
+          case 0:
+            /*continue*/
+            uip_next_hdr = &UIP_EXT_BUF->next;
+            uip_ext_len += (UIP_EXT_BUF->len << 3) + 8;
+            break;
+          case 1:
+            /*silently discard*/
+            goto drop;
+          case 2:
+            /* send icmp error message (created in ext_hdr_options_process)
+             * and discard*/
+            goto send;
+        }
+        break;
+      case UIP_PROTO_ROUTING:
+#if UIP_CONF_IPV6_CHECKS
+        /* Routing header. If we saw one already, drop */
+        if(uip_ext_bitmap & UIP_EXT_HDR_BITMAP_ROUTING) {
+          goto bad_hdr;
+        } else {
+          uip_ext_bitmap |= UIP_EXT_HDR_BITMAP_ROUTING;
+        }
+#endif /*UIP_CONF_IPV6_CHECKS*/
+        /*
+         * Routing Header  length field is in units of 8 bytes, excluding
+         * As per RFC2460 section 4.4, if routing type is unrecognized:
+         * if segments left = 0, ignore the header
+         * if segments left > 0, discard packet and send icmp error pointing
+         * to the routing type
+         */
+
+        PRINTF("Processing Routing header\n");
+        if(UIP_ROUTING_BUF->seg_left > 0) {
+          uip_icmp6_error_output(ICMP6_PARAM_PROB, ICMP6_PARAMPROB_HEADER, UIP_IPH_LEN + uip_ext_len + 2);
+          UIP_STAT(++uip_stat.ip.drop);
+          UIP_LOG("ip6: unrecognized routing type");
+          goto send;
+        }
+        uip_next_hdr = &UIP_EXT_BUF->next;
+        uip_ext_len += (UIP_EXT_BUF->len << 3) + 8;
+        break;
+      case UIP_PROTO_FRAG:
+        /* Fragmentation header:call the reassembly function, then leave */
+#if UIP_CONF_IPV6_REASSEMBLY
+        PRINTF("Processing frag header\n");
+        uip_len = uip_reass();
+        if(uip_len == 0) {
+          goto drop;
+        }
+        if(uip_reassflags & UIP_REASS_FLAG_ERROR_MSG){
+          /* we are not done with reassembly, this is an error message */
+          goto send;
+        }
+        /*packet is reassembled, reset the next hdr to the beginning
+           of the IP header and restart the parsing of the reassembled pkt*/
+        PRINTF("Processing reassembled packet\n");
+        uip_ext_len = 0;
+        uip_ext_bitmap = 0;
+        uip_next_hdr = &UIP_IP_BUF->proto;
+        break;
+#else /* UIP_CONF_IPV6_REASSEMBLY */
+        UIP_STAT(++uip_stat.ip.drop);
+        UIP_STAT(++uip_stat.ip.fragerr);
+        UIP_LOG("ip: fragment dropped.");
+        goto drop;
+#endif /* UIP_CONF_IPV6_REASSEMBLY */
+      case UIP_PROTO_NONE:
+        goto drop;
+      default:
+        goto bad_hdr;
+    }
+  }
+  bad_hdr:
+  /*
+   * RFC 2460 send error message parameterr problem, code unrecognized
+   * next header, pointing to the next header field
+   */
+  uip_icmp6_error_output(ICMP6_PARAM_PROB, ICMP6_PARAMPROB_NEXTHEADER, (uint32_t)(uip_next_hdr - (uint8_t *)UIP_IP_BUF));
+  UIP_STAT(++uip_stat.ip.drop);
+  UIP_STAT(++uip_stat.ip.protoerr);
+  UIP_LOG("ip6: unrecognized header");
+  goto send;
+  /* End of headers processing */
+  
+  icmp6_input:
+  /* This is IPv6 ICMPv6 processing code. */
+  PRINTF("icmp6_input: length %d type: %d \n", uip_len, UIP_ICMP_BUF->type);
+
+#if UIP_CONF_IPV6_CHECKS
+  /* Compute and check the ICMP header checksum */
+  if(uip_icmp6chksum() != 0xffff) {
+    UIP_STAT(++uip_stat.icmp.drop);
+    UIP_STAT(++uip_stat.icmp.chkerr);
+    UIP_LOG("icmpv6: bad checksum.");
+    PRINTF("icmpv6: bad checksum.");
+    goto drop;
+  }
+#endif /*UIP_CONF_IPV6_CHECKS*/
+
+  UIP_STAT(++uip_stat.icmp.recv);
+  /*
+   * Here we process incoming ICMPv6 packets
+   * For echo request, we send echo reply
+   * For ND pkts, we call the appropriate function in uip-nd6.c
+   * We do not treat Error messages for now
+   * If no pkt is to be sent as an answer to the incoming one, we
+   * "goto drop". Else we just break; then at the after the "switch"
+   * we "goto send"
+   */
+#if UIP_CONF_ICMP6
+  UIP_ICMP6_APPCALL(UIP_ICMP_BUF->type);
+#endif /*UIP_CONF_ICMP6*/
+
+  switch(UIP_ICMP_BUF->type) {
+    case ICMP6_NS:
+#if UIP_ND6_SEND_NA
+      uip_nd6_ns_input();
+#else /* UIP_ND6_SEND_NA */
+      UIP_STAT(++uip_stat.icmp.drop);
+      uip_len = 0;
+#endif /* UIP_ND6_SEND_NA */
+      break;
+    case ICMP6_NA:
+#if UIP_ND6_SEND_NA
+      uip_nd6_na_input();
+#else /* UIP_ND6_SEND_NA */
+      UIP_STAT(++uip_stat.icmp.drop);
+      uip_len = 0;
+#endif /* UIP_ND6_SEND_NA */
+      break;
+    case ICMP6_RS:
+#if UIP_CONF_ROUTER && UIP_ND6_SEND_RA
+    uip_nd6_rs_input();
+#else /* UIP_CONF_ROUTER && UIP_ND6_SEND_RA */
+    UIP_STAT(++uip_stat.icmp.drop);
+    uip_len = 0;
+#endif /* UIP_CONF_ROUTER && UIP_ND6_SEND_RA */
+    break;
+  case ICMP6_RA:
+#if UIP_CONF_ROUTER
+    UIP_STAT(++uip_stat.icmp.drop);
+    uip_len = 0;
+#else /* UIP_CONF_ROUTER */
+    uip_nd6_ra_input();
+#endif /* UIP_CONF_ROUTER */
+    break;
+#if UIP_CONF_IPV6_RPL
+    case ICMP6_RPL:
+      uip_rpl_input();
+      break;
+#endif /* UIP_CONF_IPV6_RPL */
+    case ICMP6_ECHO_REQUEST:
+      uip_icmp6_echo_request_input();
+      break;
+    case ICMP6_ECHO_REPLY:
+      /** \note We don't implement any application callback for now */
+      PRINTF("Received an icmp6 echo reply\n");
+      UIP_STAT(++uip_stat.icmp.recv);
+      uip_len = 0;
+      break;
+    default:
+      PRINTF("Unknown icmp6 message type %d\n", UIP_ICMP_BUF->type);
+      UIP_STAT(++uip_stat.icmp.drop);
+      UIP_STAT(++uip_stat.icmp.typeerr);
+      UIP_LOG("icmp6: unknown ICMP message.");
+      uip_len = 0;
+      break;
+  }
+  
+  if(uip_len > 0) {
+    goto send;
+  } else {
+    goto drop;
+  }
+  /* End of IPv6 ICMP processing. */
+   
+
+#if UIP_UDP
+  /* UDP input processing. */
+ udp_input:
+
+  remove_ext_hdr();
+
+  PRINTF("Receiving UDP packet\n");
+  UIP_STAT(++uip_stat.udp.recv);
+ 
+  /* UDP processing is really just a hack. We don't do anything to the
+     UDP/IP headers, but let the UDP application do all the hard
+     work. If the application sets uip_slen, it has a packet to
+     send. */
+#if UIP_UDP_CHECKSUMS
+  uip_len = uip_len - UIP_IPUDPH_LEN;
+  uip_appdata = &uip_buf[UIP_IPUDPH_LEN + UIP_LLH_LEN];
+  /* XXX hack: UDP/IPv6 receivers should drop packets with UDP
+     checksum 0. Here, we explicitly receive UDP packets with checksum
+     0. This is to be able to debug code that for one reason or
+     another miscomputes UDP checksums. The reception of zero UDP
+     checksums should be turned into a configration option. */
+  if(UIP_UDP_BUF->udpchksum != 0 && uip_udpchksum() != 0xffff) {
+    UIP_STAT(++uip_stat.udp.drop);
+    UIP_STAT(++uip_stat.udp.chkerr);
+    PRINTF("udp: bad checksum 0x%04x 0x%04x\n", UIP_UDP_BUF->udpchksum,
+           uip_udpchksum());
+    goto drop;
+  }
+#else /* UIP_UDP_CHECKSUMS */
+  uip_len = uip_len - UIP_IPUDPH_LEN;
+#endif /* UIP_UDP_CHECKSUMS */
+
+  /* Make sure that the UDP destination port number is not zero. */
+  if(UIP_UDP_BUF->destport == 0) {
+    PRINTF("udp: zero port.\n");
+    goto drop;
+  }
+
+  /* Demultiplex this UDP packet between the UDP "connections". */
+  for(uip_udp_conn = &uip_udp_conns[0];
+      uip_udp_conn < &uip_udp_conns[UIP_UDP_CONNS];
+      ++uip_udp_conn) {
+    /* If the local UDP port is non-zero, the connection is considered
+       to be used. If so, the local port number is checked against the
+       destination port number in the received packet. If the two port
+       numbers match, the remote port number is checked if the
+       connection is bound to a remote port. Finally, if the
+       connection is bound to a remote IP address, the source IP
+       address of the packet is checked. */
+    if(uip_udp_conn->lport != 0 &&
+       UIP_UDP_BUF->destport == uip_udp_conn->lport &&
+       (uip_udp_conn->rport == 0 ||
+        UIP_UDP_BUF->srcport == uip_udp_conn->rport) &&
+       (uip_is_addr_unspecified(&uip_udp_conn->ripaddr) ||
+        uip_ipaddr_cmp(&UIP_IP_BUF->srcipaddr, &uip_udp_conn->ripaddr))) {
+      goto udp_found;
+    }
+  }
+  PRINTF("udp: no matching connection found\n");
+
+#if UIP_UDP_SEND_UNREACH_NOPORT
+  uip_icmp6_error_output(ICMP6_DST_UNREACH, ICMP6_DST_UNREACH_NOPORT, 0);
+  UIP_STAT(++uip_stat.ip.drop);
+  goto send;
+#else
+  goto drop;
+#endif
+
+ udp_found:
+  PRINTF("In udp_found\n");
+ 
+  uip_conn = NULL;
+  uip_flags = UIP_NEWDATA;
+  uip_sappdata = uip_appdata = &uip_buf[UIP_IPUDPH_LEN + UIP_LLH_LEN];
+  uip_slen = 0;
+  UIP_UDP_APPCALL();
+
+ udp_send:
+  PRINTF("In udp_send\n");
+
+  if(uip_slen == 0) {
+    goto drop;
+  }
+  uip_len = uip_slen + UIP_IPUDPH_LEN;
+
+  /* For IPv6, the IP length field does not include the IPv6 IP header
+     length. */
+  UIP_IP_BUF->len[0] = ((uip_len - UIP_IPH_LEN) >> 8);
+  UIP_IP_BUF->len[1] = ((uip_len - UIP_IPH_LEN) & 0xff);
+
+  UIP_IP_BUF->ttl = uip_udp_conn->ttl;
+  UIP_IP_BUF->proto = UIP_PROTO_UDP;
+
+  UIP_UDP_BUF->udplen = UIP_HTONS(uip_slen + UIP_UDPH_LEN);
+  UIP_UDP_BUF->udpchksum = 0;
+
+  UIP_UDP_BUF->srcport  = uip_udp_conn->lport;
+  UIP_UDP_BUF->destport = uip_udp_conn->rport;
+
+  uip_ipaddr_copy(&UIP_IP_BUF->destipaddr, &uip_udp_conn->ripaddr);
+  uip_ds6_select_src(&UIP_IP_BUF->srcipaddr, &UIP_IP_BUF->destipaddr);
+
+  uip_appdata = &uip_buf[UIP_LLH_LEN + UIP_IPTCPH_LEN];
+
+#if UIP_CONF_IPV6_RPL
+  rpl_insert_header();
+#endif /* UIP_CONF_IPV6_RPL */
+
+#if UIP_UDP_CHECKSUMS
+  /* Calculate UDP checksum. */
+  UIP_UDP_BUF->udpchksum = ~(uip_udpchksum());
+  if(UIP_UDP_BUF->udpchksum == 0) {
+    UIP_UDP_BUF->udpchksum = 0xffff;
+  }
+#endif /* UIP_UDP_CHECKSUMS */
+  UIP_STAT(++uip_stat.udp.sent);
+  goto ip_send_nolen;
+#endif /* UIP_UDP */
+
+#if UIP_TCP
+  /* TCP input processing. */
+ tcp_input:
+
+  remove_ext_hdr();
+
+  UIP_STAT(++uip_stat.tcp.recv);
+  PRINTF("Receiving TCP packet\n");
+  /* Start of TCP input header processing code. */
+  
+  if(uip_tcpchksum() != 0xffff) {   /* Compute and check the TCP
+                                       checksum. */
+    UIP_STAT(++uip_stat.tcp.drop);
+    UIP_STAT(++uip_stat.tcp.chkerr);
+    PRINTF("tcp: bad checksum 0x%04x 0x%04x\n", UIP_TCP_BUF->tcpchksum,
+           uip_tcpchksum());
+    goto drop;
+  }
+
+  /* Make sure that the TCP port number is not zero. */
+  if(UIP_TCP_BUF->destport == 0 || UIP_TCP_BUF->srcport == 0) {
+    PRINTF("tcp: zero port.");
+    goto drop;
+  }
+
+  /* Demultiplex this segment. */
+  /* First check any active connections. */
+  for(uip_connr = &uip_conns[0]; uip_connr <= &uip_conns[UIP_CONNS - 1];
+      ++uip_connr) {
+    if(uip_connr->tcpstateflags != UIP_CLOSED &&
+       UIP_TCP_BUF->destport == uip_connr->lport &&
+       UIP_TCP_BUF->srcport == uip_connr->rport &&
+       uip_ipaddr_cmp(&UIP_IP_BUF->srcipaddr, &uip_connr->ripaddr)) {
+      goto found;
+    }
+  }
+
+  /* If we didn't find and active connection that expected the packet,
+     either this packet is an old duplicate, or this is a SYN packet
+     destined for a connection in LISTEN. If the SYN flag isn't set,
+     it is an old packet and we send a RST. */
+  if((UIP_TCP_BUF->flags & TCP_CTL) != TCP_SYN) {
+    goto reset;
+  }
+  
+  tmp16 = UIP_TCP_BUF->destport;
+  /* Next, check listening connections. */
+  for(c = 0; c < UIP_LISTENPORTS; ++c) {
+    if(tmp16 == uip_listenports[c]) {
+      goto found_listen;
+    }
+  }
+  
+  /* No matching connection found, so we send a RST packet. */
+  UIP_STAT(++uip_stat.tcp.synrst);
+
+ reset:
+  PRINTF("In reset\n");
+  /* We do not send resets in response to resets. */
+  if(UIP_TCP_BUF->flags & TCP_RST) {
+    goto drop;
+  }
+
+  UIP_STAT(++uip_stat.tcp.rst);
+  
+  UIP_TCP_BUF->flags = TCP_RST | TCP_ACK;
+  uip_len = UIP_IPTCPH_LEN;
+  UIP_TCP_BUF->tcpoffset = 5 << 4;
+
+  /* Flip the seqno and ackno fields in the TCP header. */
+  c = UIP_TCP_BUF->seqno[3];
+  UIP_TCP_BUF->seqno[3] = UIP_TCP_BUF->ackno[3];
+  UIP_TCP_BUF->ackno[3] = c;
+  
+  c = UIP_TCP_BUF->seqno[2];
+  UIP_TCP_BUF->seqno[2] = UIP_TCP_BUF->ackno[2];
+  UIP_TCP_BUF->ackno[2] = c;
+  
+  c = UIP_TCP_BUF->seqno[1];
+  UIP_TCP_BUF->seqno[1] = UIP_TCP_BUF->ackno[1];
+  UIP_TCP_BUF->ackno[1] = c;
+  
+  c = UIP_TCP_BUF->seqno[0];
+  UIP_TCP_BUF->seqno[0] = UIP_TCP_BUF->ackno[0];
+  UIP_TCP_BUF->ackno[0] = c;
+
+  /* We also have to increase the sequence number we are
+     acknowledging. If the least significant byte overflowed, we need
+     to propagate the carry to the other bytes as well. */
+  if(++UIP_TCP_BUF->ackno[3] == 0) {
+    if(++UIP_TCP_BUF->ackno[2] == 0) {
+      if(++UIP_TCP_BUF->ackno[1] == 0) {
+        ++UIP_TCP_BUF->ackno[0];
+      }
+    }
+  }
+ 
+  /* Swap port numbers. */
+  tmp16 = UIP_TCP_BUF->srcport;
+  UIP_TCP_BUF->srcport = UIP_TCP_BUF->destport;
+  UIP_TCP_BUF->destport = tmp16;
+  
+  /* Swap IP addresses. */
+  uip_ipaddr_copy(&UIP_IP_BUF->destipaddr, &UIP_IP_BUF->srcipaddr);
+  uip_ds6_select_src(&UIP_IP_BUF->srcipaddr, &UIP_IP_BUF->destipaddr);
+  /* And send out the RST packet! */
+  goto tcp_send_noconn;
+
+  /* This label will be jumped to if we matched the incoming packet
+     with a connection in LISTEN. In that case, we should create a new
+     connection and send a SYNACK in return. */
+ found_listen:
+  PRINTF("In found listen\n");
+  /* First we check if there are any connections avaliable. Unused
+     connections are kept in the same table as used connections, but
+     unused ones have the tcpstate set to CLOSED. Also, connections in
+     TIME_WAIT are kept track of and we'll use the oldest one if no
+     CLOSED connections are found. Thanks to Eddie C. Dost for a very
+     nice algorithm for the TIME_WAIT search. */
+  uip_connr = 0;
+  for(c = 0; c < UIP_CONNS; ++c) {
+    if(uip_conns[c].tcpstateflags == UIP_CLOSED) {
+      uip_connr = &uip_conns[c];
+      break;
+    }
+    if(uip_conns[c].tcpstateflags == UIP_TIME_WAIT) {
+      if(uip_connr == 0 ||
+         uip_conns[c].tmr > uip_connr->tmr) {
+        uip_connr = &uip_conns[c];
+      }
+    }
+  }
+
+  if(uip_connr == 0) {
+    /* All connections are used already, we drop packet and hope that
+       the remote end will retransmit the packet at a time when we
+       have more spare connections. */
+    UIP_STAT(++uip_stat.tcp.syndrop);
+    UIP_LOG("tcp: found no unused connections.");
+    goto drop;
+  }
+  uip_conn = uip_connr;
+  
+  /* Fill in the necessary fields for the new connection. */
+  uip_connr->rto = uip_connr->tmr = UIP_RTO;
+  uip_connr->sa = 0;
+  uip_connr->sv = 4;
+  uip_connr->nrtx = 0;
+  uip_connr->lport = UIP_TCP_BUF->destport;
+  uip_connr->rport = UIP_TCP_BUF->srcport;
+  uip_ipaddr_copy(&uip_connr->ripaddr, &UIP_IP_BUF->srcipaddr);
+  uip_connr->tcpstateflags = UIP_SYN_RCVD;
+
+  uip_connr->snd_nxt[0] = iss[0];
+  uip_connr->snd_nxt[1] = iss[1];
+  uip_connr->snd_nxt[2] = iss[2];
+  uip_connr->snd_nxt[3] = iss[3];
+  uip_connr->len = 1;
+
+  /* rcv_nxt should be the seqno from the incoming packet + 1. */
+  uip_connr->rcv_nxt[3] = UIP_TCP_BUF->seqno[3];
+  uip_connr->rcv_nxt[2] = UIP_TCP_BUF->seqno[2];
+  uip_connr->rcv_nxt[1] = UIP_TCP_BUF->seqno[1];
+  uip_connr->rcv_nxt[0] = UIP_TCP_BUF->seqno[0];
+  uip_add_rcv_nxt(1);
+
+  /* Parse the TCP MSS option, if present. */
+  if((UIP_TCP_BUF->tcpoffset & 0xf0) > 0x50) {
+    for(c = 0; c < ((UIP_TCP_BUF->tcpoffset >> 4) - 5) << 2 ;) {
+      opt = uip_buf[UIP_TCPIP_HLEN + UIP_LLH_LEN + c];
+      if(opt == TCP_OPT_END) {
+        /* End of options. */
+        break;
+      } else if(opt == TCP_OPT_NOOP) {
+        ++c;
+        /* NOP option. */
+      } else if(opt == TCP_OPT_MSS &&
+                uip_buf[UIP_TCPIP_HLEN + UIP_LLH_LEN + 1 + c] == TCP_OPT_MSS_LEN) {
+        /* An MSS option with the right option length. */
+        tmp16 = ((uint16_t)uip_buf[UIP_TCPIP_HLEN + UIP_LLH_LEN + 2 + c] << 8) |
+          (uint16_t)uip_buf[UIP_IPTCPH_LEN + UIP_LLH_LEN + 3 + c];
+        uip_connr->initialmss = uip_connr->mss =
+          tmp16 > UIP_TCP_MSS? UIP_TCP_MSS: tmp16;
+   
+        /* And we are done processing options. */
+        break;
+      } else {
+        /* All other options have a length field, so that we easily
+           can skip past them. */
+        if(uip_buf[UIP_TCPIP_HLEN + UIP_LLH_LEN + 1 + c] == 0) {
+          /* If the length field is zero, the options are malformed
+             and we don't process them further. */
+          break;
+        }
+        c += uip_buf[UIP_TCPIP_HLEN + UIP_LLH_LEN + 1 + c];
+      }
+    }
+  }
+  
+  /* Our response will be a SYNACK. */
+#if UIP_ACTIVE_OPEN
+ tcp_send_synack:
+  UIP_TCP_BUF->flags = TCP_ACK;
+  
+ tcp_send_syn:
+  UIP_TCP_BUF->flags |= TCP_SYN;
+#else /* UIP_ACTIVE_OPEN */
+ tcp_send_synack:
+  UIP_TCP_BUF->flags = TCP_SYN | TCP_ACK;
+#endif /* UIP_ACTIVE_OPEN */
+  
+  /* We send out the TCP Maximum Segment Size option with our
+     SYNACK. */
+  UIP_TCP_BUF->optdata[0] = TCP_OPT_MSS;
+  UIP_TCP_BUF->optdata[1] = TCP_OPT_MSS_LEN;
+  UIP_TCP_BUF->optdata[2] = (UIP_TCP_MSS) / 256;
+  UIP_TCP_BUF->optdata[3] = (UIP_TCP_MSS) & 255;
+  uip_len = UIP_IPTCPH_LEN + TCP_OPT_MSS_LEN;
+  UIP_TCP_BUF->tcpoffset = ((UIP_TCPH_LEN + TCP_OPT_MSS_LEN) / 4) << 4;
+  goto tcp_send;
+
+  /* This label will be jumped to if we found an active connection. */
+ found:
+  PRINTF("In found\n");
+  uip_conn = uip_connr;
+  uip_flags = 0;
+  /* We do a very naive form of TCP reset processing; we just accept
+     any RST and kill our connection. We should in fact check if the
+     sequence number of this reset is wihtin our advertised window
+     before we accept the reset. */
+  if(UIP_TCP_BUF->flags & TCP_RST) {
+    uip_connr->tcpstateflags = UIP_CLOSED;
+    UIP_LOG("tcp: got reset, aborting connection.");
+    uip_flags = UIP_ABORT;
+    UIP_APPCALL();
+    goto drop;
+  }
+  /* Calculate the length of the data, if the application has sent
+     any data to us. */
+  c = (UIP_TCP_BUF->tcpoffset >> 4) << 2;
+  /* uip_len will contain the length of the actual TCP data. This is
+     calculated by subtracing the length of the TCP header (in
+     c) and the length of the IP header (20 bytes). */
+  uip_len = uip_len - c - UIP_IPH_LEN;
+
+  /* First, check if the sequence number of the incoming packet is
+     what we're expecting next. If not, we send out an ACK with the
+     correct numbers in, unless we are in the SYN_RCVD state and
+     receive a SYN, in which case we should retransmit our SYNACK
+     (which is done futher down). */
+  if(!((((uip_connr->tcpstateflags & UIP_TS_MASK) == UIP_SYN_SENT) &&
+	((UIP_TCP_BUF->flags & TCP_CTL) == (TCP_SYN | TCP_ACK))) ||
+       (((uip_connr->tcpstateflags & UIP_TS_MASK) == UIP_SYN_RCVD) &&
+	((UIP_TCP_BUF->flags & TCP_CTL) == TCP_SYN)))) {
+    if((uip_len > 0 || ((UIP_TCP_BUF->flags & (TCP_SYN | TCP_FIN)) != 0)) &&
+       (UIP_TCP_BUF->seqno[0] != uip_connr->rcv_nxt[0] ||
+        UIP_TCP_BUF->seqno[1] != uip_connr->rcv_nxt[1] ||
+        UIP_TCP_BUF->seqno[2] != uip_connr->rcv_nxt[2] ||
+        UIP_TCP_BUF->seqno[3] != uip_connr->rcv_nxt[3])) {
+
+      if(UIP_TCP_BUF->flags & TCP_SYN) {
+        goto tcp_send_synack;
+      }
+      goto tcp_send_ack;
+    }
+  }
+
+  /* Next, check if the incoming segment acknowledges any outstanding
+     data. If so, we update the sequence number, reset the length of
+     the outstanding data, calculate RTT estimations, and reset the
+     retransmission timer. */
+  if((UIP_TCP_BUF->flags & TCP_ACK) && uip_outstanding(uip_connr)) {
+    uip_add32(uip_connr->snd_nxt, uip_connr->len);
+
+    if(UIP_TCP_BUF->ackno[0] == uip_acc32[0] &&
+       UIP_TCP_BUF->ackno[1] == uip_acc32[1] &&
+       UIP_TCP_BUF->ackno[2] == uip_acc32[2] &&
+       UIP_TCP_BUF->ackno[3] == uip_acc32[3]) {
+      /* Update sequence number. */
+      uip_connr->snd_nxt[0] = uip_acc32[0];
+      uip_connr->snd_nxt[1] = uip_acc32[1];
+      uip_connr->snd_nxt[2] = uip_acc32[2];
+      uip_connr->snd_nxt[3] = uip_acc32[3];
+   
+      /* Do RTT estimation, unless we have done retransmissions. */
+      if(uip_connr->nrtx == 0) {
+        signed char m;
+        m = uip_connr->rto - uip_connr->tmr;
+        /* This is taken directly from VJs original code in his paper */
+        m = m - (uip_connr->sa >> 3);
+        uip_connr->sa += m;
+        if(m < 0) {
+          m = -m;
+        }
+        m = m - (uip_connr->sv >> 2);
+        uip_connr->sv += m;
+        uip_connr->rto = (uip_connr->sa >> 3) + uip_connr->sv;
+
+      }
+      /* Set the acknowledged flag. */
+      uip_flags = UIP_ACKDATA;
+      /* Reset the retransmission timer. */
+      uip_connr->tmr = uip_connr->rto;
+
+      /* Reset length of outstanding data. */
+      uip_connr->len = 0;
+    }
+    
+  }
+
+  /* Do different things depending on in what state the connection is. */
+  switch(uip_connr->tcpstateflags & UIP_TS_MASK) {
+    /* CLOSED and LISTEN are not handled here. CLOSE_WAIT is not
+       implemented, since we force the application to close when the
+       peer sends a FIN (hence the application goes directly from
+       ESTABLISHED to LAST_ACK). */
+    case UIP_SYN_RCVD:
+      /* In SYN_RCVD we have sent out a SYNACK in response to a SYN, and
+         we are waiting for an ACK that acknowledges the data we sent
+         out the last time. Therefore, we want to have the UIP_ACKDATA
+         flag set. If so, we enter the ESTABLISHED state. */
+      if(uip_flags & UIP_ACKDATA) {
+        uip_connr->tcpstateflags = UIP_ESTABLISHED;
+        uip_flags = UIP_CONNECTED;
+        uip_connr->len = 0;
+        if(uip_len > 0) {
+          uip_flags |= UIP_NEWDATA;
+          uip_add_rcv_nxt(uip_len);
+        }
+        uip_slen = 0;
+        UIP_APPCALL();
+        goto appsend;
+      }
+      /* We need to retransmit the SYNACK */
+      if((UIP_TCP_BUF->flags & TCP_CTL) == TCP_SYN) {
+	goto tcp_send_synack;
+      }
+      goto drop;
+#if UIP_ACTIVE_OPEN
+    case UIP_SYN_SENT:
+      /* In SYN_SENT, we wait for a SYNACK that is sent in response to
+         our SYN. The rcv_nxt is set to sequence number in the SYNACK
+         plus one, and we send an ACK. We move into the ESTABLISHED
+         state. */
+      if((uip_flags & UIP_ACKDATA) &&
+         (UIP_TCP_BUF->flags & TCP_CTL) == (TCP_SYN | TCP_ACK)) {
+
+        /* Parse the TCP MSS option, if present. */
+        if((UIP_TCP_BUF->tcpoffset & 0xf0) > 0x50) {
+          for(c = 0; c < ((UIP_TCP_BUF->tcpoffset >> 4) - 5) << 2 ;) {
+            opt = uip_buf[UIP_IPTCPH_LEN + UIP_LLH_LEN + c];
+            if(opt == TCP_OPT_END) {
+              /* End of options. */
+              break;
+            } else if(opt == TCP_OPT_NOOP) {
+              ++c;
+              /* NOP option. */
+            } else if(opt == TCP_OPT_MSS &&
+                      uip_buf[UIP_TCPIP_HLEN + UIP_LLH_LEN + 1 + c] == TCP_OPT_MSS_LEN) {
+              /* An MSS option with the right option length. */
+              tmp16 = (uip_buf[UIP_TCPIP_HLEN + UIP_LLH_LEN + 2 + c] << 8) |
+                uip_buf[UIP_TCPIP_HLEN + UIP_LLH_LEN + 3 + c];
+              uip_connr->initialmss =
+                uip_connr->mss = tmp16 > UIP_TCP_MSS? UIP_TCP_MSS: tmp16;
+
+              /* And we are done processing options. */
+              break;
+            } else {
+              /* All other options have a length field, so that we easily
+                 can skip past them. */
+              if(uip_buf[UIP_TCPIP_HLEN + UIP_LLH_LEN + 1 + c] == 0) {
+                /* If the length field is zero, the options are malformed
+                   and we don't process them further. */
+                break;
+              }
+              c += uip_buf[UIP_TCPIP_HLEN + UIP_LLH_LEN + 1 + c];
+            }
+          }
+        }
+        uip_connr->tcpstateflags = UIP_ESTABLISHED;
+        uip_connr->rcv_nxt[0] = UIP_TCP_BUF->seqno[0];
+        uip_connr->rcv_nxt[1] = UIP_TCP_BUF->seqno[1];
+        uip_connr->rcv_nxt[2] = UIP_TCP_BUF->seqno[2];
+        uip_connr->rcv_nxt[3] = UIP_TCP_BUF->seqno[3];
+        uip_add_rcv_nxt(1);
+        uip_flags = UIP_CONNECTED | UIP_NEWDATA;
+        uip_connr->len = 0;
+        uip_len = 0;
+        uip_slen = 0;
+        UIP_APPCALL();
+        goto appsend;
+      }
+      /* Inform the application that the connection failed */
+      uip_flags = UIP_ABORT;
+      UIP_APPCALL();
+      /* The connection is closed after we send the RST */
+      uip_conn->tcpstateflags = UIP_CLOSED;
+      goto reset;
+#endif /* UIP_ACTIVE_OPEN */
+    
+    case UIP_ESTABLISHED:
+      /* In the ESTABLISHED state, we call upon the application to feed
+         data into the uip_buf. If the UIP_ACKDATA flag is set, the
+         application should put new data into the buffer, otherwise we are
+         retransmitting an old segment, and the application should put that
+         data into the buffer.
+
+         If the incoming packet is a FIN, we should close the connection on
+         this side as well, and we send out a FIN and enter the LAST_ACK
+         state. We require that there is no outstanding data; otherwise the
+         sequence numbers will be screwed up. */
+
+      if(UIP_TCP_BUF->flags & TCP_FIN && !(uip_connr->tcpstateflags & UIP_STOPPED)) {
+        if(uip_outstanding(uip_connr)) {
+          goto drop;
+        }
+        uip_add_rcv_nxt(1 + uip_len);
+        uip_flags |= UIP_CLOSE;
+        if(uip_len > 0) {
+          uip_flags |= UIP_NEWDATA;
+        }
+        UIP_APPCALL();
+        uip_connr->len = 1;
+        uip_connr->tcpstateflags = UIP_LAST_ACK;
+        uip_connr->nrtx = 0;
+      tcp_send_finack:
+        UIP_TCP_BUF->flags = TCP_FIN | TCP_ACK;
+        goto tcp_send_nodata;
+      }
+
+      /* Check the URG flag. If this is set, the segment carries urgent
+         data that we must pass to the application. */
+      if((UIP_TCP_BUF->flags & TCP_URG) != 0) {
+#if UIP_URGDATA > 0
+        uip_urglen = (UIP_TCP_BUF->urgp[0] << 8) | UIP_TCP_BUF->urgp[1];
+        if(uip_urglen > uip_len) {
+          /* There is more urgent data in the next segment to come. */
+          uip_urglen = uip_len;
+        }
+        uip_add_rcv_nxt(uip_urglen);
+        uip_len -= uip_urglen;
+        uip_urgdata = uip_appdata;
+        uip_appdata += uip_urglen;
+      } else {
+        uip_urglen = 0;
+#else /* UIP_URGDATA > 0 */
+        uip_appdata = ((char *)uip_appdata) + ((UIP_TCP_BUF->urgp[0] << 8) | UIP_TCP_BUF->urgp[1]);
+        uip_len -= (UIP_TCP_BUF->urgp[0] << 8) | UIP_TCP_BUF->urgp[1];
+#endif /* UIP_URGDATA > 0 */
+      }
+
+      /* If uip_len > 0 we have TCP data in the packet, and we flag this
+         by setting the UIP_NEWDATA flag and update the sequence number
+         we acknowledge. If the application has stopped the dataflow
+         using uip_stop(), we must not accept any data packets from the
+         remote host. */
+      if(uip_len > 0 && !(uip_connr->tcpstateflags & UIP_STOPPED)) {
+        uip_flags |= UIP_NEWDATA;
+        uip_add_rcv_nxt(uip_len);
+      }
+
+      /* Check if the available buffer space advertised by the other end
+         is smaller than the initial MSS for this connection. If so, we
+         set the current MSS to the window size to ensure that the
+         application does not send more data than the other end can
+         handle.
+
+         If the remote host advertises a zero window, we set the MSS to
+         the initial MSS so that the application will send an entire MSS
+         of data. This data will not be acknowledged by the receiver,
+         and the application will retransmit it. This is called the
+         "persistent timer" and uses the retransmission mechanim.
+      */
+      tmp16 = ((uint16_t)UIP_TCP_BUF->wnd[0] << 8) + (uint16_t)UIP_TCP_BUF->wnd[1];
+      if(tmp16 > uip_connr->initialmss ||
+         tmp16 == 0) {
+        tmp16 = uip_connr->initialmss;
+      }
+      uip_connr->mss = tmp16;
+
+      /* If this packet constitutes an ACK for outstanding data (flagged
+         by the UIP_ACKDATA flag, we should call the application since it
+         might want to send more data. If the incoming packet had data
+         from the peer (as flagged by the UIP_NEWDATA flag), the
+         application must also be notified.
+
+         When the application is called, the global variable uip_len
+         contains the length of the incoming data. The application can
+         access the incoming data through the global pointer
+         uip_appdata, which usually points UIP_IPTCPH_LEN + UIP_LLH_LEN
+         bytes into the uip_buf array.
+
+         If the application wishes to send any data, this data should be
+         put into the uip_appdata and the length of the data should be
+         put into uip_len. If the application don't have any data to
+         send, uip_len must be set to 0. */
+      if(uip_flags & (UIP_NEWDATA | UIP_ACKDATA)) {
+        uip_slen = 0;
+        UIP_APPCALL();
+
+      appsend:
+      
+        if(uip_flags & UIP_ABORT) {
+          uip_slen = 0;
+          uip_connr->tcpstateflags = UIP_CLOSED;
+          UIP_TCP_BUF->flags = TCP_RST | TCP_ACK;
+          goto tcp_send_nodata;
+        }
+
+        if(uip_flags & UIP_CLOSE) {
+          uip_slen = 0;
+          uip_connr->len = 1;
+          uip_connr->tcpstateflags = UIP_FIN_WAIT_1;
+          uip_connr->nrtx = 0;
+          UIP_TCP_BUF->flags = TCP_FIN | TCP_ACK;
+          goto tcp_send_nodata;
+        }
+
+        /* If uip_slen > 0, the application has data to be sent. */
+        if(uip_slen > 0) {
+
+          /* If the connection has acknowledged data, the contents of
+             the ->len variable should be discarded. */
+          if((uip_flags & UIP_ACKDATA) != 0) {
+            uip_connr->len = 0;
+          }
+
+          /* If the ->len variable is non-zero the connection has
+             already data in transit and cannot send anymore right
+             now. */
+          if(uip_connr->len == 0) {
+
+            /* The application cannot send more than what is allowed by
+               the mss (the minumum of the MSS and the available
+               window). */
+            if(uip_slen > uip_connr->mss) {
+              uip_slen = uip_connr->mss;
+            }
+
+            /* Remember how much data we send out now so that we know
+               when everything has been acknowledged. */
+            uip_connr->len = uip_slen;
+          } else {
+
+            /* If the application already had unacknowledged data, we
+               make sure that the application does not send (i.e.,
+               retransmit) out more than it previously sent out. */
+            uip_slen = uip_connr->len;
+          }
+        }
+        uip_connr->nrtx = 0;
+      apprexmit:
+        uip_appdata = uip_sappdata;
+      
+        /* If the application has data to be sent, or if the incoming
+           packet had new data in it, we must send out a packet. */
+        if(uip_slen > 0 && uip_connr->len > 0) {
+          /* Add the length of the IP and TCP headers. */
+          uip_len = uip_connr->len + UIP_TCPIP_HLEN;
+          /* We always set the ACK flag in response packets. */
+          UIP_TCP_BUF->flags = TCP_ACK | TCP_PSH;
+          /* Send the packet. */
+          goto tcp_send_noopts;
+        }
+        /* If there is no data to send, just send out a pure ACK if
+           there is newdata. */
+        if(uip_flags & UIP_NEWDATA) {
+          uip_len = UIP_TCPIP_HLEN;
+          UIP_TCP_BUF->flags = TCP_ACK;
+          goto tcp_send_noopts;
+        }
+      }
+      goto drop;
+    case UIP_LAST_ACK:
+      /* We can close this connection if the peer has acknowledged our
+         FIN. This is indicated by the UIP_ACKDATA flag. */
+      if(uip_flags & UIP_ACKDATA) {
+        uip_connr->tcpstateflags = UIP_CLOSED;
+        uip_flags = UIP_CLOSE;
+        UIP_APPCALL();
+      }
+      break;
+    
+    case UIP_FIN_WAIT_1:
+      /* The application has closed the connection, but the remote host
+         hasn't closed its end yet. Thus we do nothing but wait for a
+         FIN from the other side. */
+      if(uip_len > 0) {
+        uip_add_rcv_nxt(uip_len);
+      }
+      if(UIP_TCP_BUF->flags & TCP_FIN) {
+        if(uip_flags & UIP_ACKDATA) {
+          uip_connr->tcpstateflags = UIP_TIME_WAIT;
+          uip_connr->tmr = 0;
+          uip_connr->len = 0;
+        } else {
+          uip_connr->tcpstateflags = UIP_CLOSING;
+        }
+        uip_add_rcv_nxt(1);
+        uip_flags = UIP_CLOSE;
+        UIP_APPCALL();
+        goto tcp_send_ack;
+      } else if(uip_flags & UIP_ACKDATA) {
+        uip_connr->tcpstateflags = UIP_FIN_WAIT_2;
+        uip_connr->len = 0;
+        goto drop;
+      }
+      if(uip_len > 0) {
+        goto tcp_send_ack;
+      }
+      goto drop;
+      
+    case UIP_FIN_WAIT_2:
+      if(uip_len > 0) {
+        uip_add_rcv_nxt(uip_len);
+      }
+      if(UIP_TCP_BUF->flags & TCP_FIN) {
+        uip_connr->tcpstateflags = UIP_TIME_WAIT;
+        uip_connr->tmr = 0;
+        uip_add_rcv_nxt(1);
+        uip_flags = UIP_CLOSE;
+        UIP_APPCALL();
+        goto tcp_send_ack;
+      }
+      if(uip_len > 0) {
+        goto tcp_send_ack;
+      }
+      goto drop;
+
+    case UIP_TIME_WAIT:
+      goto tcp_send_ack;
+    
+    case UIP_CLOSING:
+      if(uip_flags & UIP_ACKDATA) {
+        uip_connr->tcpstateflags = UIP_TIME_WAIT;
+        uip_connr->tmr = 0;
+      }
+  }
+  goto drop;
+  
+  /* We jump here when we are ready to send the packet, and just want
+     to set the appropriate TCP sequence numbers in the TCP header. */
+ tcp_send_ack:
+  UIP_TCP_BUF->flags = TCP_ACK;
+
+ tcp_send_nodata:
+  uip_len = UIP_IPTCPH_LEN;
+
+ tcp_send_noopts:
+  UIP_TCP_BUF->tcpoffset = (UIP_TCPH_LEN / 4) << 4;
+
+  /* We're done with the input processing. We are now ready to send a
+     reply. Our job is to fill in all the fields of the TCP and IP
+     headers before calculating the checksum and finally send the
+     packet. */
+ tcp_send:
+  PRINTF("In tcp_send\n");
+   
+  UIP_TCP_BUF->ackno[0] = uip_connr->rcv_nxt[0];
+  UIP_TCP_BUF->ackno[1] = uip_connr->rcv_nxt[1];
+  UIP_TCP_BUF->ackno[2] = uip_connr->rcv_nxt[2];
+  UIP_TCP_BUF->ackno[3] = uip_connr->rcv_nxt[3];
+  
+  UIP_TCP_BUF->seqno[0] = uip_connr->snd_nxt[0];
+  UIP_TCP_BUF->seqno[1] = uip_connr->snd_nxt[1];
+  UIP_TCP_BUF->seqno[2] = uip_connr->snd_nxt[2];
+  UIP_TCP_BUF->seqno[3] = uip_connr->snd_nxt[3];
+
+  UIP_IP_BUF->proto = UIP_PROTO_TCP;
+
+  UIP_TCP_BUF->srcport  = uip_connr->lport;
+  UIP_TCP_BUF->destport = uip_connr->rport;
+
+  uip_ipaddr_copy(&UIP_IP_BUF->destipaddr, &uip_connr->ripaddr);
+  uip_ds6_select_src(&UIP_IP_BUF->srcipaddr, &UIP_IP_BUF->destipaddr);
+  PRINTF("Sending TCP packet to ");
+  PRINT6ADDR(&UIP_IP_BUF->destipaddr);
+  PRINTF(" from ");
+  PRINT6ADDR(&UIP_IP_BUF->srcipaddr);
+  PRINTF("\n");
+
+  if(uip_connr->tcpstateflags & UIP_STOPPED) {
+    /* If the connection has issued uip_stop(), we advertise a zero
+       window so that the remote host will stop sending data. */
+    UIP_TCP_BUF->wnd[0] = UIP_TCP_BUF->wnd[1] = 0;
+  } else {
+    UIP_TCP_BUF->wnd[0] = ((UIP_RECEIVE_WINDOW) >> 8);
+    UIP_TCP_BUF->wnd[1] = ((UIP_RECEIVE_WINDOW) & 0xff);
+  }
+
+ tcp_send_noconn:
+  UIP_IP_BUF->ttl = uip_ds6_if.cur_hop_limit;
+  UIP_IP_BUF->len[0] = ((uip_len - UIP_IPH_LEN) >> 8);
+  UIP_IP_BUF->len[1] = ((uip_len - UIP_IPH_LEN) & 0xff);
+
+  UIP_TCP_BUF->urgp[0] = UIP_TCP_BUF->urgp[1] = 0;
+  
+  /* Calculate TCP checksum. */
+  UIP_TCP_BUF->tcpchksum = 0;
+  UIP_TCP_BUF->tcpchksum = ~(uip_tcpchksum());
+  UIP_STAT(++uip_stat.tcp.sent);
+
+#endif /* UIP_TCP */
+#if UIP_UDP
+ ip_send_nolen:
+#endif
+  UIP_IP_BUF->vtc = 0x60;
+  UIP_IP_BUF->tcflow = 0x00;
+  UIP_IP_BUF->flow = 0x00;
+ send:
+  PRINTF("Sending packet with length %d (%d)\n", uip_len,
+         (UIP_IP_BUF->len[0] << 8) | UIP_IP_BUF->len[1]);
+  
+  UIP_STAT(++uip_stat.ip.sent);
+  /* Return and let the caller do the actual transmission. */
+  uip_flags = 0;
+  return;
+
+ drop:
+  uip_len = 0;
+  uip_ext_len = 0;
+  uip_ext_bitmap = 0;
+  uip_flags = 0;
+  return;
+}
+/*---------------------------------------------------------------------------*/
+uint16_t
+uip_htons(uint16_t val)
+{
+  return UIP_HTONS(val);
+}
+
+uint32_t
+uip_htonl(uint32_t val)
+{
+  return UIP_HTONL(val);
+}
+/*---------------------------------------------------------------------------*/
+void
+uip_send(const void *data, int len)
+{
+  int copylen;
+#define MIN(a,b) ((a) < (b)? (a): (b))
+  copylen = MIN(len, UIP_BUFSIZE - UIP_LLH_LEN - UIP_TCPIP_HLEN -
+                (int)((char *)uip_sappdata - (char *)&uip_buf[UIP_LLH_LEN + UIP_TCPIP_HLEN]));
+  if(copylen > 0) {
+    uip_slen = copylen;
+    if(data != uip_sappdata) {
+      memcpy(uip_sappdata, (data), uip_slen);
+    }
+  }
+}
+/*---------------------------------------------------------------------------*/
+/** @} */
+#endif /* UIP_CONF_IPV6 */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/uip_arp.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/uip_arp.c
@@ -1,0 +1,471 @@
+// Copyright (c) 2011, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+
+/**
+ * \addtogroup uip
+ * @{
+ */
+
+/**
+ * \defgroup uiparp uIP Address Resolution Protocol
+ * @{
+ *
+ * The Address Resolution Protocol ARP is used for mapping between IP
+ * addresses and link level addresses such as the Ethernet MAC
+ * addresses. ARP uses broadcast queries to ask for the link level
+ * address of a known IP address and the host which is configured with
+ * the IP address for which the query was meant, will respond with its
+ * link level address.
+ *
+ * \note This ARP implementation only supports Ethernet.
+ */
+ 
+/**
+ * \file
+ * Implementation of the ARP Address Resolution Protocol.
+ * \author Adam Dunkels <adam@dunkels.com>
+ *
+ */
+
+/*
+ * Copyright (c) 2001-2003, Adam Dunkels.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This file is part of the uIP TCP/IP stack.
+ *
+ * $Id: uip_arp.c,v 1.8 2006/06/02 23:36:21 adam Exp $
+ *
+ */
+
+
+#include "net/uip_arp.h"
+
+#include <string.h>
+#include <print.h>
+
+#if UIP_USE_AUTOIP
+#include "autoip.h"
+#endif
+
+struct arp_hdr {
+  struct uip_eth_hdr ethhdr;
+  uint16_t hwtype;
+  uint16_t protocol;
+  uint8_t hwlen;
+  uint8_t protolen;
+  uint16_t opcode;
+  struct uip_eth_addr shwaddr;
+//  u16_t sipaddr[2];  // ORIG XMOS
+  uip_ipaddr_t sipaddr;
+  struct uip_eth_addr dhwaddr;
+//  u16_t dipaddr[2];
+  uip_ipaddr_t dipaddr;
+};
+
+struct ethip_hdr {
+  struct uip_eth_hdr ethhdr;
+  /* IP header. */
+  uint8_t vhl,
+    tos,
+    len[2],
+    ipid[2],
+    ipoffset[2],
+    ttl,
+    proto;
+  uint16_t ipchksum;
+//  u16_t srcipaddr[2], destipaddr[2];  // ORIG XMOS
+  uip_ipaddr_t srcipaddr, destipaddr;
+};
+
+#define ARP_REQUEST 1
+#define ARP_REPLY   2
+
+#define ARP_HWTYPE_ETH 1
+
+struct arp_entry {
+//  u16_t ipaddr[2]; // ORIG XMOS
+  uip_ipaddr_t ipaddr;
+  struct uip_eth_addr ethaddr;
+  uint8_t time;
+};
+
+static const struct uip_eth_addr broadcast_ethaddr =
+  {{0xff,0xff,0xff,0xff,0xff,0xff}};
+static const uint16_t broadcast_ipaddr[2] = {0xffff,0xffff};
+
+static struct arp_entry arp_table[UIP_ARPTAB_SIZE];
+//static u16_t ipaddr[2];  // ORIG XMOS
+static uip_ipaddr_t ipaddr;
+static uint8_t i, c;
+
+static uint8_t arptime;
+static uint8_t tmpage;
+
+#define BUF   ((struct arp_hdr *)&uip_buf[0])
+#define IPBUF ((struct ethip_hdr *)&uip_buf[0])
+
+#define DEBUG 0
+#if DEBUG
+#include <stdio.h>
+#define PRINTF(...) printf(__VA_ARGS__)
+#else
+#define PRINTF(...)
+#endif
+
+/*-----------------------------------------------------------------------------------*/
+/**
+ * Initialize the ARP module.
+ *
+ */
+/*-----------------------------------------------------------------------------------*/
+void
+uip_arp_init(void)
+{
+  for(i = 0; i < UIP_ARPTAB_SIZE; ++i) {
+    memset(&(arp_table[i].ipaddr), 0, sizeof(uip_ipaddr_t));
+  }
+}
+/*-----------------------------------------------------------------------------------*/
+/**
+ * Periodic ARP processing function.
+ *
+ * This function performs periodic timer processing in the ARP module
+ * and should be called at regular intervals. The recommended interval
+ * is 10 seconds between the calls.
+ *
+ */
+/*-----------------------------------------------------------------------------------*/
+void
+uip_arp_timer(void)
+{
+  struct arp_entry *tabptr;
+  
+  ++arptime;
+  for(i = 0; i < UIP_ARPTAB_SIZE; ++i) {
+    tabptr = &arp_table[i];
+    if(uip_ipaddr_cmp(&tabptr->ipaddr, &uip_all_zeroes_addr) &&
+       arptime - tabptr->time >= UIP_ARP_MAXAGE) {
+      memset(&tabptr->ipaddr, 0, 4);
+    }
+  }
+
+}
+
+/*-----------------------------------------------------------------------------------*/
+static void
+uip_arp_update(uip_ipaddr_t *ipaddr, struct uip_eth_addr *ethaddr)
+{
+  register struct arp_entry *tabptr;
+  /* Walk through the ARP mapping table and try to find an entry to
+     update. If none is found, the IP -> MAC address mapping is
+     inserted in the ARP table. */
+  for(i = 0; i < UIP_ARPTAB_SIZE; ++i) {
+
+    tabptr = &arp_table[i];
+    /* Only check those entries that are actually in use. */
+    if(!uip_ipaddr_cmp(&tabptr->ipaddr, &uip_all_zeroes_addr)) {
+
+      /* Check if the source IP address of the incoming packet matches
+         the IP address in this ARP table entry. */
+      if(uip_ipaddr_cmp(ipaddr, &tabptr->ipaddr)) {
+	 
+	/* An old entry found, update this and return. */
+	memcpy(tabptr->ethaddr.addr, ethaddr->addr, 6);
+	tabptr->time = arptime;
+
+	return;
+      }
+    }
+  }
+
+  /* If we get here, no existing ARP table entry was found, so we
+     create one. */
+
+  /* First, we try to find an unused entry in the ARP table. */
+  for(i = 0; i < UIP_ARPTAB_SIZE; ++i) {
+    tabptr = &arp_table[i];
+    if(uip_ipaddr_cmp(&tabptr->ipaddr, &uip_all_zeroes_addr)) {
+      break;
+    }
+  }
+
+  /* If no unused entry is found, we try to find the oldest entry and
+     throw it away. */
+  if(i == UIP_ARPTAB_SIZE) {
+    tmpage = 0;
+    c = 0;
+    for(i = 0; i < UIP_ARPTAB_SIZE; ++i) {
+      tabptr = &arp_table[i];
+      if(arptime - tabptr->time > tmpage) {
+	tmpage = arptime - tabptr->time;
+	c = i;
+      }
+    }
+    i = c;
+    tabptr = &arp_table[i];
+  }
+
+  /* Now, i is the ARP table entry which we will fill with the new
+     information. */
+  uip_ipaddr_copy(&tabptr->ipaddr, ipaddr);
+  memcpy(tabptr->ethaddr.addr, ethaddr->addr, 6);
+  tabptr->time = arptime;
+}
+/*-----------------------------------------------------------------------------------*/
+/**
+ * ARP processing for incoming IP packets
+ *
+ * This function should be called by the device driver when an IP
+ * packet has been received. The function will check if the address is
+ * in the ARP cache, and if so the ARP cache entry will be
+ * refreshed. If no ARP cache entry was found, a new one is created.
+ *
+ * This function expects an IP packet with a prepended Ethernet header
+ * in the uip_buf[] buffer, and the length of the packet in the global
+ * variable uip_len.
+ */
+/*-----------------------------------------------------------------------------------*/
+#if 0
+void
+uip_arp_ipin(void)
+{
+  uip_len -= sizeof(struct uip_eth_hdr);
+	
+  /* Only insert/update an entry if the source IP address of the
+     incoming IP packet comes from a host on the local network. */
+  if((IPBUF->srcipaddr[0] & uip_netmask[0]) !=
+     (uip_hostaddr[0] & uip_netmask[0])) {
+    return;
+  }
+  if((IPBUF->srcipaddr[1] & uip_netmask[1]) !=
+     (uip_hostaddr[1] & uip_netmask[1])) {
+    return;
+  }
+  uip_arp_update(IPBUF->srcipaddr, &(IPBUF->ethhdr.src));
+
+  return;
+}
+#endif /* 0 */
+/*-----------------------------------------------------------------------------------*/
+/**
+ * ARP processing for incoming ARP packets.
+ *
+ * This function should be called by the device driver when an ARP
+ * packet has been received. The function will act differently
+ * depending on the ARP packet type: if it is a reply for a request
+ * that we previously sent out, the ARP cache will be filled in with
+ * the values from the ARP reply. If the incoming ARP packet is an ARP
+ * request for our IP address, an ARP reply packet is created and put
+ * into the uip_buf[] buffer.
+ *
+ * When the function returns, the value of the global variable uip_len
+ * indicates whether the device driver should send out a packet or
+ * not. If uip_len is zero, no packet should be sent. If uip_len is
+ * non-zero, it contains the length of the outbound packet that is
+ * present in the uip_buf[] buffer.
+ *
+ * This function expects an ARP packet with a prepended Ethernet
+ * header in the uip_buf[] buffer, and the length of the packet in the
+ * global variable uip_len.
+ */
+/*-----------------------------------------------------------------------------------*/
+void
+uip_arp_arpin(void)
+{
+  
+  if(uip_len < sizeof(struct arp_hdr)) {
+    uip_len = 0;
+    return;
+  }
+  uip_len = 0;
+  
+#if UIP_USE_AUTOIP
+  autoip_arp_in();
+#endif  
+
+  switch(BUF->opcode) {
+  case UIP_HTONS(ARP_REQUEST):
+    /* ARP request. If it asked for our address, we send out a
+       reply. */
+    /*    if(BUF->dipaddr[0] == uip_hostaddr[0] &&
+	  BUF->dipaddr[1] == uip_hostaddr[1]) {*/
+    PRINTF("uip_arp_arpin: request for %d.%d.%d.%d (we are %d.%d.%d.%d)\n",
+	   BUF->dipaddr.u8[0], BUF->dipaddr.u8[1],
+	   BUF->dipaddr.u8[2], BUF->dipaddr.u8[3],
+	   uip_hostaddr.u8[0], uip_hostaddr.u8[1],
+	   uip_hostaddr.u8[2], uip_hostaddr.u8[3]);
+    if(uip_ipaddr_cmp(&BUF->dipaddr, &uip_hostaddr)) {
+      /* First, we register the one who made the request in our ARP
+	 table, since it is likely that we will do more communication
+	 with this host in the future. */
+      uip_arp_update(&BUF->sipaddr, &BUF->shwaddr);
+      
+      BUF->opcode = UIP_HTONS(ARP_REPLY);
+
+      memcpy(BUF->dhwaddr.addr, BUF->shwaddr.addr, 6);
+      memcpy(BUF->shwaddr.addr, uip_lladdr.addr, 6);
+      memcpy(BUF->ethhdr.src.addr, uip_lladdr.addr, 6);
+      memcpy(BUF->ethhdr.dest.addr, BUF->dhwaddr.addr, 6);
+      
+      uip_ipaddr_copy(&BUF->dipaddr, &BUF->sipaddr);
+      uip_ipaddr_copy(&BUF->sipaddr, &uip_hostaddr);
+
+      BUF->ethhdr.type = UIP_HTONS(UIP_ETHTYPE_ARP);
+      uip_len = sizeof(struct arp_hdr);
+    }
+    break;
+  case UIP_HTONS(ARP_REPLY):
+    /* ARP reply. We insert or update the ARP table if it was meant
+       for us. */
+    if(uip_ipaddr_cmp(&BUF->dipaddr, &uip_hostaddr)) {
+      uip_arp_update(&BUF->sipaddr, &BUF->shwaddr);
+    }
+    break;
+  }
+
+  return;
+}
+/*-----------------------------------------------------------------------------------*/
+/**
+ * Prepend Ethernet header to an outbound IP packet and see if we need
+ * to send out an ARP request.
+ *
+ * This function should be called before sending out an IP packet. The
+ * function checks the destination IP address of the IP packet to see
+ * what Ethernet MAC address that should be used as a destination MAC
+ * address on the Ethernet.
+ *
+ * If the destination IP address is in the local network (determined
+ * by logical ANDing of netmask and our IP address), the function
+ * checks the ARP cache to see if an entry for the destination IP
+ * address is found. If so, an Ethernet header is prepended and the
+ * function returns. If no ARP cache entry is found for the
+ * destination IP address, the packet in the uip_buf[] is replaced by
+ * an ARP request packet for the IP address. The IP packet is dropped
+ * and it is assumed that they higher level protocols (e.g., TCP)
+ * eventually will retransmit the dropped packet.
+ *
+ * If the destination IP address is not on the local network, the IP
+ * address of the default router is used instead.
+ *
+ * When the function returns, a packet is present in the uip_buf[]
+ * buffer, and the length of the packet is in the global variable
+ * uip_len.
+ */
+/*-----------------------------------------------------------------------------------*/
+void
+uip_arp_out(struct uip_udp_conn *conn)
+{
+  struct arp_entry *tabptr;
+  
+  /* Find the destination IP address in the ARP table and construct
+     the Ethernet header. If the destination IP addres isn't on the
+     local network, we use the default router's IP address instead.
+
+     If not ARP table entry is found, we overwrite the original IP
+     packet with an ARP request for the IP address. */
+
+  /* First check if destination is a local broadcast. */
+  if(uip_ipaddr_cmp(&IPBUF->destipaddr, &uip_broadcast_addr)) {
+    memcpy(IPBUF->ethhdr.dest.addr, broadcast_ethaddr.addr, 6);
+  } else if(IPBUF->destipaddr.u8[0] == 224) {
+    /* Multicast. */
+    IPBUF->ethhdr.dest.addr[0] = 0x01;
+    IPBUF->ethhdr.dest.addr[1] = 0x00;
+    IPBUF->ethhdr.dest.addr[2] = 0x5e;
+    IPBUF->ethhdr.dest.addr[3] = IPBUF->destipaddr.u8[1];
+    IPBUF->ethhdr.dest.addr[4] = IPBUF->destipaddr.u8[2];
+    IPBUF->ethhdr.dest.addr[5] = IPBUF->destipaddr.u8[3];
+  } else {
+    /* Check if the destination address is on the local network. */
+    if(!uip_ipaddr_maskcmp(&IPBUF->destipaddr, &uip_hostaddr, &uip_netmask)) {
+      /* Destination address was not on the local network, so we need to
+	 use the default router's IP address instead of the destination
+	 address when determining the MAC address. */
+      uip_ipaddr_copy(&ipaddr, &uip_draddr);
+    } else {
+      /* Else, we use the destination IP address. */
+      uip_ipaddr_copy(&ipaddr, &IPBUF->destipaddr);
+    }
+    for(i = 0; i < UIP_ARPTAB_SIZE; ++i) {
+      if(uip_ipaddr_cmp(&ipaddr, &tabptr->ipaddr)) {
+	break;
+      }
+	  tabptr++;
+    }
+
+    if(i == UIP_ARPTAB_SIZE) {
+      /* The destination address was not in our ARP table, so we
+	 overwrite the IP packet with an ARP request. */
+
+      memset(BUF->ethhdr.dest.addr, 0xff, 6);
+      memset(BUF->dhwaddr.addr, 0x00, 6);
+      memcpy(BUF->ethhdr.src.addr, uip_lladdr.addr, 6);
+      memcpy(BUF->shwaddr.addr, uip_lladdr.addr, 6);
+    
+      uip_ipaddr_copy(&BUF->dipaddr, &ipaddr);
+      uip_ipaddr_copy(&BUF->sipaddr, &uip_hostaddr);
+      BUF->opcode = UIP_HTONS(ARP_REQUEST); /* ARP request. */
+      BUF->hwtype = UIP_HTONS(ARP_HWTYPE_ETH);
+      BUF->protocol = UIP_HTONS(UIP_ETHTYPE_IP);
+      BUF->hwlen = 6;
+      BUF->protolen = 4;
+      BUF->ethhdr.type = UIP_HTONS(UIP_ETHTYPE_ARP);
+
+      uip_appdata = &uip_buf[UIP_TCPIP_HLEN + UIP_LLH_LEN];
+    
+      uip_len = sizeof(struct arp_hdr);
+
+      /* If we have a dependent udp connection mark it as pending an arp reply
+       */
+
+      if (conn != NULL)
+        conn->udpflags |= UDP_PENDING_ARP;
+
+      return;
+    }
+
+    /* Build an ethernet header. */
+    memcpy(IPBUF->ethhdr.dest.addr, tabptr->ethaddr.addr, 6);
+  }
+  memcpy(IPBUF->ethhdr.src.addr, uip_lladdr.addr, 6);
+  
+  IPBUF->ethhdr.type = UIP_HTONS(UIP_ETHTYPE_IP);
+  
+  if (conn != NULL)
+    conn->udpflags |= UDP_SENT;
+
+  uip_len += sizeof(struct uip_eth_hdr);
+}
+/*-----------------------------------------------------------------------------------*/
+
+/** @} */
+/** @} */
+

--- a/module_xtcp/src/xtcp_uip6/contiki/net/uip_arp.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/uip_arp.h
@@ -1,0 +1,158 @@
+// Copyright (c) 2011, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+
+/**
+ * \addtogroup uip
+ * @{
+ */
+
+/**
+ * \addtogroup uiparp
+ * @{
+ */
+ 
+/**
+ * \file
+ * Macros and definitions for the ARP module.
+ * \author Adam Dunkels <adam@dunkels.com>
+ */
+  
+
+/*
+ * Copyright (c) 2001-2003, Adam Dunkels.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This file is part of the uIP TCP/IP stack.
+ *
+ * $Id: uip_arp.h,v 1.5 2006/06/11 21:46:39 adam Exp $
+ *
+ */
+
+#ifndef __UIP_ARP_H__
+#define __UIP_ARP_H__
+
+#include "net/uip.h"
+
+
+extern struct uip_eth_addr uip_lladdr;
+
+/**
+ * The Ethernet header.
+ */
+struct uip_eth_hdr {
+  struct uip_eth_addr dest;
+  struct uip_eth_addr src;
+  uint16_t type;
+};
+
+#define UIP_ETHTYPE_ARP  0x0806
+#define UIP_ETHTYPE_IP   0x0800
+#define UIP_ETHTYPE_IPV6 0x86dd
+
+
+/* The uip_arp_init() function must be called before any of the other
+   ARP functions. */
+void uip_arp_init(void);
+
+/* The uip_arp_ipin() function should be called whenever an IP packet
+   arrives from the Ethernet. This function refreshes the ARP table or
+   inserts a new mapping if none exists. The function assumes that an
+   IP packet with an Ethernet header is present in the uip_buf buffer
+   and that the length of the packet is in the uip_len variable. */
+/*void uip_arp_ipin(void);*/
+#define uip_arp_ipin()
+
+/* The uip_arp_arpin() should be called when an ARP packet is received
+   by the Ethernet driver. This function also assumes that the
+   Ethernet frame is present in the uip_buf buffer. When the
+   uip_arp_arpin() function returns, the contents of the uip_buf
+   buffer should be sent out on the Ethernet if the uip_len variable
+   is > 0. */
+void uip_arp_arpin(void);
+
+/* The uip_arp_out() function should be called when an IP packet
+   should be sent out on the Ethernet. This function creates an
+   Ethernet header before the IP header in the uip_buf buffer. The
+   Ethernet header will have the correct Ethernet MAC destination
+   address filled in if an ARP table entry for the destination IP
+   address (or the IP address of the default router) is present. If no
+   such table entry is found, the IP packet is overwritten with an ARP
+   request and we rely on TCP to retransmit the packet that was
+   overwritten. In any case, the uip_len variable holds the length of
+   the Ethernet frame that should be transmitted. 
+
+   The function takes one argument which is an optional pointer to a 
+   udp connection. If supplied, and the arp packet overwrites the
+   existing packet then the PENDING_ARP flag is set in that udp 
+   connection so that when an arp reply comes back the application layer
+   is asked to retransmit the udp packet.
+*/
+void uip_arp_out(struct uip_udp_conn* conn);
+
+/* The uip_arp_timer() function should be called every ten seconds. It
+   is responsible for flushing old entries in the ARP table. */
+void uip_arp_timer(void);
+
+/** @} */
+
+/**
+ * \addtogroup uipconffunc
+ * @{
+ */
+
+
+/**
+ * Specifiy the Ethernet MAC address.
+ *
+ * The ARP code needs to know the MAC address of the Ethernet card in
+ * order to be able to respond to ARP queries and to generate working
+ * Ethernet headers.
+ *
+ * \note This macro only specifies the Ethernet MAC address to the ARP
+ * code. It cannot be used to change the MAC address of the Ethernet
+ * card.
+ *
+ * \param eaddr A pointer to a struct uip_eth_addr containing the
+ * Ethernet MAC address of the Ethernet card.
+ *
+ * \hideinitializer
+ */
+#define uip_setethaddr(eaddr) do {uip_lladdr.addr[0] = eaddr.addr[0]; \
+                              uip_lladdr.addr[1] = eaddr.addr[1];\
+                              uip_lladdr.addr[2] = eaddr.addr[2];\
+                              uip_lladdr.addr[3] = eaddr.addr[3];\
+                              uip_lladdr.addr[4] = eaddr.addr[4];\
+                              uip_lladdr.addr[5] = eaddr.addr[5];} while(0)
+
+/** @} */
+
+
+#endif /* __UIP_ARP_H__ */
+/** @} */

--- a/module_xtcp/src/xtcp_uip6/contiki/net/uipopt.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/net/uipopt.h
@@ -1,0 +1,697 @@
+// Copyright (c) 2011, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+
+/**
+ * \defgroup uipopt Configuration options for uIP
+ * @{
+ *
+ * uIP is configured using the per-project configuration file
+ * "uipopt.h". This file contains all compile-time options for uIP and
+ * should be tweaked to match each specific project. The uIP
+ * distribution contains a documented example "uipopt.h" that can be
+ * copied and modified for each project.
+ *
+ * \note Most of the configuration options in the uipopt.h should not
+ * be changed, but rather the per-project uip-conf.h file.
+ */
+
+/**
+ * \file
+ * Configuration options for uIP.
+ * \author Adam Dunkels <adam@dunkels.com>
+ *
+ * This file is used for tweaking various configuration options for
+ * uIP. You should make a copy of this file into one of your project's
+ * directories instead of editing this example "uipopt.h" file that
+ * comes with the uIP distribution.
+ */
+
+/*
+ * Copyright (c) 2001-2003, Adam Dunkels.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This file is part of the uIP TCP/IP stack.
+ *
+ *
+ */
+
+#ifndef __UIPOPT_H__
+#define __UIPOPT_H__
+
+#ifndef UIP_LITTLE_ENDIAN
+#define UIP_LITTLE_ENDIAN  3412
+#endif /* UIP_LITTLE_ENDIAN */
+#ifndef UIP_BIG_ENDIAN
+#define UIP_BIG_ENDIAN     1234
+#endif /* UIP_BIG_ENDIAN */
+
+#include "uip-conf.h"
+
+/*------------------------------------------------------------------------------*/
+
+/**
+ * \defgroup uipoptstaticconf Static configuration options
+ * @{
+ *
+ * These configuration options can be used for setting the IP address
+ * settings statically, but only if UIP_FIXEDADDR is set to 1. The
+ * configuration options for a specific node includes IP address,
+ * netmask and default router as well as the Ethernet address. The
+ * netmask, default router and Ethernet address are applicable only
+ * if uIP should be run over Ethernet.
+ *
+ * This options are meaningful only for the IPv4 code.
+ *
+ * All of these should be changed to suit your project.
+ */
+
+/**
+ * Determines if uIP should use a fixed IP address or not.
+ *
+ * If uIP should use a fixed IP address, the settings are set in the
+ * uipopt.h file. If not, the macros uip_sethostaddr(),
+ * uip_setdraddr() and uip_setnetmask() should be used instead.
+ *
+ * \hideinitializer
+ */
+#define UIP_FIXEDADDR    0
+
+/**
+ * Ping IP address assignment.
+ *
+ * uIP uses a "ping" packets for setting its own IP address if this
+ * option is set. If so, uIP will start with an empty IP address and
+ * the destination IP address of the first incoming "ping" (ICMP echo)
+ * packet will be used for setting the hosts IP address.
+ *
+ * \note This works only if UIP_FIXEDADDR is 0.
+ *
+ * \hideinitializer
+ */
+#ifdef UIP_CONF_PINGADDRCONF
+#define UIP_PINGADDRCONF (UIP_CONF_PINGADDRCONF)
+#else /* UIP_CONF_PINGADDRCONF */
+#define UIP_PINGADDRCONF 0
+#endif /* UIP_CONF_PINGADDRCONF */
+
+
+/**
+ * Specifies if the uIP ARP module should be compiled with a fixed
+ * Ethernet MAC address or not.
+ *
+ * If this configuration option is 0, the macro uip_setethaddr() can
+ * be used to specify the Ethernet address at run-time.
+ *
+ * \hideinitializer
+ */
+#define UIP_FIXEDETHADDR 0
+
+/** @} */
+/*------------------------------------------------------------------------------*/
+/**
+ * \defgroup uipoptip IP configuration options
+ * @{
+ *
+ */
+/**
+ * The IP TTL (time to live) of IP packets sent by uIP.
+ *
+ * This should normally not be changed.
+ */
+#define UIP_TTL         64
+
+/**
+ * The maximum time an IP fragment should wait in the reassembly
+ * buffer before it is dropped.
+ *
+ */
+#define UIP_REASS_MAXAGE 60 /*60s*/
+
+/**
+ * Turn on support for IP packet reassembly.
+ *
+ * uIP supports reassembly of fragmented IP packets. This features
+ * requires an additional amount of RAM to hold the reassembly buffer
+ * and the reassembly code size is approximately 700 bytes.  The
+ * reassembly buffer is of the same size as the uip_buf buffer
+ * (configured by UIP_BUFSIZE).
+ *
+ * \note IP packet reassembly is not heavily tested.
+ *
+ * \hideinitializer
+ */
+#ifdef UIP_CONF_REASSEMBLY
+#define UIP_REASSEMBLY (UIP_CONF_REASSEMBLY)
+#else /* UIP_CONF_REASSEMBLY */
+#define UIP_REASSEMBLY 0
+#endif /* UIP_CONF_REASSEMBLY */
+/** @} */
+
+/*------------------------------------------------------------------------------*/
+/**
+ * \defgroup uipoptipv6 IPv6 configuration options
+ * @{
+ *
+ */
+
+/** The maximum transmission unit at the IP Layer*/
+#define UIP_LINK_MTU 1280
+
+#ifndef UIP_CONF_IPV6
+/** Do we use IPv6 or not (default: no) */
+#define UIP_CONF_IPV6                 1
+#endif
+
+#ifndef UIP_CONF_IPV6_QUEUE_PKT
+/** Do we do per %neighbor queuing during address resolution (default: no) */
+#define UIP_CONF_IPV6_QUEUE_PKT       0
+#endif
+
+#ifndef UIP_CONF_IPV6_CHECKS
+/** Do we do IPv6 consistency checks (highly recommended, default: yes) */
+#define UIP_CONF_IPV6_CHECKS          1
+#endif
+
+#ifndef UIP_CONF_IPV6_REASSEMBLY
+/** Do we do IPv6 fragmentation (default: no) */
+#define UIP_CONF_IPV6_REASSEMBLY      0
+#endif
+
+#ifndef UIP_CONF_NETIF_MAX_ADDRESSES
+/** Default number of IPv6 addresses associated to the node's interface */
+#define UIP_CONF_NETIF_MAX_ADDRESSES  3
+#endif
+
+#ifndef UIP_CONF_DS6_PREFIX_NBU
+/** Default number of IPv6 prefixes associated to the node's interface */
+#define UIP_CONF_DS6_PREFIX_NBU     2
+#endif
+
+#ifndef UIP_CONF_DS6_DEFRT_NBU
+/** Minimum number of default routers */
+#define UIP_CONF_DS6_DEFRT_NBU       2
+#endif
+/** @} */
+
+/*------------------------------------------------------------------------------*/
+/**
+ * \defgroup uipoptudp UDP configuration options
+ * @{
+ *
+ * \note The UDP support in uIP is still not entirely complete; there
+ * is no support for sending or receiving broadcast or multicast
+ * packets, but it works well enough to support a number of vital
+ * applications such as DNS queries, though
+ */
+
+/**
+ * Toggles whether UDP support should be compiled in or not.
+ *
+ * \hideinitializer
+ */
+#ifdef UIP_CONF_UDP
+#define UIP_UDP UIP_CONF_UDP
+#else /* UIP_CONF_UDP */
+#define UIP_UDP           1
+#endif /* UIP_CONF_UDP */
+
+/**
+ * Toggles if UDP checksums should be used or not.
+ *
+ * \note Support for UDP checksums is currently not included in uIP,
+ * so this option has no function.
+ *
+ * \hideinitializer
+ */
+#ifdef UIP_CONF_UDP_CHECKSUMS
+#define UIP_UDP_CHECKSUMS (UIP_CONF_UDP_CHECKSUMS)
+#else
+#define UIP_UDP_CHECKSUMS (UIP_CONF_IPV6)
+#endif
+
+/**
+ * The maximum amount of concurrent UDP connections.
+ *
+ * \hideinitializer
+ */
+#ifdef UIP_CONF_UDP_CONNS
+#define UIP_UDP_CONNS (UIP_CONF_UDP_CONNS)
+#else /* UIP_CONF_UDP_CONNS */
+#define UIP_UDP_CONNS    10
+#endif /* UIP_CONF_UDP_CONNS */
+
+/**
+ * The name of the function that should be called when UDP datagrams arrive.
+ *
+ * \hideinitializer
+ */
+
+
+/** @} */
+/*------------------------------------------------------------------------------*/
+/**
+ * \defgroup uipopttcp TCP configuration options
+ * @{
+ */
+
+/**
+ * Toggles whether TCP support should be compiled in or not.
+ *
+ * \hideinitializer
+ */
+#ifdef UIP_CONF_TCP
+#define UIP_TCP (UIP_CONF_TCP)
+#else /* UIP_CONF_TCP */
+#define UIP_TCP           1
+#endif /* UIP_CONF_TCP */
+
+/**
+ * Determines if support for opening connections from uIP should be
+ * compiled in.
+ *
+ * If the applications that are running on top of uIP for this project
+ * do not need to open outgoing TCP connections, this configuration
+ * option can be turned off to reduce the code size of uIP.
+ *
+ * \hideinitializer
+ */
+#ifndef UIP_CONF_ACTIVE_OPEN
+#define UIP_ACTIVE_OPEN 1
+#else /* UIP_CONF_ACTIVE_OPEN */
+#define UIP_ACTIVE_OPEN (UIP_CONF_ACTIVE_OPEN)
+#endif /* UIP_CONF_ACTIVE_OPEN */
+
+/**
+ * The maximum number of simultaneously open TCP connections.
+ *
+ * Since the TCP connections are statically allocated, turning this
+ * configuration knob down results in less RAM used. Each TCP
+ * connection requires approximately 30 bytes of memory.
+ *
+ * \hideinitializer
+ */
+#ifndef UIP_CONF_MAX_CONNECTIONS
+#define UIP_CONNS       10
+#else /* UIP_CONF_MAX_CONNECTIONS */
+#define UIP_CONNS (UIP_CONF_MAX_CONNECTIONS)
+#endif /* UIP_CONF_MAX_CONNECTIONS */
+
+
+/**
+ * The maximum number of simultaneously listening TCP ports.
+ *
+ * Each listening TCP port requires 2 bytes of memory.
+ *
+ * \hideinitializer
+ */
+#ifndef UIP_CONF_MAX_LISTENPORTS
+#define UIP_LISTENPORTS 20
+#else /* UIP_CONF_MAX_LISTENPORTS */
+#define UIP_LISTENPORTS (UIP_CONF_MAX_LISTENPORTS)
+#endif /* UIP_CONF_MAX_LISTENPORTS */
+
+/**
+ * Determines if support for TCP urgent data notification should be
+ * compiled in.
+ *
+ * Urgent data (out-of-band data) is a rarely used TCP feature that
+ * very seldom would be required.
+ *
+ * \hideinitializer
+ */
+#define UIP_URGDATA      0
+
+/**
+ * The initial retransmission timeout counted in timer pulses.
+ *
+ * This should not be changed.
+ */
+#define UIP_RTO         3
+
+/**
+ * The maximum number of times a segment should be retransmitted
+ * before the connection should be aborted.
+ *
+ * This should not be changed.
+ */
+#define UIP_MAXRTX      8
+
+/**
+ * The maximum number of times a SYN segment should be retransmitted
+ * before a connection request should be deemed to have been
+ * unsuccessful.
+ *
+ * This should not need to be changed.
+ */
+#define UIP_MAXSYNRTX      5
+
+/**
+ * The TCP maximum segment size.
+ *
+ * This is should not be to set to more than
+ * UIP_BUFSIZE - UIP_LLH_LEN - UIP_TCPIP_HLEN.
+ */
+#ifdef UIP_CONF_TCP_MSS
+#define UIP_TCP_MSS (UIP_CONF_TCP_MSS)
+#else
+#define UIP_TCP_MSS     (UIP_BUFSIZE - UIP_LLH_LEN - UIP_TCPIP_HLEN)
+#endif
+
+/**
+ * The size of the advertised receiver's window.
+ *
+ * Should be set low (i.e., to the size of the uip_buf buffer) if the
+ * application is slow to process incoming data, or high (32768 bytes)
+ * if the application processes data quickly.
+ *
+ * \hideinitializer
+ */
+#ifndef UIP_CONF_RECEIVE_WINDOW
+#define UIP_RECEIVE_WINDOW (UIP_TCP_MSS)
+#else
+#define UIP_RECEIVE_WINDOW (UIP_CONF_RECEIVE_WINDOW)
+#endif
+
+/**
+ * How long a connection should stay in the TIME_WAIT state.
+ *
+ * This can be reduced for faster entry into power saving modes.
+ */
+#ifndef UIP_CONF_WAIT_TIMEOUT
+#define UIP_TIME_WAIT_TIMEOUT 120
+#else
+#define UIP_TIME_WAIT_TIMEOUT UIP_CONF_WAIT_TIMEOUT
+#endif
+
+/** @} */
+/*------------------------------------------------------------------------------*/
+/**
+ * \defgroup uipoptarp ARP configuration options
+ * @{
+ */
+
+/**
+ * The size of the ARP table.
+ *
+ * This option should be set to a larger value if this uIP node will
+ * have many connections from the local network.
+ *
+ * \hideinitializer
+ */
+#ifdef UIP_CONF_ARPTAB_SIZE
+#define UIP_ARPTAB_SIZE (UIP_CONF_ARPTAB_SIZE)
+#else
+#define UIP_ARPTAB_SIZE 8
+#endif
+
+/**
+ * The maximum age of ARP table entries measured in 10ths of seconds.
+ *
+ * An UIP_ARP_MAXAGE of 120 corresponds to 20 minutes (BSD
+ * default).
+ */
+#define UIP_ARP_MAXAGE 120
+
+
+/** @} */
+
+/*------------------------------------------------------------------------------*/
+
+/**
+ * \defgroup uipoptmac layer 2 options (for ipv6)
+ * @{
+ */
+
+#define UIP_DEFAULT_PREFIX_LEN 64
+
+/** @} */
+
+/*------------------------------------------------------------------------------*/
+
+/**
+ * \defgroup uipoptsics 6lowpan options (for ipv6)
+ * @{
+ */
+/**
+ * Timeout for packet reassembly at the 6lowpan layer
+ * (should be < 60s)
+ */
+#ifdef SICSLOWPAN_CONF_MAXAGE
+#define SICSLOWPAN_REASS_MAXAGE (SICSLOWPAN_CONF_MAXAGE)
+#else
+#define SICSLOWPAN_REASS_MAXAGE 20
+#endif
+
+/**
+ * Do we compress the IP header or not (default: no)
+ */
+#ifndef SICSLOWPAN_CONF_COMPRESSION
+#define SICSLOWPAN_CONF_COMPRESSION 0
+#endif
+
+/**
+ * If we use IPHC compression, how many address contexts do we support
+ */
+#ifndef SICSLOWPAN_CONF_MAX_ADDR_CONTEXTS 
+#define SICSLOWPAN_CONF_MAX_ADDR_CONTEXTS 1
+#endif
+
+/**
+ * Do we support 6lowpan fragmentation
+ */
+#ifndef SICSLOWPAN_CONF_FRAG  
+#define SICSLOWPAN_CONF_FRAG  0
+#endif
+
+/** @} */
+
+/*------------------------------------------------------------------------------*/
+
+/**
+ * \defgroup uipoptgeneral General configuration options
+ * @{
+ */
+
+/**
+ * The size of the uIP packet buffer.
+ *
+ * The uIP packet buffer should not be smaller than 60 bytes, and does
+ * not need to be larger than 1514 bytes. Lower size results in lower
+ * TCP throughput, larger size results in higher TCP throughput.
+ *
+ * \hideinitializer
+ */
+#ifndef UIP_CONF_BUFFER_SIZE
+#define UIP_BUFSIZE    1546		//XXX chsc - Orig: UIP_BUFSIZE (UIP_LINK_MTU + UIP_LLH_LEN)
+#else /* UIP_CONF_BUFFER_SIZE */
+#define UIP_BUFSIZE (UIP_CONF_BUFFER_SIZE)
+#endif /* UIP_CONF_BUFFER_SIZE */
+
+
+/**
+ * Determines if statistics support should be compiled in.
+ *
+ * The statistics is useful for debugging and to show the user.
+ *
+ * \hideinitializer
+ */
+#ifndef UIP_CONF_STATISTICS
+#define UIP_STATISTICS  0
+#else /* UIP_CONF_STATISTICS */
+#define UIP_STATISTICS (UIP_CONF_STATISTICS)
+#endif /* UIP_CONF_STATISTICS */
+
+/**
+ * Determines if logging of certain events should be compiled in.
+ *
+ * This is useful mostly for debugging. The function uip_log()
+ * must be implemented to suit the architecture of the project, if
+ * logging is turned on.
+ *
+ * \hideinitializer
+ */
+#ifndef UIP_CONF_LOGGING
+#define UIP_LOGGING     0
+#else /* UIP_CONF_LOGGING */
+#define UIP_LOGGING     (UIP_CONF_LOGGING)
+#endif /* UIP_CONF_LOGGING */
+
+/**
+ * Broadcast support.
+ *
+ * This flag configures IP broadcast support. This is useful only
+ * together with UDP.
+ *
+ * \hideinitializer
+ *
+ */
+#ifndef UIP_CONF_BROADCAST
+#define UIP_BROADCAST 0
+#else /* UIP_CONF_BROADCAST */
+#define UIP_BROADCAST (UIP_CONF_BROADCAST)
+#endif /* UIP_CONF_BROADCAST */
+
+/**
+ * Print out a uIP log message.
+ *
+ * This function must be implemented by the module that uses uIP, and
+ * is called by uIP whenever a log message is generated.
+ */
+void uip_log(char msg[]);
+
+/**
+ * The link level header length.
+ *
+ * This is the offset into the uip_buf where the IP header can be
+ * found. For Ethernet, this should be set to 14. For SLIP, this
+ * should be set to 0.
+ *
+ * \note we probably won't use this constant for other link layers than
+ * ethernet as they have variable header length (this is due to variable
+ * number and type of address fields and to optional security features)
+ * E.g.: 802.15.4 -> 2 + (1/2*4/8) + 0/5/6/10/14
+ *       802.11 -> 4 + (6*3/4) + 2
+ * \hideinitializer
+ */
+#ifdef UIP_CONF_LLH_LEN
+#define UIP_LLH_LEN (UIP_CONF_LLH_LEN)
+#else /* UIP_LLH_LEN */
+#define UIP_LLH_LEN     14
+#endif /* UIP_CONF_LLH_LEN */
+
+/*
+ * Pico]OS: Check alignment and calculate
+ * necessary link-layer header padding
+ * to achive 32-bit alignment for ip headers.
+ */
+#if (UIP_LLH_LEN) % 2 != 0
+#error alignment failure
+#endif
+
+#define UIP_LLH_PAD (UIP_LLH_LEN % 4)
+
+/** @} */
+/*------------------------------------------------------------------------------*/
+/**
+ * \defgroup uipoptcpu CPU architecture configuration
+ * @{
+ *
+ * The CPU architecture configuration is where the endianess of the
+ * CPU on which uIP is to be run is specified. Most CPUs today are
+ * little endian, and the most notable exception are the Motorolas
+ * which are big endian. The BYTE_ORDER macro should be changed to
+ * reflect the CPU architecture on which uIP is to be run.
+ */
+
+/**
+ * The byte order of the CPU architecture on which uIP is to be run.
+ *
+ * This option can be either UIP_BIG_ENDIAN (Motorola byte order) or
+ * UIP_LITTLE_ENDIAN (Intel byte order).
+ *
+ * \hideinitializer
+ */
+#ifdef UIP_CONF_BYTE_ORDER
+#define UIP_BYTE_ORDER     (UIP_CONF_BYTE_ORDER)
+#else /* UIP_CONF_BYTE_ORDER */
+#define UIP_BYTE_ORDER     (UIP_LITTLE_ENDIAN)
+#endif /* UIP_CONF_BYTE_ORDER */
+
+/** @} */
+/*------------------------------------------------------------------------------*/
+
+/**
+ * \defgroup uipoptapp Application specific configurations
+ * @{
+ *
+ * An uIP application is implemented using a single application
+ * function that is called by uIP whenever a TCP/IP event occurs. The
+ * name of this function must be registered with uIP at compile time
+ * using the UIP_APPCALL definition.
+ *
+ * uIP applications can store the application state within the
+ * uip_conn structure by specifying the type of the application
+ * structure by typedef:ing the type uip_tcp_appstate_t and uip_udp_appstate_t.
+ *
+ * The file containing the definitions must be included in the
+ * uipopt.h file.
+ *
+ * The following example illustrates how this can look.
+ \code
+
+ void httpd_appcall(void);
+ #define UIP_APPCALL     httpd_appcall
+
+ struct httpd_state {
+ uint8_t state;
+ uint16_t count;
+ char *dataptr;
+ char *script;
+ };
+ typedef struct httpd_state uip_tcp_appstate_t
+ \endcode
+*/
+
+/**
+ * \var #define UIP_APPCALL
+ *
+ * The name of the application function that uIP should call in
+ * response to TCP/IP events.
+ *
+ */
+
+/**
+ * \var typedef uip_tcp_appstate_t
+ *
+ * The type of the application state that is to be stored in the
+ * uip_conn structure. This usually is typedef:ed to a struct holding
+ * application state information.
+ */
+
+/**
+ * \var typedef uip_udp_appstate_t
+ *
+ * The type of the application state that is to be stored in the
+ * uip_conn structure. This usually is typedef:ed to a struct holding
+ * application state information.
+ */
+/** @} */
+/** @} */
+
+
+#ifdef UIP_CONF_SLIDING_WINDOW
+#define UIP_SLIDING_WINDOW UIP_CONF_SLIDING_WINDOW
+#else
+#define UIP_SLIDING_WINDOW 0
+#endif
+
+#endif /* __UIPOPT_H__ */
+/** @} */
+/** @} */

--- a/module_xtcp/src/xtcp_uip6/contiki/sys/arg.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/sys/arg.c
@@ -1,0 +1,134 @@
+/**
+ * \file
+ * Argument buffer for passing arguments when starting processes
+ * \author Adam Dunkels <adam@dunkels.com>
+ */
+
+/**
+ * \addtogroup sys
+ * @{
+ */
+
+/**
+ * \defgroup arg Argument buffer
+ * @{
+ *
+ * The argument buffer can be used when passing an argument from an
+ * exiting process to a process that has not been created yet. Since
+ * the exiting process will have exited when the new process is
+ * started, the argument cannot be passed in any of the processes'
+ * addres spaces. In such situations, the argument buffer can be used.
+ *
+ * The argument buffer is statically allocated in memory and is
+ * globally accessible to all processes.
+ *
+ * An argument buffer is allocated with the arg_alloc() function and
+ * deallocated with the arg_free() function. The arg_free() function
+ * is designed so that it can take any pointer, not just an argument
+ * buffer pointer. If the pointer to arg_free() is not an argument
+ * buffer, the function does nothing.
+ */
+
+/*
+ * Copyright (c) 2003, Adam Dunkels.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ * 3. The name of the author may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This file is part of the Contiki desktop OS
+ *
+ *
+ */
+#if NO_XMOS_PROJECT
+#include "contiki.h"
+#endif
+#include "sys/arg.h"
+
+/**
+ * \internal Structure used for holding an argument buffer.
+ */
+struct argbuf {
+  char buf[128];
+  char used;
+};
+
+static struct argbuf bufs[1];
+
+/*-----------------------------------------------------------------------------------*/
+/**
+ * \internal Initalizer, called by the dispatcher module.
+ */
+/*-----------------------------------------------------------------------------------*/
+void
+arg_init(void)
+{
+  bufs[0].used = 0;
+}
+/*-----------------------------------------------------------------------------------*/
+/**
+ * Allocates an argument buffer.
+ *
+ * \param size The requested size of the buffer, in bytes.
+ *
+ * \return Pointer to allocated buffer, or NULL if no buffer could be
+ * allocated.
+ *
+ * \note It currently is not possible to allocate argument buffers of
+ * any other size than 128 bytes.
+ *
+ */
+/*-----------------------------------------------------------------------------------*/
+char *
+arg_alloc(char size)
+{
+  if(bufs[0].used == 0) {
+    bufs[0].used = 1;
+    return bufs[0].buf;
+  }
+  return 0;
+}
+/*-----------------------------------------------------------------------------------*/
+/**
+ * Deallocates an argument buffer.
+ *
+ * This function deallocates the argument buffer pointed to by the
+ * parameter, but only if the buffer actually is an argument buffer
+ * and is allocated. It is perfectly safe to call this function with
+ * any pointer.
+ *
+ * \param arg A pointer.
+ */
+/*-----------------------------------------------------------------------------------*/
+void
+arg_free(char *arg)
+{
+  if(arg == bufs[0].buf) {
+    bufs[0].used = 0;
+  }
+}
+/*-----------------------------------------------------------------------------------*/
+/** @} */
+/** @} */

--- a/module_xtcp/src/xtcp_uip6/contiki/sys/arg.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/sys/arg.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2003, Adam Dunkels.
+ * All rights reserved. 
+ *
+ * Redistribution and use in source and binary forms, with or without 
+ * modification, are permitted provided that the following conditions 
+ * are met: 
+ * 1. Redistributions of source code must retain the above copyright 
+ *    notice, this list of conditions and the following disclaimer. 
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution. 
+ * 3. The name of the author may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.  
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+ *
+ * This file is part of the Contiki desktop OS
+ *
+ *
+ */
+#ifndef __ARG_H__
+#define __ARG_H__
+
+void arg_init(void);
+
+char *arg_alloc(char size);
+void arg_free(char *arg);
+
+#endif /* __ARG_H__ */

--- a/module_xtcp/src/xtcp_uip6/contiki/sys/cc.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/sys/cc.h
@@ -1,0 +1,139 @@
+/**
+ * \file
+ * Default definitions of C compiler quirk work-arounds.
+ * \author Adam Dunkels <adam@dunkels.com>
+ *
+ * This file is used for making use of extra functionality of some C
+ * compilers used for Contiki, and defining work-arounds for various
+ * quirks and problems with some other C compilers.
+ */
+
+/*
+ * Copyright (c) 2003, Adam Dunkels.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ * 3. The name of the author may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This file is part of the Contiki desktop OS
+ *
+ *
+ */
+#ifndef __CC_H__
+#define __CC_H__
+
+#include "uip-conf.h"
+
+/**
+ * Configure if the C compiler supports the "register" keyword for
+ * function arguments.
+ */
+#if CC_CONF_REGISTER_ARGS
+#define CC_REGISTER_ARG register
+#else /* CC_CONF_REGISTER_ARGS */
+#define CC_REGISTER_ARG
+#endif /* CC_CONF_REGISTER_ARGS */
+
+/**
+ * Configure if the C compiler supports the arguments for function
+ * pointers.
+ */
+#if CC_CONF_FUNCTION_POINTER_ARGS
+#define CC_FUNCTION_POINTER_ARGS 1
+#else /* CC_CONF_FUNCTION_POINTER_ARGS */
+#define CC_FUNCTION_POINTER_ARGS 0
+#endif /* CC_CONF_FUNCTION_POINTER_ARGS */
+
+/**
+ * Configure if the C compiler supports fastcall function
+ * declarations.
+ */
+#ifdef CC_CONF_FASTCALL
+#define CC_FASTCALL CC_CONF_FASTCALL
+#else /* CC_CONF_FASTCALL */
+#define CC_FASTCALL
+#endif /* CC_CONF_FASTCALL */
+
+/**
+ * Configure if the C compiler have problems with const function pointers
+ */
+#ifdef CC_CONF_CONST_FUNCTION_BUG
+#define CC_CONST_FUNCTION
+#else /* CC_CONF_FASTCALL */
+#define CC_CONST_FUNCTION const
+#endif /* CC_CONF_FASTCALL */
+
+/**
+ * Configure work-around for unsigned char bugs with sdcc.
+ */
+#if CC_CONF_UNSIGNED_CHAR_BUGS
+#define CC_UNSIGNED_CHAR_BUGS 1
+#else /* CC_CONF_UNSIGNED_CHAR_BUGS */
+#define CC_UNSIGNED_CHAR_BUGS 0
+#endif /* CC_CONF_UNSIGNED_CHAR_BUGS */
+
+/**
+ * Configure if C compiler supports double hash marks in C macros.
+ */
+#if CC_CONF_DOUBLE_HASH
+#define CC_DOUBLE_HASH 1
+#else /* CC_CONF_DOUBLE_HASH */
+#define CC_DOUBLE_HASH 0
+#endif /* CC_CONF_DOUBLE_HASH */
+
+#ifdef CC_CONF_INLINE
+#define CC_INLINE CC_CONF_INLINE
+#else /* CC_CONF_INLINE */
+#define CC_INLINE
+#endif /* CC_CONF_INLINE */
+
+/**
+ * Configure if the C compiler supports the assignment of struct value.
+ */
+#ifdef CC_CONF_ASSIGN_AGGREGATE
+#define CC_ASSIGN_AGGREGATE(dest, src)	CC_CONF_ASSIGN_AGGREGATE(dest, src)
+#else /* CC_CONF_ASSIGN_AGGREGATE */
+#define CC_ASSIGN_AGGREGATE(dest, src)	*dest = *src
+#endif /* CC_CONF_ASSIGN_AGGREGATE */
+
+#if CC_CONF_NO_VA_ARGS
+#define CC_NO_VA_ARGS CC_CONF_VA_ARGS
+#endif
+
+#ifndef NULL
+#define NULL 0
+#endif /* NULL */
+
+#define CC_CONCAT2(s1, s2) s1##s2
+/**
+ * A C preprocessing macro for concatenating to
+ * strings.
+ *
+ * We need use two macros (CC_CONCAT and CC_CONCAT2) in order to allow
+ * concatenation of two #defined macros.
+ */
+#define CC_CONCAT(s1, s2) CC_CONCAT2(s1, s2)
+
+#endif /* __CC_H__ */

--- a/module_xtcp/src/xtcp_uip6/contiki/sys/clock.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/sys/clock.h
@@ -1,0 +1,117 @@
+// Copyright (c) 2011, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+
+/**
+ * \defgroup clock Clock interface
+ *
+ * The clock interface is the interface between the \ref timer "timer library"
+ * and the platform specific clock functionality. The clock
+ * interface must be implemented for each platform that uses the \ref
+ * timer "timer library".
+ *
+ * The clock interface does only one this: it measures time. The clock
+ * interface provides a macro, CLOCK_SECOND, which corresponds to one
+ * second of system time.
+ *
+ * \sa \ref timer "Timer library"
+ *
+ * @{
+ */
+
+/*
+ * Copyright (c) 2004, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the uIP TCP/IP stack
+ *
+ * Author: Adam Dunkels <adam@sics.se>
+ *
+ * $Id: clock.h,v 1.3 2006/06/11 21:46:39 adam Exp $
+ */
+#ifndef __CLOCK_H__
+#define __CLOCK_H__
+
+#include "clock-arch.h"
+/**
+ * A second, measured in system clock time.
+ *
+ * \hideinitializer
+ */
+#ifdef CLOCK_CONF_SECOND
+#define CLOCK_SECOND CLOCK_CONF_SECOND
+#else
+#define CLOCK_SECOND (clock_time_t)32
+#endif
+
+/**
+ * Initialize the clock library.
+ *
+ * This function initializes the clock library and should be called
+ * from the main() function of the system.
+ *
+ */
+void clock_init(void);
+
+/**
+ * Get the current clock time.
+ *
+ * This function returns the current system clock time.
+ *
+ * \return The current clock time, measured in system ticks.
+ */
+clock_time_t clock_time(void);
+
+/**
+ * Get the current value of the platform seconds.
+ *
+ * This could be the number of seconds since startup, or
+ * since a standard epoch.
+ *
+ * \return The value.
+ */
+unsigned long clock_seconds(void);
+
+/**
+ * Set the value of the platform seconds.
+ * \param sec   The value to set.
+ *
+ */
+void clock_set_seconds(unsigned long sec);
+
+/**
+ * Update the current system second counter
+ *
+ */
+void upd_clock_seconds(void);
+
+
+#endif /* __CLOCK_H__ */
+
+/** @} */

--- a/module_xtcp/src/xtcp_uip6/contiki/sys/ctimer.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/sys/ctimer.c
@@ -1,0 +1,173 @@
+/**
+ * \addtogroup ctimer
+ * @{
+ */
+
+/*
+ * Copyright (c) 2006, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+/**
+ * \file
+ *         Callback timer implementation
+ * \author
+ *         Adam Dunkels <adam@sics.se>
+ */
+
+#include "sys/ctimer.h"
+#if NO_XMOS_PROJECT
+#include "contiki.h"
+#endif
+#include "lib/list.h"
+
+LIST(ctimer_list);
+
+static char initialized;
+
+#define DEBUG 0
+#if DEBUG
+#include <stdio.h>
+#define PRINTF(...) printf(__VA_ARGS__)
+#else
+#define PRINTF(...)
+#endif
+
+/*---------------------------------------------------------------------------*/
+PROCESS(ctimer_process, "Ctimer process");
+PROCESS_THREAD(ctimer_process, ev, data)
+{
+  struct ctimer *c;
+  PROCESS_BEGIN();
+
+  for(c = list_head(ctimer_list); c != NULL; c = c->next) {
+    etimer_set(&c->etimer, c->etimer.tmr.interval);
+  }
+  initialized = 1;
+
+  while(1) {
+    PROCESS_YIELD_UNTIL(ev == PROCESS_EVENT_TIMER);
+    for(c = list_head(ctimer_list); c != NULL; c = c->next) {
+      if(&c->etimer == data) {
+	list_remove(ctimer_list, c);
+	PROCESS_CONTEXT_BEGIN(c->p);
+	if(c->f != NULL) {
+	  c->f(c->ptr);
+	}
+	PROCESS_CONTEXT_END(c->p);
+	break;
+      }
+    }
+  }
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/
+void
+ctimer_init(void)
+{
+  initialized = 0;
+  list_init(ctimer_list);
+  process_start(&ctimer_process, NULL);
+}
+/*---------------------------------------------------------------------------*/
+void
+ctimer_set(struct ctimer *c, clock_time_t t,
+	   void (*f)(void *), void *ptr)
+{
+  PRINTF("ctimer_set %p %u\n", c, (unsigned)t);
+  c->p = PROCESS_CURRENT();
+  c->f = f;
+  c->ptr = ptr;
+  if(initialized) {
+    PROCESS_CONTEXT_BEGIN(&ctimer_process);
+    etimer_set(&c->etimer, t);
+    PROCESS_CONTEXT_END(&ctimer_process);
+  } else {
+    c->etimer.tmr.interval = t;
+  }
+
+  list_remove(ctimer_list, c);
+  list_add(ctimer_list, c);
+}
+/*---------------------------------------------------------------------------*/
+void
+ctimer_reset(struct ctimer *c)
+{
+  if(initialized) {
+    PROCESS_CONTEXT_BEGIN(&ctimer_process);
+    etimer_reset(&c->etimer);
+    PROCESS_CONTEXT_END(&ctimer_process);
+  }
+
+  list_remove(ctimer_list, c);
+  list_add(ctimer_list, c);
+}
+/*---------------------------------------------------------------------------*/
+void
+ctimer_restart(struct ctimer *c)
+{
+  if(initialized) {
+    PROCESS_CONTEXT_BEGIN(&ctimer_process);
+    etimer_restart(&c->etimer);
+    PROCESS_CONTEXT_END(&ctimer_process);
+  }
+
+  list_remove(ctimer_list, c);
+  list_add(ctimer_list, c);
+}
+/*---------------------------------------------------------------------------*/
+void
+ctimer_stop(struct ctimer *c)
+{
+  if(initialized) {
+    etimer_stop(&c->etimer);
+  } else {
+    c->etimer.next = NULL;
+    c->etimer.p = PROCESS_NONE;
+  }
+  list_remove(ctimer_list, c);
+}
+/*---------------------------------------------------------------------------*/
+int
+ctimer_expired(struct ctimer *c)
+{
+  struct ctimer *t;
+  if(initialized) {
+    return etimer_expired(&c->etimer);
+  }
+  for(t = list_head(ctimer_list); t != NULL; t = t->next) {
+    if(t == c) {
+      return 0;
+    }
+  }
+  return 1;
+}
+/*---------------------------------------------------------------------------*/
+/** @} */

--- a/module_xtcp/src/xtcp_uip6/contiki/sys/ctimer.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/sys/ctimer.h
@@ -1,0 +1,148 @@
+/**
+ * \addtogroup sys
+ * @{
+ */
+
+/**
+ * \defgroup ctimer Callback timer
+ * @{
+ *
+ * The ctimer module provides a timer mechanism that calls a specified
+ * C function when a ctimer expires.
+ *
+ */
+
+/*
+ * Copyright (c) 2006, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+/**
+ * \file
+ *         Header file for the callback timer
+ * \author
+ *         Adam Dunkels <adam@sics.se>
+ */
+
+#ifndef __CTIMER_H__
+#define __CTIMER_H__
+
+#include "sys/etimer.h"
+
+struct ctimer {
+  struct ctimer *next;
+  struct etimer etimer;
+  struct process *p;
+  void (*f)(void *);
+  void *ptr;
+};
+
+/**
+ * \brief      Reset a callback timer with the same interval as was
+ *             previously set.
+ * \param c    A pointer to the callback timer.
+ *
+ *             This function resets the callback timer with the same
+ *             interval that was given to the callback timer with the
+ *             ctimer_set() function. The start point of the interval
+ *             is the exact time that the callback timer last
+ *             expired. Therefore, this function will cause the timer
+ *             to be stable over time, unlike the ctimer_restart()
+ *             function.
+ *
+ * \sa ctimer_restart()
+ */
+void ctimer_reset(struct ctimer *c);
+
+/**
+ * \brief      Restart a callback timer from the current point in time
+ * \param c    A pointer to the callback timer.
+ *
+ *             This function restarts the callback timer with the same
+ *             interval that was given to the ctimer_set()
+ *             function. The callback timer will start at the current
+ *             time.
+ *
+ *             \note A periodic timer will drift if this function is
+ *             used to reset it. For periodic timers, use the
+ *             ctimer_reset() function instead.
+ *
+ * \sa ctimer_reset()
+ */
+void ctimer_restart(struct ctimer *c);
+
+/**
+ * \brief      Set a callback timer.
+ * \param c    A pointer to the callback timer.
+ * \param t    The interval before the timer expires.
+ * \param f    A function to be called when the timer expires.
+ * \param ptr  An opaque pointer that will be supplied as an argument to the callback function.
+ *
+ *             This function is used to set a callback timer for a time
+ *             sometime in the future. When the callback timer expires,
+ *             the callback function f will be called with ptr as argument.
+ *
+ */
+void ctimer_set(struct ctimer *c, clock_time_t t,
+		void (*f)(void *), void *ptr);
+
+/**
+ * \brief      Stop a pending callback timer.
+ * \param c    A pointer to the pending callback timer.
+ *
+ *             This function stops a callback timer that has previously
+ *             been set with ctimer_set(), ctimer_reset(), or ctimer_restart().
+ *             After this function has been called, the callback timer will be
+ *             expired and will not call the callback function.
+ *
+ */
+void ctimer_stop(struct ctimer *c);
+
+/**
+ * \brief      Check if a callback timer has expired.
+ * \param c    A pointer to the callback timer
+ * \return     Non-zero if the timer has expired, zero otherwise.
+ *
+ *             This function tests if a callback timer has expired and
+ *             returns true or false depending on its status.
+ */
+int ctimer_expired(struct ctimer *c);
+
+/**
+ * \brief      Initialize the callback timer library.
+ *
+ *             This function initializes the callback timer library and
+ *             should be called from the system boot up code.
+ */
+void ctimer_init(void);
+
+#endif /* __CTIMER_H__ */
+/** @} */
+/** @} */

--- a/module_xtcp/src/xtcp_uip6/contiki/sys/etimer.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/sys/etimer.c
@@ -1,0 +1,262 @@
+/**
+ * \addtogroup etimer
+ * @{
+ */
+
+/**
+ * \file
+ * Event timer library implementation.
+ * \author
+ * Adam Dunkels <adam@sics.se>
+ */
+
+/*
+ * Copyright (c) 2004, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ * Author: Adam Dunkels <adam@sics.se>
+ *
+ */
+#if NO_XMOS_PROJECT
+#include "contiki-conf.h"
+#endif
+#include "sys/etimer.h"
+#include "sys/process.h"
+
+static struct etimer *timerlist;
+static clock_time_t next_expiration;
+
+PROCESS(etimer_process, "Event timer");
+/*---------------------------------------------------------------------------*/
+static void
+update_time(void)
+{
+  clock_time_t tdist;
+  clock_time_t now;
+  struct etimer *t;
+
+  if (timerlist == NULL) {
+    next_expiration = 0;
+  } else {
+    now = clock_time();
+    t = timerlist;
+    /* Must calculate distance to next time into account due to wraps */
+    tdist = t->tmr.start + t->tmr.interval - now;
+    for(t = t->next; t != NULL; t = t->next) {
+      if(t->tmr.start + t->tmr.interval - now < tdist) {
+	tdist = t->tmr.start + t->tmr.interval - now;
+      }
+    }
+    next_expiration = now + tdist;
+  }
+}
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(etimer_process, ev, data)
+{
+  struct etimer *t, *u;
+	
+  PROCESS_BEGIN();
+
+  timerlist = NULL;
+  
+  while(1) {
+    PROCESS_YIELD();
+
+    if(ev == PROCESS_EVENT_EXITED) {
+      struct process *p = data;
+
+      while(timerlist != NULL && timerlist->p == p) {
+        timerlist = timerlist->next;
+      }
+
+      if(timerlist != NULL) {
+        t = timerlist;
+        while(t->next != NULL) {
+          if(t->next->p == p) {
+            t->next = t->next->next;
+          } else
+            t = t->next;
+        }
+      }
+      continue;
+    } else if(ev != PROCESS_EVENT_POLL) {
+      continue;
+    }
+
+  again:
+    
+    u = NULL;
+    
+    for(t = timerlist; t != NULL; t = t->next) {
+      if(timer_expired(&t->tmr)) {
+        if(process_post(t->p, PROCESS_EVENT_TIMER, t) == PROCESS_ERR_OK) {
+
+          /* Reset the process ID of the event timer, to signal that the
+             etimer has expired. This is later checked in the
+             etimer_expired() function. */
+          t->p = PROCESS_NONE;
+          if(u != NULL) {
+            u->next = t->next;
+          } else {
+            timerlist = t->next;
+          }
+          t->next = NULL;
+          update_time();
+          goto again;
+        } else {
+          etimer_request_poll();
+        }
+      }
+      u = t;
+    }
+  }
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/
+void
+etimer_request_poll(void)
+{
+  process_poll(&etimer_process);
+}
+/*---------------------------------------------------------------------------*/
+static void
+add_timer(struct etimer *timer)
+{
+  struct etimer *t;
+
+  etimer_request_poll();
+
+  if(timer->p != PROCESS_NONE) {
+    for(t = timerlist; t != NULL; t = t->next) {
+      if(t == timer) {
+	/* Timer already on list, bail out. */
+        timer->p = PROCESS_CURRENT();
+	update_time();
+	return;
+      }
+    }
+  }
+
+  /* Timer not on list. */
+  timer->p = PROCESS_CURRENT();
+  timer->next = timerlist;
+  timerlist = timer;
+
+  update_time();
+}
+/*---------------------------------------------------------------------------*/
+void
+etimer_set(struct etimer *et, clock_time_t interval)
+{
+  timer_set(&et->tmr, interval);
+  add_timer(et);
+}
+/*---------------------------------------------------------------------------*/
+void
+etimer_reset(struct etimer *et)
+{
+  timer_reset(&et->tmr);
+  add_timer(et);
+}
+/*---------------------------------------------------------------------------*/
+void
+etimer_restart(struct etimer *et)
+{
+  timer_restart(&et->tmr);
+  add_timer(et);
+}
+/*---------------------------------------------------------------------------*/
+void
+etimer_adjust(struct etimer *et, int timediff)
+{
+  et->tmr.start += timediff;
+  update_time();
+}
+/*---------------------------------------------------------------------------*/
+int
+etimer_expired(struct etimer *et)
+{
+  return et->p == PROCESS_NONE;
+}
+/*---------------------------------------------------------------------------*/
+clock_time_t
+etimer_expiration_time(struct etimer *et)
+{
+  return et->tmr.start + et->tmr.interval;
+}
+/*---------------------------------------------------------------------------*/
+clock_time_t
+etimer_start_time(struct etimer *et)
+{
+  return et->tmr.start;
+}
+/*---------------------------------------------------------------------------*/
+int
+etimer_pending(void)
+{
+  return timerlist != NULL;
+}
+/*---------------------------------------------------------------------------*/
+clock_time_t
+etimer_next_expiration_time(void)
+{
+  return etimer_pending() ? next_expiration : 0;
+}
+/*---------------------------------------------------------------------------*/
+void
+etimer_stop(struct etimer *et)
+{
+  struct etimer *t;
+
+  /* First check if et is the first event timer on the list. */
+  if(et == timerlist) {
+    timerlist = timerlist->next;
+    update_time();
+  } else {
+    /* Else walk through the list and try to find the item before the
+       et timer. */
+    for(t = timerlist; t != NULL && t->next != et; t = t->next);
+
+    if(t != NULL) {
+      /* We've found the item before the event timer that we are about
+	 to remove. We point the items next pointer to the event after
+	 the removed item. */
+      t->next = et->next;
+
+      update_time();
+    }
+  }
+
+  /* Remove the next pointer from the item to be removed. */
+  et->next = NULL;
+  /* Set the timer as expired */
+  et->p = PROCESS_NONE;
+}
+/*---------------------------------------------------------------------------*/
+/** @} */

--- a/module_xtcp/src/xtcp_uip6/contiki/sys/etimer.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/sys/etimer.h
@@ -1,0 +1,242 @@
+/** \addtogroup sys
+ * @{ */
+
+/**
+ * \defgroup etimer Event timers
+ *
+ * Event timers provides a way to generate timed events. An event
+ * timer will post an event to the process that set the timer when the
+ * event timer expires.
+ *
+ * An event timer is declared as a \c struct \c etimer and all access
+ * to the event timer is made by a pointer to the declared event
+ * timer.
+ *
+ * \sa \ref timer "Simple timer library"
+ * \sa \ref clock "Clock library" (used by the timer library)
+ *
+ * @{
+ */
+
+
+/**
+ * \file
+ * Event timer header file.
+ * \author
+ * Adam Dunkels <adam@sics.se>
+ */
+
+/*
+ * Copyright (c) 2004, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ * Author: Adam Dunkels <adam@sics.se>
+ *
+ */
+#ifndef __ETIMER_H__
+#define __ETIMER_H__
+
+#include "sys/timer.h"
+#include "sys/process.h"
+#include <xccompat.h>
+
+/**
+ * A timer.
+ *
+ * This structure is used for declaring a timer. The timer must be set
+ * with etimer_set() before it can be used.
+ *
+ * \hideinitializer
+ */
+struct etimer {
+  struct uip_timer tmr;
+  struct etimer *next;
+  struct process *p;
+};
+
+/**
+ * \name Functions called from application programs
+ * @{
+ */
+
+/**
+ * \brief      Set an event timer.
+ * \param et   A pointer to the event timer
+ * \param interval The interval before the timer expires.
+ *
+ *             This function is used to set an event timer for a time
+ *             sometime in the future. When the event timer expires,
+ *             the event PROCESS_EVENT_TIMER will be posted to the
+ *             process that called the etimer_set() function.
+ *
+ */
+void etimer_set(struct etimer *et, clock_time_t interval);
+
+/**
+ * \brief      Reset an event timer with the same interval as was
+ *             previously set.
+ * \param et   A pointer to the event timer.
+ *
+ *             This function resets the event timer with the same
+ *             interval that was given to the event timer with the
+ *             etimer_set() function. The start point of the interval
+ *             is the exact time that the event timer last
+ *             expired. Therefore, this function will cause the timer
+ *             to be stable over time, unlike the etimer_restart()
+ *             function.
+ *
+ * \sa etimer_restart()
+ */
+void etimer_reset(struct etimer *et);
+
+/**
+ * \brief      Restart an event timer from the current point in time
+ * \param et   A pointer to the event timer.
+ *
+ *             This function restarts the event timer with the same
+ *             interval that was given to the etimer_set()
+ *             function. The event timer will start at the current
+ *             time.
+ *
+ *             \note A periodic timer will drift if this function is
+ *             used to reset it. For periodic timers, use the
+ *             etimer_reset() function instead.
+ *
+ * \sa etimer_reset()
+ */
+void etimer_restart(struct etimer *et);
+
+/**
+ * \brief      Adjust the expiration time for an event timer
+ * \param et   A pointer to the event timer.
+ * \param td   The time difference to adjust the expiration time with.
+ *
+ *             This function is used to adjust the time the event
+ *             timer will expire. It can be used to synchronize
+ *             periodic timers without the need to restart the timer
+ *             or change the timer interval.
+ *
+ *             \note This function should only be used for small
+ *             adjustments. For large adjustments use etimer_set()
+ *             instead.
+ *
+ *             \note A periodic timer will drift unless the
+ *             etimer_reset() function is used.
+ *
+ * \sa etimer_set()
+ * \sa etimer_reset()
+ */
+void etimer_adjust(struct etimer *et, int td);
+
+/**
+ * \brief      Get the expiration time for the event timer.
+ * \param et   A pointer to the event timer
+ * \return     The expiration time for the event timer.
+ *
+ *             This function returns the expiration time for an event timer.
+ */
+clock_time_t etimer_expiration_time(struct etimer *et);
+
+/**
+ * \brief      Get the start time for the event timer.
+ * \param et   A pointer to the event timer
+ * \return     The start time for the event timer.
+ *
+ *             This function returns the start time (when the timer
+ *             was last set) for an event timer.
+ */
+clock_time_t etimer_start_time(struct etimer *et);
+
+/**
+ * \brief      Check if an event timer has expired.
+ * \param et   A pointer to the event timer
+ * \return     Non-zero if the timer has expired, zero otherwise.
+ *
+ *             This function tests if an event timer has expired and
+ *             returns true or false depending on its status.
+ */
+int etimer_expired(struct etimer *et);
+
+/**
+ * \brief      Stop a pending event timer.
+ * \param et   A pointer to the pending event timer.
+ *
+ *             This function stops an event timer that has previously
+ *             been set with etimer_set() or etimer_reset(). After
+ *             this function has been called, the event timer will not
+ *             emit any event when it expires.
+ *
+ */
+void etimer_stop(struct etimer *et);
+
+/** @} */
+
+/**
+ * \name Functions called from timer interrupts, by the system
+ * @{
+ */
+
+/**
+ * \brief      Make the event timer aware that the clock has changed
+ *
+ *             This function is used to inform the event timer module
+ *             that the system clock has been updated. Typically, this
+ *             function would be called from the timer interrupt
+ *             handler when the clock has ticked.
+ */
+void etimer_request_poll(void);
+
+/**
+ * \brief      Check if there are any non-expired event timers.
+ * \return     True if there are active event timers, false if there are
+ *             no active timers.
+ *
+ *             This function checks if there are any active event
+ *             timers that have not expired.
+ */
+int etimer_pending(void);
+
+/**
+ * \brief      Get next event timer expiration time.
+ * \return     Next expiration time of all pending event timers.
+ *             If there are no pending event timers this function
+ *	       returns 0.
+ *
+ *             This functions returns next expiration time of all
+ *             pending event timers.
+ */
+clock_time_t etimer_next_expiration_time(void);
+
+
+/** @} */
+
+PROCESS_NAME(etimer_process);
+#endif /* __ETIMER_H__ */
+/** @} */
+/** @} */

--- a/module_xtcp/src/xtcp_uip6/contiki/sys/lc-addrlabels.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/sys/lc-addrlabels.h
@@ -1,0 +1,88 @@
+// Copyright (c) 2011, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+/*
+ * Copyright (c) 2004-2005, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the uIP TCP/IP stack
+ *
+ * Author: Adam Dunkels <adam@sics.se>
+ *
+ * $Id: lc-addrlabels.h,v 1.3 2006/06/12 08:00:30 adam Exp $
+ */
+
+/**
+ * \addtogroup lc
+ * @{
+ */
+
+/**
+ * \file
+ * Implementation of local continuations based on the "Labels as
+ * values" feature of gcc
+ * \author
+ * Adam Dunkels <adam@sics.se>
+ *
+ * This implementation of local continuations is based on a special
+ * feature of the GCC C compiler called "labels as values". This
+ * feature allows assigning pointers with the address of the code
+ * corresponding to a particular C label.
+ *
+ * For more information, see the GCC documentation:
+ * http://gcc.gnu.org/onlinedocs/gcc/Labels-as-Values.html
+ *
+ * Thanks to dividuum for finding the nice local scope label
+ * implementation.
+ */
+
+#ifndef __LC_ADDRLABELS_H__
+#define __LC_ADDRLABELS_H__
+
+/** \hideinitializer */
+typedef void * lc_t;
+
+#define LC_INIT(s) s = NULL
+
+
+#define LC_RESUME(s)                            \
+  do {                                          \
+    if(s != NULL) {                             \
+      goto *s;                                  \
+    }                                           \
+  } while(0)
+
+#define LC_SET(s)                               \
+  do { ({ __label__ resume; resume: (s) = &&resume; }); }while(0)
+
+#define LC_END(s)
+
+#endif /* __LC_ADDRLABELS_H__ */
+
+/**  @} */

--- a/module_xtcp/src/xtcp_uip6/contiki/sys/lc-switch.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/sys/lc-switch.h
@@ -1,0 +1,82 @@
+// Copyright (c) 2011, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+
+/*
+ * Copyright (c) 2004-2005, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the uIP TCP/IP stack
+ *
+ * Author: Adam Dunkels <adam@sics.se>
+ *
+ * $Id: lc-switch.h,v 1.2 2006/06/12 08:00:30 adam Exp $
+ */
+
+/**
+ * \addtogroup lc
+ * @{
+ */
+
+/**
+ * \file
+ * Implementation of local continuations based on switch() statment
+ * \author Adam Dunkels <adam@sics.se>
+ *
+ * This implementation of local continuations uses the C switch()
+ * statement to resume execution of a function somewhere inside the
+ * function's body. The implementation is based on the fact that
+ * switch() statements are able to jump directly into the bodies of
+ * control structures such as if() or while() statements.
+ *
+ * This implementation borrows heavily from Simon Tatham's coroutines
+ * implementation in C:
+ * http://www.chiark.greenend.org.uk/~sgtatham/coroutines.html
+ */
+
+#ifndef __LC_SWITCH_H__
+#define __LC_SWITCH_H__
+
+/* WARNING! lc implementation using switch() does not work if an
+   LC_SET() is done within another switch() statement! */
+
+/** \hideinitializer */
+typedef unsigned short lc_t;
+
+#define LC_INIT(s) s = 0;
+
+#define LC_RESUME(s) switch(s) { case 0:
+
+#define LC_SET(s) s = __LINE__; case __LINE__:
+
+#define LC_END(s) }
+
+#endif /* __LC_SWITCH_H__ */
+
+/** @} */

--- a/module_xtcp/src/xtcp_uip6/contiki/sys/lc.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/sys/lc.h
@@ -1,0 +1,137 @@
+// Copyright (c) 2011, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+
+/*
+ * Copyright (c) 2004-2005, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the uIP TCP/IP stack
+ *
+ * Author: Adam Dunkels <adam@sics.se>
+ *
+ * $Id: lc.h,v 1.2 2006/06/12 08:00:30 adam Exp $
+ */
+
+/**
+ * \addtogroup pt
+ * @{
+ */
+
+/**
+ * \defgroup lc Local continuations
+ * @{
+ *
+ * Local continuations form the basis for implementing protothreads. A
+ * local continuation can be <i>set</i> in a specific function to
+ * capture the state of the function. After a local continuation has
+ * been set can be <i>resumed</i> in order to restore the state of the
+ * function at the point where the local continuation was set.
+ *
+ *
+ */
+
+/**
+ * \file lc.h
+ * Local continuations
+ * \author
+ * Adam Dunkels <adam@sics.se>
+ *
+ */
+
+#ifdef DOXYGEN
+/**
+ * Initialize a local continuation.
+ *
+ * This operation initializes the local continuation, thereby
+ * unsetting any previously set continuation state.
+ *
+ * \hideinitializer
+ */
+#define LC_INIT(lc)
+
+/**
+ * Set a local continuation.
+ *
+ * The set operation saves the state of the function at the point
+ * where the operation is executed. As far as the set operation is
+ * concerned, the state of the function does <b>not</b> include the
+ * call-stack or local (automatic) variables, but only the program
+ * counter and such CPU registers that needs to be saved.
+ *
+ * \hideinitializer
+ */
+#define LC_SET(lc)
+
+/**
+ * Resume a local continuation.
+ *
+ * The resume operation resumes a previously set local continuation, thus
+ * restoring the state in which the function was when the local
+ * continuation was set. If the local continuation has not been
+ * previously set, the resume operation does nothing.
+ *
+ * \hideinitializer
+ */
+#define LC_RESUME(lc)
+
+/**
+ * Mark the end of local continuation usage.
+ *
+ * The end operation signifies that local continuations should not be
+ * used any more in the function. This operation is not needed for
+ * most implementations of local continuation, but is required by a
+ * few implementations.
+ *
+ * \hideinitializer
+ */
+#define LC_END(lc)
+
+/**
+ * \var typedef lc_t;
+ *
+ * The local continuation type.
+ *
+ * \hideinitializer
+ */
+#endif /* DOXYGEN */
+
+#ifndef __LC_H__
+#define __LC_H__
+
+#ifdef LC_CONF_INCLUDE
+#include LC_CONF_INCLUDE
+#else /* LC_CONF_INCLUDE */
+#include "sys/lc-switch.h"
+#endif /* LC_CONF_INCLUDE */
+
+#endif /* __LC_H__ */
+
+/** @} */
+/** @} */

--- a/module_xtcp/src/xtcp_uip6/contiki/sys/process.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/sys/process.c
@@ -1,0 +1,389 @@
+/*
+ * Copyright (c) 2005, Swedish Institute of Computer Science
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+/**
+ * \addtogroup process
+ * @{
+ */
+
+/**
+ * \file
+ *         Implementation of the Contiki process kernel.
+ * \author
+ *         Adam Dunkels <adam@sics.se>
+ *
+ */
+
+#include <stdio.h>
+
+#include "sys/process.h"
+#include "sys/arg.h"
+
+/*
+ * Pointer to the currently running process structure.
+ */
+struct process *process_list = NULL;
+struct process *process_current = NULL;
+ 
+static process_event_t lastevent;
+
+/*
+ * Structure used for keeping the queue of active events.
+ */
+struct event_data {
+  process_event_t ev;
+  process_data_t data;
+  struct process *p;
+};
+
+static process_num_events_t nevents, fevent;
+static struct event_data events[PROCESS_CONF_NUMEVENTS];
+
+#if PROCESS_CONF_STATS
+process_num_events_t process_maxevents;
+#endif
+
+static volatile unsigned char poll_requested;
+
+#define PROCESS_STATE_NONE        0
+#define PROCESS_STATE_RUNNING     1
+#define PROCESS_STATE_CALLED      2
+
+static void call_process(struct process *p, process_event_t ev, process_data_t data);
+
+#define DEBUG 0
+#if DEBUG
+#include <stdio.h>
+#define PRINTF(...) printf(__VA_ARGS__)
+#else
+#define PRINTF(...)
+#endif
+
+/*---------------------------------------------------------------------------*/
+process_event_t
+process_alloc_event(void)
+{
+  return lastevent++;
+}
+/*---------------------------------------------------------------------------*/
+void
+process_start(struct process *p, const char *arg)
+{
+  struct process *q;
+
+  /* First make sure that we don't try to start a process that is
+     already running. */
+  for(q = process_list; q != p && q != NULL; q = q->next);
+
+  /* If we found the process on the process list, we bail out. */
+  if(q == p) {
+    return;
+  }
+  /* Put on the procs list.*/
+  p->next = process_list;
+  process_list = p;
+  p->state = PROCESS_STATE_RUNNING;
+  PT_INIT(&p->pt);
+
+  PRINTF("process: starting '%s'\n", PROCESS_NAME_STRING(p));
+
+  /* Post a synchronous initialization event to the process. */
+  process_post_synch(p, PROCESS_EVENT_INIT, (process_data_t)arg);
+}
+/*---------------------------------------------------------------------------*/
+static void
+exit_process(struct process *p, struct process *fromprocess)
+{
+  register struct process *q;
+  struct process *old_current = process_current;
+
+  PRINTF("process: exit_process '%s'\n", PROCESS_NAME_STRING(p));
+
+  /* Make sure the process is in the process list before we try to
+     exit it. */
+  for(q = process_list; q != p && q != NULL; q = q->next);
+  if(q == NULL) {
+    return;
+  }
+
+  if(process_is_running(p)) {
+    /* Process was running */
+    p->state = PROCESS_STATE_NONE;
+
+    /*
+     * Post a synchronous event to all processes to inform them that
+     * this process is about to exit. This will allow services to
+     * deallocate state associated with this process.
+     */
+    for(q = process_list; q != NULL; q = q->next) {
+      if(p != q) {
+	call_process(q, PROCESS_EVENT_EXITED, (process_data_t)p);
+      }
+    }
+
+    if(p->thread != NULL && p != fromprocess) {
+      /* Post the exit event to the process that is about to exit. */
+      process_current = p;
+      p->thread(&p->pt, PROCESS_EVENT_EXIT, NULL);
+    }
+  }
+
+  if(p == process_list) {
+    process_list = process_list->next;
+  } else {
+    for(q = process_list; q != NULL; q = q->next) {
+      if(q->next == p) {
+	q->next = p->next;
+	break;
+      }
+    }
+  }
+
+  process_current = old_current;
+}
+/*---------------------------------------------------------------------------*/
+#pragma stackfunction 50 //TODO: CHSC find out, how mutch stack is realy used
+static void
+call_process(struct process *p, process_event_t ev, process_data_t data)
+{
+  int ret;
+
+#if DEBUG
+  if(p->state == PROCESS_STATE_CALLED) {
+    printf("process: process '%s' called again with event %d\n", PROCESS_NAME_STRING(p), ev);
+  }
+#endif /* DEBUG */
+  
+  if((p->state & PROCESS_STATE_RUNNING) &&
+     p->thread != NULL) {
+    PRINTF("process: calling process '%s' with event %d\n", PROCESS_NAME_STRING(p), ev);
+    process_current = p;
+    p->state = PROCESS_STATE_CALLED;
+    ret = p->thread(&p->pt, ev, data);
+    if(ret == PT_EXITED ||
+       ret == PT_ENDED ||
+       ev == PROCESS_EVENT_EXIT) {
+      exit_process(p, p);
+    } else {
+      p->state = PROCESS_STATE_RUNNING;
+    }
+  }
+}
+/*---------------------------------------------------------------------------*/
+void
+process_exit(struct process *p)
+{
+  exit_process(p, PROCESS_CURRENT());
+}
+/*---------------------------------------------------------------------------*/
+void
+process_init(void)
+{
+  lastevent = PROCESS_EVENT_MAX;
+
+  nevents = fevent = 0;
+#if PROCESS_CONF_STATS
+  process_maxevents = 0;
+#endif /* PROCESS_CONF_STATS */
+
+  process_current = process_list = NULL;
+}
+/*---------------------------------------------------------------------------*/
+/*
+ * Call each process' poll handler.
+ */
+/*---------------------------------------------------------------------------*/
+static void
+do_poll(void)
+{
+  struct process *p;
+
+  poll_requested = 0;
+  /* Call the processes that needs to be polled. */
+  for(p = process_list; p != NULL; p = p->next) {
+    if(p->needspoll) {
+      p->state = PROCESS_STATE_RUNNING;
+      p->needspoll = 0;
+      call_process(p, PROCESS_EVENT_POLL, NULL);
+    }
+  }
+}
+/*---------------------------------------------------------------------------*/
+/*
+ * Process the next event in the event queue and deliver it to
+ * listening processes.
+ */
+/*---------------------------------------------------------------------------*/
+static void
+do_event(void)
+{
+  static process_event_t ev;
+  static process_data_t data;
+  static struct process *receiver;
+  static struct process *p;
+  
+  /*
+   * If there are any events in the queue, take the first one and walk
+   * through the list of processes to see if the event should be
+   * delivered to any of them. If so, we call the event handler
+   * function for the process. We only process one event at a time and
+   * call the poll handlers inbetween.
+   */
+
+  if(nevents > 0) {
+    
+    /* There are events that we should deliver. */
+    ev = events[fevent].ev;
+    
+    data = events[fevent].data;
+    receiver = events[fevent].p;
+
+    /* Since we have seen the new event, we move pointer upwards
+       and decrese the number of events. */
+    fevent = (fevent + 1) % PROCESS_CONF_NUMEVENTS;
+    --nevents;
+
+    /* If this is a broadcast event, we deliver it to all events, in
+       order of their priority. */
+    if(receiver == PROCESS_BROADCAST) {
+      for(p = process_list; p != NULL; p = p->next) {
+
+	/* If we have been requested to poll a process, we do this in
+	   between processing the broadcast event. */
+	if(poll_requested) {
+	  do_poll();
+	}
+	call_process(p, ev, data);
+      }
+    } else {
+      /* This is not a broadcast event, so we deliver it to the
+	 specified process. */
+      /* If the event was an INIT event, we should also update the
+	 state of the process. */
+      if(ev == PROCESS_EVENT_INIT) {
+	receiver->state = PROCESS_STATE_RUNNING;
+      }
+
+      /* Make sure that the process actually is running. */
+      call_process(receiver, ev, data);
+    }
+  }
+}
+/*---------------------------------------------------------------------------*/
+int
+process_run(void)
+{
+  /* Process poll events. */
+  if(poll_requested) {
+    do_poll();
+  }
+
+  /* Process one event from the queue */
+  do_event();
+
+  return nevents + poll_requested;
+}
+/*---------------------------------------------------------------------------*/
+int
+process_nevents(void)
+{
+  return nevents + poll_requested;
+}
+/*---------------------------------------------------------------------------*/
+int
+process_post(struct process *p, process_event_t ev, process_data_t data)
+{
+  static process_num_events_t snum;
+
+  if(PROCESS_CURRENT() == NULL) {
+    PRINTF("process_post: NULL process posts event %d to process '%s', nevents %d\n",
+	   ev,PROCESS_NAME_STRING(p), nevents);
+  } else {
+    PRINTF("process_post: Process '%s' posts event %d to process '%s', nevents %d\n",
+	   PROCESS_NAME_STRING(PROCESS_CURRENT()), ev,
+	   p == PROCESS_BROADCAST? "<broadcast>": PROCESS_NAME_STRING(p), nevents);
+  }
+  
+  if(nevents == PROCESS_CONF_NUMEVENTS) {
+#if DEBUG
+    if(p == PROCESS_BROADCAST) {
+      printf("soft panic: event queue is full when broadcast event %d was posted from %s\n", ev, PROCESS_NAME_STRING(process_current));
+    } else {
+      printf("soft panic: event queue is full when event %d was posted to %s frpm %s\n", ev, PROCESS_NAME_STRING(p), PROCESS_NAME_STRING(process_current));
+    }
+#endif /* DEBUG */
+    return PROCESS_ERR_FULL;
+  }
+  
+  snum = (process_num_events_t)(fevent + nevents) % PROCESS_CONF_NUMEVENTS;
+  events[snum].ev = ev;
+  events[snum].data = data;
+  events[snum].p = p;
+  ++nevents;
+
+#if PROCESS_CONF_STATS
+  if(nevents > process_maxevents) {
+    process_maxevents = nevents;
+  }
+#endif /* PROCESS_CONF_STATS */
+  
+  return PROCESS_ERR_OK;
+}
+/*---------------------------------------------------------------------------*/
+void
+process_post_synch(struct process *p, process_event_t ev, process_data_t data)
+{
+  struct process *caller = process_current;
+
+  call_process(p, ev, data);
+  process_current = caller;
+}
+/*---------------------------------------------------------------------------*/
+void
+process_poll(struct process *p)
+{
+  if(p != NULL) {
+    if(p->state == PROCESS_STATE_RUNNING ||
+       p->state == PROCESS_STATE_CALLED) {
+      p->needspoll = 1;
+      poll_requested = 1;
+    }
+  }
+}
+/*---------------------------------------------------------------------------*/
+int
+process_is_running(struct process *p)
+{
+  return p->state != PROCESS_STATE_NONE;
+}
+/*---------------------------------------------------------------------------*/
+/** @} */

--- a/module_xtcp/src/xtcp_uip6/contiki/sys/process.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/sys/process.h
@@ -1,0 +1,531 @@
+/*
+ * Copyright (c) 2005, Swedish Institute of Computer Science
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+/**
+ * \addtogroup sys
+ * @{
+ */
+
+/**
+ * \defgroup process Contiki processes
+ *
+ * A process in Contiki consists of a single \ref pt "protothread".
+ *
+ * @{
+ */
+
+/**
+ * \file
+ * Header file for the Contiki process interface.
+ * \author
+ * Adam Dunkels <adam@sics.se>
+ *
+ */
+#ifndef __PROCESS_H__
+#define __PROCESS_H__
+
+#include "sys/pt.h"
+#include "sys/cc.h"
+#ifndef __XC__
+typedef unsigned char process_event_t;
+typedef void *        process_data_t;
+typedef unsigned char process_num_events_t;
+
+/**
+ * \name Return values
+ * @{
+ */
+
+/**
+ * \brief      Return value indicating that an operation was successful.
+ *
+ *             This value is returned to indicate that an operation
+ *             was successful.
+ */
+#define PROCESS_ERR_OK        0
+/**
+ * \brief      Return value indicating that the event queue was full.
+ *
+ *             This value is returned from process_post() to indicate
+ *             that the event queue was full and that an event could
+ *             not be posted.
+ */
+#define PROCESS_ERR_FULL      1
+/* @} */
+
+#define PROCESS_NONE          NULL
+
+#ifndef PROCESS_CONF_NUMEVENTS
+#define PROCESS_CONF_NUMEVENTS 32
+#endif /* PROCESS_CONF_NUMEVENTS */
+
+#define PROCESS_EVENT_NONE            0x80
+#define PROCESS_EVENT_INIT            0x81
+#define PROCESS_EVENT_POLL            0x82
+#define PROCESS_EVENT_EXIT            0x83
+#define PROCESS_EVENT_SERVICE_REMOVED 0x84
+#define PROCESS_EVENT_CONTINUE        0x85
+#define PROCESS_EVENT_MSG             0x86
+#define PROCESS_EVENT_EXITED          0x87
+#define PROCESS_EVENT_TIMER           0x88
+#define PROCESS_EVENT_COM             0x89
+#define PROCESS_EVENT_MAX             0x8a
+
+#define PROCESS_BROADCAST NULL
+#define PROCESS_ZOMBIE ((struct process *)0x1)
+
+/**
+ * \name Process protothread functions
+ * @{
+ */
+
+/**
+ * Define the beginning of a process.
+ *
+ * This macro defines the beginning of a process, and must always
+ * appear in a PROCESS_THREAD() definition. The PROCESS_END() macro
+ * must come at the end of the process.
+ *
+ * \hideinitializer
+ */
+#define PROCESS_BEGIN()             PT_BEGIN(process_pt)
+
+/**
+ * Define the end of a process.
+ *
+ * This macro defines the end of a process. It must appear in a
+ * PROCESS_THREAD() definition and must always be included. The
+ * process exits when the PROCESS_END() macro is reached.
+ *
+ * \hideinitializer
+ */
+#define PROCESS_END()               PT_END(process_pt)
+
+/**
+ * Wait for an event to be posted to the process.
+ *
+ * This macro blocks the currently running process until the process
+ * receives an event.
+ *
+ * \hideinitializer
+ */
+#define PROCESS_WAIT_EVENT()        PROCESS_YIELD()
+
+/**
+ * Wait for an event to be posted to the process, with an extra
+ * condition.
+ *
+ * This macro is similar to PROCESS_WAIT_EVENT() in that it blocks the
+ * currently running process until the process receives an event. But
+ * PROCESS_WAIT_EVENT_UNTIL() takes an extra condition which must be
+ * true for the process to continue.
+ *
+ * \param c The condition that must be true for the process to continue.
+ * \sa PT_WAIT_UNTIL()
+ *
+ * \hideinitializer
+ */
+#define PROCESS_WAIT_EVENT_UNTIL(c) PROCESS_YIELD_UNTIL(c)
+
+/**
+ * Yield the currently running process.
+ *
+ * \hideinitializer
+ */
+#define PROCESS_YIELD()             PT_YIELD(process_pt)
+
+/**
+ * Yield the currently running process until a condition occurs.
+ *
+ * This macro is different from PROCESS_WAIT_UNTIL() in that
+ * PROCESS_YIELD_UNTIL() is guaranteed to always yield at least
+ * once. This ensures that the process does not end up in an infinite
+ * loop and monopolizing the CPU.
+ *
+ * \param c The condition to wait for.
+ *
+ * \hideinitializer
+ */
+#define PROCESS_YIELD_UNTIL(c)      PT_YIELD_UNTIL(process_pt, c)
+
+/**
+ * Wait for a condition to occur.
+ *
+ * This macro does not guarantee that the process yields, and should
+ * therefore be used with care. In most cases, PROCESS_WAIT_EVENT(),
+ * PROCESS_WAIT_EVENT_UNTIL(), PROCESS_YIELD() or
+ * PROCESS_YIELD_UNTIL() should be used instead.
+ *
+ * \param c The condition to wait for.
+ *
+ * \hideinitializer
+ */
+#define PROCESS_WAIT_UNTIL(c)       PT_WAIT_UNTIL(process_pt, c)
+#define PROCESS_WAIT_WHILE(c)       PT_WAIT_WHILE(process_pt, c)
+
+/**
+ * Exit the currently running process.
+ *
+ * \hideinitializer
+ */
+#define PROCESS_EXIT()              PT_EXIT(process_pt)
+
+/**
+ * Spawn a protothread from the process.
+ *
+ * \param pt The protothread state (struct pt) for the new protothread
+ * \param thread The call to the protothread function.
+ * \sa PT_SPAWN()
+ *
+ * \hideinitializer
+ */
+#define PROCESS_PT_SPAWN(pt, thread)   PT_SPAWN(process_pt, pt, thread)
+
+/**
+ * Yield the process for a short while.
+ *
+ * This macro yields the currently running process for a short while,
+ * thus letting other processes run before the process continues.
+ *
+ * \hideinitializer
+ */
+#define PROCESS_PAUSE()             do {				\
+  process_post(PROCESS_CURRENT(), PROCESS_EVENT_CONTINUE, NULL);	\
+  PROCESS_WAIT_EVENT_UNTIL(ev == PROCESS_EVENT_CONTINUE);               \
+} while(0)
+
+/** @} end of protothread functions */
+
+/**
+ * \name Poll and exit handlers
+ * @{
+ */
+/**
+ * Specify an action when a process is polled.
+ *
+ * \note This declaration must come immediately before the
+ * PROCESS_BEGIN() macro.
+ *
+ * \param handler The action to be performed.
+ *
+ * \hideinitializer
+ */
+#define PROCESS_POLLHANDLER(handler) if(ev == PROCESS_EVENT_POLL) { handler; }
+
+/**
+ * Specify an action when a process exits.
+ *
+ * \note This declaration must come immediately before the
+ * PROCESS_BEGIN() macro.
+ *
+ * \param handler The action to be performed.
+ *
+ * \hideinitializer
+ */
+#define PROCESS_EXITHANDLER(handler) if(ev == PROCESS_EVENT_EXIT) { handler; }
+
+/** @} */
+
+/**
+ * \name Process declaration and definition
+ * @{
+ */
+
+/**
+ * Define the body of a process.
+ *
+ * This macro is used to define the body (protothread) of a
+ * process. The process is called whenever an event occurs in the
+ * system, A process always start with the PROCESS_BEGIN() macro and
+ * end with the PROCESS_END() macro.
+ *
+ * \hideinitializer
+ */
+#define PROCESS_THREAD(name, ev, data) 				\
+static PT_THREAD(process_thread_##name(struct pt *process_pt,	\
+				       process_event_t ev,	\
+				       process_data_t data))
+
+/**
+ * Declare the name of a process.
+ *
+ * This macro is typically used in header files to declare the name of
+ * a process that is implemented in the C file.
+ *
+ * \hideinitializer
+ */
+#define PROCESS_NAME(name) extern struct process name
+
+/**
+ * Declare a process.
+ *
+ * This macro declares a process. The process has two names: the
+ * variable of the process structure, which is used by the C program,
+ * and a human readable string name, which is used when debugging.
+ * A configuration option allows removal of the readable name to save RAM.
+ *
+ * \param name The variable name of the process structure.
+ * \param strname The string representation of the process' name.
+ *
+ * \hideinitializer
+ */
+#if PROCESS_CONF_NO_PROCESS_NAMES
+#define PROCESS(name, strname)				\
+  PROCESS_THREAD(name, ev, data);			\
+  struct process name = { NULL,		        \
+                          process_thread_##name }
+#else
+#define PROCESS(name, strname)				\
+  PROCESS_THREAD(name, ev, data);			\
+  struct process name = { NULL, strname,		\
+                          process_thread_##name }
+#endif
+
+/** @} */
+
+struct process {
+  struct process *next;
+#if PROCESS_CONF_NO_PROCESS_NAMES
+#define PROCESS_NAME_STRING(process) ""
+#else
+  const char *name;
+#define PROCESS_NAME_STRING(process) (process)->name
+#endif
+  PT_THREAD((* thread)(struct pt *, process_event_t, process_data_t));
+  struct pt pt;
+  unsigned char state, needspoll;
+};
+
+/**
+ * \name Functions called from application programs
+ * @{
+ */
+
+/**
+ * Start a process.
+ *
+ * \param p A pointer to a process structure.
+ *
+ * \param arg An argument pointer that can be passed to the new
+ * process
+ *
+ */
+void process_start(struct process *p, const char *arg);
+
+/**
+ * Post an asynchronous event.
+ *
+ * This function posts an asynchronous event to one or more
+ * processes. The handing of the event is deferred until the target
+ * process is scheduled by the kernel. An event can be broadcast to
+ * all processes, in which case all processes in the system will be
+ * scheduled to handle the event.
+ *
+ * \param ev The event to be posted.
+ *
+ * \param data The auxiliary data to be sent with the event
+ *
+ * \param p The process to which the event should be posted, or
+ * PROCESS_BROADCAST if the event should be posted to all processes.
+ *
+ * \retval PROCESS_ERR_OK The event could be posted.
+ *
+ * \retval PROCESS_ERR_FULL The event queue was full and the event could
+ * not be posted.
+ */
+int process_post(struct process *p, process_event_t ev, void* data);
+
+/**
+ * Post a synchronous event to a process.
+ *
+ * \param p A pointer to the process' process structure.
+ *
+ * \param ev The event to be posted.
+ *
+ * \param data A pointer to additional data that is posted together
+ * with the event.
+ */
+void process_post_synch(struct process *p,
+			     process_event_t ev, void* data);
+
+/**
+ * \brief      Cause a process to exit
+ * \param p    The process that is to be exited
+ *
+ *             This function causes a process to exit. The process can
+ *             either be the currently executing process, or another
+ *             process that is currently running.
+ *
+ * \sa PROCESS_CURRENT()
+ */
+void process_exit(struct process *p);
+
+
+/**
+ * Get a pointer to the currently running process.
+ *
+ * This macro get a pointer to the currently running
+ * process. Typically, this macro is used to post an event to the
+ * current process with process_post().
+ *
+ * \hideinitializer
+ */
+#define PROCESS_CURRENT() process_current
+extern struct process *process_current;
+
+/**
+ * Switch context to another process
+ *
+ * This function switch context to the specified process and executes
+ * the code as if run by that process. Typical use of this function is
+ * to switch context in services, called by other processes. Each
+ * PROCESS_CONTEXT_BEGIN() must be followed by the
+ * PROCESS_CONTEXT_END() macro to end the context switch.
+ *
+ * Example:
+ \code
+ PROCESS_CONTEXT_BEGIN(&test_process);
+ etimer_set(&timer, CLOCK_SECOND);
+ PROCESS_CONTEXT_END(&test_process);
+ \endcode
+ *
+ * \param p    The process to use as context
+ *
+ * \sa PROCESS_CONTEXT_END()
+ * \sa PROCESS_CURRENT()
+ */
+#define PROCESS_CONTEXT_BEGIN(p) {\
+struct process *tmp_current = PROCESS_CURRENT();\
+process_current = p
+
+/**
+ * End a context switch
+ *
+ * This function ends a context switch and changes back to the
+ * previous process.
+ *
+ * \param p    The process used in the context switch
+ *
+ * \sa PROCESS_CONTEXT_START()
+ */
+#define PROCESS_CONTEXT_END(p) process_current = tmp_current; }
+
+/**
+ * \brief      Allocate a global event number.
+ * \return     The allocated event number
+ *
+ *             In Contiki, event numbers above 128 are global and may
+ *             be posted from one process to another. This function
+ *             allocates one such event number.
+ *
+ * \note       There currently is no way to deallocate an allocated event
+ *             number.
+ */
+process_event_t process_alloc_event(void);
+
+/** @} */
+
+/**
+ * \name Functions called from device drivers
+ * @{
+ */
+
+/**
+ * Request a process to be polled.
+ *
+ * This function typically is called from an interrupt handler to
+ * cause a process to be polled.
+ *
+ * \param p A pointer to the process' process structure.
+ */
+void process_poll(struct process *p);
+#endif /* __XC__ */
+/** @} */
+
+/**
+ * \name Functions called by the system and boot-up code
+ * @{
+ */
+
+/**
+ * \brief      Initialize the process module.
+ *
+ *             This function initializes the process module and should
+ *             be called by the system boot-up code.
+ */
+void process_init(void);
+
+/**
+ * Run the system once - call poll handlers and process one event.
+ *
+ * This function should be called repeatedly from the main() program
+ * to actually run the Contiki system. It calls the necessary poll
+ * handlers, and processes one event. The function returns the number
+ * of events that are waiting in the event queue so that the caller
+ * may choose to put the CPU to sleep when there are no pending
+ * events.
+ *
+ * \return The number of events that are currently waiting in the
+ * event queue.
+ */
+int process_run(void);
+
+#ifndef __XC__
+/**
+ * Check if a process is running.
+ *
+ * This function checks if a specific process is running.
+ *
+ * \param p The process.
+ * \retval Non-zero if the process is running.
+ * \retval Zero if the process is not running.
+ */
+int process_is_running(struct process *p);
+
+/**
+ *  Number of events waiting to be processed.
+ *
+ * \return The number of events that are currently waiting to be
+ * processed.
+ */
+int process_nevents(void);
+
+/** @} */
+
+extern struct process *process_list;
+
+#define PROCESS_LIST() process_list
+#endif /* __XC__ */
+#endif /* __PROCESS_H__ */
+
+/** @} */
+/** @} */

--- a/module_xtcp/src/xtcp_uip6/contiki/sys/pt.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/sys/pt.h
@@ -1,0 +1,322 @@
+/*
+ * Copyright (c) 2004-2005, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ * Author: Adam Dunkels <adam@sics.se>
+ *
+ */
+
+/**
+ * \addtogroup pt
+ * @{
+ */
+
+/**
+ * \file
+ * Protothreads implementation.
+ * \author
+ * Adam Dunkels <adam@sics.se>
+ *
+ */
+
+#ifndef __PT_H__
+#define __PT_H__
+
+#include "sys/lc.h"
+
+struct pt {
+  lc_t lc;
+};
+
+#define PT_WAITING 0
+#define PT_YIELDED 1
+#define PT_EXITED  2
+#define PT_ENDED   3
+
+/**
+ * \name Initialization
+ * @{
+ */
+
+/**
+ * Initialize a protothread.
+ *
+ * Initializes a protothread. Initialization must be done prior to
+ * starting to execute the protothread.
+ *
+ * \param pt A pointer to the protothread control structure.
+ *
+ * \sa PT_SPAWN()
+ *
+ * \hideinitializer
+ */
+#define PT_INIT(pt)   LC_INIT((pt)->lc)
+
+/** @} */
+
+/**
+ * \name Declaration and definition
+ * @{
+ */
+
+/**
+ * Declaration of a protothread.
+ *
+ * This macro is used to declare a protothread. All protothreads must
+ * be declared with this macro.
+ *
+ * \param name_args The name and arguments of the C function
+ * implementing the protothread.
+ *
+ * \hideinitializer
+ */
+#define PT_THREAD(name_args) char name_args
+
+/**
+ * Declare the start of a protothread inside the C function
+ * implementing the protothread.
+ *
+ * This macro is used to declare the starting point of a
+ * protothread. It should be placed at the start of the function in
+ * which the protothread runs. All C statements above the PT_BEGIN()
+ * invokation will be executed each time the protothread is scheduled.
+ *
+ * \param pt A pointer to the protothread control structure.
+ *
+ * \hideinitializer
+ */
+#define PT_BEGIN(pt) { char PT_YIELD_FLAG = 1; if (PT_YIELD_FLAG) {;} LC_RESUME((pt)->lc)
+
+/**
+ * Declare the end of a protothread.
+ *
+ * This macro is used for declaring that a protothread ends. It must
+ * always be used together with a matching PT_BEGIN() macro.
+ *
+ * \param pt A pointer to the protothread control structure.
+ *
+ * \hideinitializer
+ */
+#define PT_END(pt) LC_END((pt)->lc); PT_YIELD_FLAG = 0; \
+                   PT_INIT(pt); return PT_ENDED; }
+
+/** @} */
+
+/**
+ * \name Blocked wait
+ * @{
+ */
+
+/**
+ * Block and wait until condition is true.
+ *
+ * This macro blocks the protothread until the specified condition is
+ * true.
+ *
+ * \param pt A pointer to the protothread control structure.
+ * \param condition The condition.
+ *
+ * \hideinitializer
+ */
+#define PT_WAIT_UNTIL(pt, condition)	        \
+  do {						\
+    LC_SET((pt)->lc);				\
+    if(!(condition)) {				\
+      return PT_WAITING;			\
+    }						\
+  } while(0)
+
+/**
+ * Block and wait while condition is true.
+ *
+ * This function blocks and waits while condition is true. See
+ * PT_WAIT_UNTIL().
+ *
+ * \param pt A pointer to the protothread control structure.
+ * \param cond The condition.
+ *
+ * \hideinitializer
+ */
+#define PT_WAIT_WHILE(pt, cond)  PT_WAIT_UNTIL((pt), !(cond))
+
+/** @} */
+
+/**
+ * \name Hierarchical protothreads
+ * @{
+ */
+
+/**
+ * Block and wait until a child protothread completes.
+ *
+ * This macro schedules a child protothread. The current protothread
+ * will block until the child protothread completes.
+ *
+ * \note The child protothread must be manually initialized with the
+ * PT_INIT() function before this function is used.
+ *
+ * \param pt A pointer to the protothread control structure.
+ * \param thread The child protothread with arguments
+ *
+ * \sa PT_SPAWN()
+ *
+ * \hideinitializer
+ */
+#define PT_WAIT_THREAD(pt, thread) PT_WAIT_WHILE((pt), PT_SCHEDULE(thread))
+
+/**
+ * Spawn a child protothread and wait until it exits.
+ *
+ * This macro spawns a child protothread and waits until it exits. The
+ * macro can only be used within a protothread.
+ *
+ * \param pt A pointer to the protothread control structure.
+ * \param child A pointer to the child protothread's control structure.
+ * \param thread The child protothread with arguments
+ *
+ * \hideinitializer
+ */
+#define PT_SPAWN(pt, child, thread)		\
+  do {						\
+    PT_INIT((child));				\
+    PT_WAIT_THREAD((pt), (thread));		\
+  } while(0)
+
+/** @} */
+
+/**
+ * \name Exiting and restarting
+ * @{
+ */
+
+/**
+ * Restart the protothread.
+ *
+ * This macro will block and cause the running protothread to restart
+ * its execution at the place of the PT_BEGIN() call.
+ *
+ * \param pt A pointer to the protothread control structure.
+ *
+ * \hideinitializer
+ */
+#define PT_RESTART(pt)				\
+  do {						\
+    PT_INIT(pt);				\
+    return PT_WAITING;			\
+  } while(0)
+
+/**
+ * Exit the protothread.
+ *
+ * This macro causes the protothread to exit. If the protothread was
+ * spawned by another protothread, the parent protothread will become
+ * unblocked and can continue to run.
+ *
+ * \param pt A pointer to the protothread control structure.
+ *
+ * \hideinitializer
+ */
+#define PT_EXIT(pt)				\
+  do {						\
+    PT_INIT(pt);				\
+    return PT_EXITED;			\
+  } while(0)
+
+/** @} */
+
+/**
+ * \name Calling a protothread
+ * @{
+ */
+
+/**
+ * Schedule a protothread.
+ *
+ * This function schedules a protothread. The return value of the
+ * function is non-zero if the protothread is running or zero if the
+ * protothread has exited.
+ *
+ * \param f The call to the C function implementing the protothread to
+ * be scheduled
+ *
+ * \hideinitializer
+ */
+#define PT_SCHEDULE(f) ((f) < PT_EXITED)
+
+/** @} */
+
+/**
+ * \name Yielding from a protothread
+ * @{
+ */
+
+/**
+ * Yield from the current protothread.
+ *
+ * This function will yield the protothread, thereby allowing other
+ * processing to take place in the system.
+ *
+ * \param pt A pointer to the protothread control structure.
+ *
+ * \hideinitializer
+ */
+#define PT_YIELD(pt)				\
+  do {						\
+    PT_YIELD_FLAG = 0;				\
+    LC_SET((pt)->lc);				\
+    if(PT_YIELD_FLAG == 0) {			\
+      return PT_YIELDED;			\
+    }						\
+  } while(0)
+
+/**
+ * \brief      Yield from the protothread until a condition occurs.
+ * \param pt   A pointer to the protothread control structure.
+ * \param cond The condition.
+ *
+ *             This function will yield the protothread, until the
+ *             specified condition evaluates to true.
+ *
+ *
+ * \hideinitializer
+ */
+#define PT_YIELD_UNTIL(pt, cond)		\
+  do {						\
+    PT_YIELD_FLAG = 0;				\
+    LC_SET((pt)->lc);				\
+    if((PT_YIELD_FLAG == 0) || !(cond)) {	\
+      return PT_YIELDED;			\
+    }						\
+  } while(0)
+
+/** @} */
+
+#endif /* __PT_H__ */
+
+/** @} */

--- a/module_xtcp/src/xtcp_uip6/contiki/sys/stimer.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/sys/stimer.c
@@ -1,0 +1,164 @@
+/**
+ * \addtogroup stimer
+ * @{
+ */
+
+/**
+ * \file
+ * Timer of seconds library implementation.
+ * \author
+ * Adam Dunkels <adam@sics.se>, Nicolas Tsiftes <nvt@sics.se>
+ */
+
+/*
+ * Copyright (c) 2004, 2008, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ * Author: Adam Dunkels <adam@sics.se>, Nicolas Tsiftes <nvt@sics.se>
+ *
+ */
+#if NO_XMOS_PROJECT
+#include "contiki-conf.h"
+#endif
+#include "sys/clock.h"
+#include "sys/stimer.h"
+
+#define SCLOCK_GEQ(a, b)	((unsigned long)((a) - (b)) < \
+				((unsigned long)(~((unsigned long)0)) >> 1))
+
+/*---------------------------------------------------------------------------*/
+/**
+ * Set a timer.
+ *
+ * This function is used to set a timer for a time sometime in the
+ * future. The function stimer_expired() will evaluate to true after
+ * the timer has expired.
+ *
+ * \param t A pointer to the timer
+ * \param interval The interval before the timer expires.
+ *
+ */
+void
+stimer_set(struct stimer *t, unsigned long interval)
+{
+  t->interval = interval;
+  t->start = clock_seconds();
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * Reset the timer with the same interval.
+ *
+ * This function resets the timer with the same interval that was
+ * given to the stimer_set() function. The start point of the interval
+ * is the exact time that the timer last expired. Therefore, this
+ * function will cause the timer to be stable over time, unlike the
+ * stimer_restart() function.
+ *
+ * \param t A pointer to the timer.
+ *
+ * \sa stimer_restart()
+ */
+void
+stimer_reset(struct stimer *t)
+{
+  t->start += t->interval;
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * Restart the timer from the current point in time
+ *
+ * This function restarts a timer with the same interval that was
+ * given to the stimer_set() function. The timer will start at the
+ * current time.
+ *
+ * \note A periodic timer will drift if this function is used to reset
+ * it. For preioric timers, use the stimer_reset() function instead.
+ *
+ * \param t A pointer to the timer.
+ *
+ * \sa stimer_reset()
+ */
+void
+stimer_restart(struct stimer *t)
+{
+  t->start = clock_seconds();
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * Check if a timer has expired.
+ *
+ * This function tests if a timer has expired and returns true or
+ * false depending on its status.
+ *
+ * \param t A pointer to the timer
+ *
+ * \return Non-zero if the timer has expired, zero otherwise.
+ *
+ */
+int
+stimer_expired(struct stimer *t)
+{
+  return SCLOCK_GEQ(clock_seconds(), t->start + t->interval);
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * The time until the timer expires
+ *
+ * This function returns the time until the timer expires.
+ *
+ * \param t A pointer to the timer
+ *
+ * \return The time until the timer expires
+ *
+ */
+unsigned long
+stimer_remaining(struct stimer *t)
+{
+  return t->start + t->interval - clock_seconds();
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * The time elapsed since the timer started
+ *
+ * This function returns the time elapsed.
+ *
+ * \param t A pointer to the timer
+ *
+ * \return The time elapsed since the last start of the timer
+ *
+ */
+unsigned long
+stimer_elapsed(struct stimer *t)
+{
+  return clock_seconds() - t->start;
+}
+
+/*---------------------------------------------------------------------------*/
+
+/** @} */

--- a/module_xtcp/src/xtcp_uip6/contiki/sys/stimer.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/sys/stimer.h
@@ -1,0 +1,97 @@
+/** \addtogroup sys
+ * @{ */
+
+/**
+ * \defgroup stimer Seconds timer library
+ *
+ * The stimer library provides functions for setting, resetting and
+ * restarting timers, and for checking if a timer has expired. An
+ * application must "manually" check if its timers have expired; this
+ * is not done automatically.
+ *
+ * A timer is declared as a \c struct \c stimer and all access to the
+ * timer is made by a pointer to the declared timer.
+ *
+ * \note The stimer library is not able to post events when a timer
+ * expires. The \ref etimer "Event timers" should be used for this
+ * purpose.
+ *
+ * \note The stimer library uses the \ref clock "Clock library" to
+ * measure time. Intervals should be specified in the seconds.
+ *
+ * \sa \ref etimer "Event timers"
+ *
+ * @{
+ */
+
+
+/**
+ * \file
+ * Second timer library header file.
+ * \author
+ * Adam Dunkels <adam@sics.se>, Nicolas Tsiftes <nvt@sics.se>
+ */
+
+/*
+ * Copyright (c) 2004, 2008, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ * Author: Adam Dunkels <adam@sics.se>, Nicolas Tsiftes <nvt@sics.se>
+ *
+ */
+#ifndef __STIMER_H__
+#define __STIMER_H__
+
+#include "sys/clock.h"
+
+/**
+ * A timer.
+ *
+ * This structure is used for declaring a timer. The timer must be set
+ * with stimer_set() before it can be used.
+ *
+ * \hideinitializer
+ */
+struct stimer {
+  unsigned long start;
+  unsigned long interval;
+};
+
+void stimer_set(struct stimer *t, unsigned long interval);
+void stimer_reset(struct stimer *t);
+void stimer_restart(struct stimer *t);
+int stimer_expired(struct stimer *t);
+unsigned long stimer_remaining(struct stimer *t);
+unsigned long stimer_elapsed(struct stimer *t);
+
+
+#endif /* __STIMER_H__ */
+
+/** @} */
+/** @} */

--- a/module_xtcp/src/xtcp_uip6/contiki/sys/timer.c
+++ b/module_xtcp/src/xtcp_uip6/contiki/sys/timer.c
@@ -1,0 +1,153 @@
+// Copyright (c) 2011, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+
+
+/**
+ * \addtogroup timer
+ * @{
+ */
+
+/**
+ * \file
+ * Timer library implementation.
+ * \author
+ * Adam Dunkels <adam@sics.se>
+ */
+
+/*
+ * Copyright (c) 2004, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the uIP TCP/IP stack
+ *
+ * Author: Adam Dunkels <adam@sics.se>
+ *
+ * $Id: timer.c,v 1.2 2006/06/12 08:00:30 adam Exp $
+ */
+#if NO_XMOS_PROJECT
+#include "contiki-conf.h"
+#endif
+#include "sys/clock.h"
+#include "sys/timer.h"
+
+/*---------------------------------------------------------------------------*/
+/**
+ * Set a timer.
+ *
+ * This function is used to set a timer for a time sometime in the
+ * future. The function timer_expired() will evaluate to true after
+ * the timer has expired.
+ *
+ * \param t A pointer to the timer
+ * \param interval The interval before the timer expires.
+ *
+ */
+void
+timer_set(struct uip_timer *t, clock_time_t interval)
+{
+  t->interval = interval;
+  t->start = clock_time();
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * Reset the timer with the same interval.
+ *
+ * This function resets the timer with the same interval that was
+ * given to the timer_set() function. The start point of the interval
+ * is the exact time that the timer last expired. Therefore, this
+ * function will cause the timer to be stable over time, unlike the
+ * timer_restart() function.
+ *
+ * \param t A pointer to the timer.
+ *
+ * \sa timer_restart()
+ */
+void
+timer_reset(struct uip_timer *t)
+{
+  t->start += t->interval;
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * Restart the timer from the current point in time
+ *
+ * This function restarts a timer with the same interval that was
+ * given to the timer_set() function. The timer will start at the
+ * current time.
+ *
+ * \note A periodic timer will drift if this function is used to reset
+ * it. For preioric timers, use the timer_reset() function instead.
+ *
+ * \param t A pointer to the timer.
+ *
+ * \sa timer_reset()
+ */
+void
+timer_restart(struct uip_timer *t)
+{
+  t->start = clock_time();
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * Check if a timer has expired.
+ *
+ * This function tests if a timer has expired and returns true or
+ * false depending on its status.
+ *
+ * \param t A pointer to the timer
+ *
+ * \return Non-zero if the timer has expired, zero otherwise.
+ *
+ */
+int
+timer_expired(struct uip_timer *t)
+{
+  return (clock_time_t)(clock_time() - t->start) >= (clock_time_t)t->interval;
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * The time until the timer expires
+ *
+ * This function returns the time until the timer expires.
+ *
+ * \param t A pointer to the timer
+ *
+ * \return The time until the timer expires
+ *
+ */
+clock_time_t
+timer_remaining(struct uip_timer *t)
+{
+  return t->start + t->interval - clock_time();
+}
+
+/*---------------------------------------------------------------------------*/
+
+/** @} */

--- a/module_xtcp/src/xtcp_uip6/contiki/sys/timer.h
+++ b/module_xtcp/src/xtcp_uip6/contiki/sys/timer.h
@@ -1,0 +1,94 @@
+// Copyright (c) 2011, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+
+/**
+ * \defgroup timer Timer library
+ *
+ * The timer library provides functions for setting, resetting and
+ * restarting timers, and for checking if a timer has expired. An
+ * application must "manually" check if its timers have expired; this
+ * is not done automatically.
+ *
+ * A timer is declared as a \c struct \c timer and all access to the
+ * timer is made by a pointer to the declared timer.
+ *
+ * \note The timer library uses the \ref clock "Clock library" to
+ * measure time. Intervals should be specified in the format used by
+ * the clock library.
+ *
+ * @{
+ */
+
+
+/**
+ * \file
+ * Timer library header file.
+ * \author
+ * Adam Dunkels <adam@sics.se>
+ */
+
+/*
+ * Copyright (c) 2004, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the uIP TCP/IP stack
+ *
+ * Author: Adam Dunkels <adam@sics.se>
+ *
+ * $Id: timer.h,v 1.3 2006/06/11 21:46:39 adam Exp $
+ */
+#ifndef __TIMER_H__
+#define __TIMER_H__
+
+#include "clock.h"
+
+/**
+ * A timer.
+ *
+ * This structure is used for declaring a timer. The timer must be set
+ * with timer_set() before it can be used.
+ *
+ * \hideinitializer
+ */
+struct uip_timer {
+  clock_time_t start;
+  clock_time_t interval;
+};
+
+#ifndef __XC__
+void timer_set(struct uip_timer *t, clock_time_t interval);
+void timer_reset(struct uip_timer *t);
+void timer_restart(struct uip_timer *t);
+int timer_expired(struct uip_timer *t);
+#endif
+
+#endif /* __TIMER_H__ */
+
+/** @} */

--- a/module_xtcp/src/xtcp_uip6/uip-conf.h
+++ b/module_xtcp/src/xtcp_uip6/uip-conf.h
@@ -1,0 +1,278 @@
+// Copyright (c) 2011, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+/**
+ * \addtogroup uipopt
+ * @{
+ */
+
+/**
+ * \name Project-specific configuration options
+ * @{
+ *
+ * uIP has a number of configuration options that can be overridden
+ * for each project. These are kept in a project-specific uip-conf.h
+ * file and all configuration names have the prefix UIP_CONF.
+ */
+
+/*
+ * Copyright (c) 2006, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the uIP TCP/IP stack
+ *
+ * $Id: uip-conf.h,v 1.6 2006/06/12 08:00:31 adam Exp $
+ */
+
+/**
+ * \file
+ *         An example uIP configuration file
+ * \author
+ *         Adam Dunkels <adam@sics.se>
+ */
+
+#ifndef __UIP_CONF_H__
+#define __UIP_CONF_H__
+
+#include <stdint.h>
+
+#include "xtcp_conf_derived.h"
+#include "xtcp_client.h"
+
+#ifndef XTCP_CLIENT_BUF_SIZE
+#define XTCP_CLIENT_BUF_SIZE (1472)
+#endif
+
+/**
+ * 8 bit datatype
+ *
+ * This typedef defines the 8-bit type used throughout uIP.
+ *
+ * \hideinitializer
+ */
+typedef uint8_t u8_t;
+
+/**
+ * 16 bit datatype
+ *
+ * This typedef defines the 16-bit type used throughout uIP.
+ *
+ * \hideinitializer
+ */
+typedef uint16_t u16_t;
+
+/**
+ * 32 bit datatype
+ *
+ * This typedef defines the 32-bit type used throughout uIP.
+ *
+ * \hideinitializer
+ */
+typedef uint32_t u32_t;
+
+/**
+ * Statistics datatype
+ *
+ * This typedef defines the dataype used for keeping statistics in
+ * uIP.
+ *
+ * \hideinitializer
+ */
+typedef unsigned short uip_stats_t;
+
+/**
+ * Maximum number of TCP connections.
+ *
+ * \hideinitializer
+ */
+#ifndef UIP_CONF_MAX_CONNECTIONS
+#define UIP_CONF_MAX_CONNECTIONS 10
+#endif
+
+/**
+ * Maximum number of listening TCP ports.
+ *
+ * \hideinitializer
+ */
+#ifndef UIP_CONF_MAX_LISTENPORTS
+#define UIP_CONF_MAX_LISTENPORTS 10
+#endif
+
+/**
+ * uIP buffer size.
+ *
+ * \hideinitializer
+ */
+#define UIP_CONF_BUFFER_SIZE     (XTCP_CLIENT_BUF_SIZE + UIP_LLH_LEN + UIP_TCPIP_HLEN)
+
+/**
+ * CPU byte order.
+ *
+ * \hideinitializer
+ */
+#define UIP_CONF_BYTE_ORDER      LITTLE_ENDIAN
+
+/**
+ * Logging on or off
+ *
+ * \hideinitializer
+ */
+#ifndef UIP_CONF_LOGGING 
+#define UIP_CONF_LOGGING        0
+#endif
+
+#define UIP_CONF_BROADCAST		1
+
+/**
+ * UDP support on or off
+ *
+ * \hideinitializer
+ */
+#define UIP_CONF_UDP             1
+
+/**
+ * UDP checksums on or off
+ *
+ * \hideinitializer
+ */
+#define UIP_CONF_UDP_CHECKSUMS   0
+
+/**
+ * uIP statistics on or off
+ *
+ * \hideinitializer
+ */
+#ifndef UIP_CONF_STATISTICS
+#define UIP_CONF_STATISTICS      0
+#endif
+
+#if !defined(UIP_CONF_RECEIVE_WINDOW) && defined(XTCP_MAX_RECEIVE_SIZE)
+#define UIP_CONF_RECEIVE_WINDOW XTCP_MAX_RECEIVE_SIZE
+#endif
+
+
+#define UIP_CONF_EXTERNAL_BUFFER     1
+
+#ifndef UIP_USE_AUTOIP
+#define UIP_USE_AUTOIP           0
+#endif
+
+#ifndef UIP_USE_DHCP
+#define UIP_USE_DHCP             0
+#endif
+
+#ifndef UIP_IGMP
+#define UIP_IGMP                 0
+#endif
+
+#ifndef UIP_CONF_ICMP6
+#define UIP_CONF_ICMP6           1
+#endif
+
+#ifndef RIMEADDR_CONF_SIZE
+#define RIMEADDR_CONF_SIZE       8
+#endif
+
+#include "xtcp_server.h"
+
+typedef struct xtcpd_state_t uip_tcp_appstate_t;
+typedef struct xtcpd_state_t uip_udp_appstate_t;
+
+void xtcpd_appcall(void);
+/* UIP_APPCALL: the name of the application function. This function
+   must return void and take no arguments (i.e., C type "void
+   appfunc(void)"). */
+#ifndef UIP_APPCALL
+#define UIP_APPCALL     xtcpd_appcall
+#endif
+
+#ifndef UIP_UDP_APPCALL
+#define UIP_UDP_APPCALL xtcpd_appcall
+#endif
+
+void xtcpd_icmp6_call(uint8_t type);
+#ifndef UIP_ICMP6_APPCALL
+#define UIP_ICMP6_APPCALL xtcpd_icmp6_call
+#endif
+
+#if XTCP_ENABLE_PARTIAL_PACKET_ACK
+#define UIP_CONF_SLIDING_WINDOW 1
+#endif
+
+/* ARP is not used in IPv6  */
+#define UIP_CONF_ARPTAB_SIZE		1
+
+/*Boolean flags*/
+#define UIP_CONF_IPV6				1
+#define UIP_CONF_IPV6_CHECKS		1
+#define UIP_CONF_IPV6_QUEUE_PKT		0
+#define UIP_CONF_IPV6_REASSEMBLY	0
+/*Integer flags*/
+#define UIP_NETIF_MAX_ADDRESSES 	3
+#define UIP_ND6_MAX_PREFIXES   		3
+#define UIP_ND6_MAX_NEIGHBORS   	4
+#define UIP_ND6_MAX_DEFROUTER  		2
+
+/* Aligne the uIP buffer. The problem is, that
+ * if Ethernet is used, the Ethernet header
+ * forces to shift the buffer by two bytes, otherwise
+ * the following data structs are no more 32bit aligned. */
+#define BUF_32BIT_ALIGN				1	// CHSC XMOS 2013
+
+/*
+ * Override uip_add32 (32-bit addition)
+ */
+#define UIP_ARCH_ADD32 							1
+
+/*
+ * Override Contiki's checksum mechanisms by architecture-specific ones
+ */
+#define UIP_ARCH_CHKSUM 						1
+
+/*
+ * If the RPL protocol is needed, enable it here.
+ *
+ * rfc6550 - IPv6 Routing Protocol for Low-Power and Lossy Networks
+ */
+#define UIP_CONF_IPV6_RPL                       0
+
+/* Here we include the header file for the application(s) we use in
+   our project. */
+/*#include "smtp.h"*/
+/*#include "hello-world.h"*/
+/*#include "telnetd.h"*/
+/*#include "webserver.h"*/
+/*#include "dhcpc.h" */
+/*#include "resolv.h"*/
+/*#include "webclient.h"*/
+
+#endif /* __UIP_CONF_H__ */
+
+/** @} */
+/** @} */

--- a/module_xtcp/src/xtcp_uip6/uip_arch/clock-arch.h
+++ b/module_xtcp/src/xtcp_uip6/uip_arch/clock-arch.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2011, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+/*
+ * Copyright (c) 2006, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the uIP TCP/IP stack
+ *
+ * $Id: clock-arch.h,v 1.2 2006/06/12 08:00:31 adam Exp $
+ */
+
+#ifndef __CLOCK_ARCH_H__
+#define __CLOCK_ARCH_H__
+
+typedef int clock_time_t;
+#define CLOCK_CONF_SECOND 1000
+
+#endif /* __CLOCK_ARCH_H__ */

--- a/module_xtcp/src/xtcp_uip6/uip_arch/clock-arch.xc
+++ b/module_xtcp/src/xtcp_uip6/uip_arch/clock-arch.xc
@@ -1,0 +1,103 @@
+// Copyright (c) 2011, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+/*
+ * Copyright (c) 2006, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the uIP TCP/IP stack
+ *
+ * $Id: clock-arch.c,v 1.2 2006/06/12 08:00:31 adam Exp $
+ */
+
+/**
+ * \file
+ *         Implementation of architecture-specific clock functionality
+ * \author
+ *         Adam Dunkels <adam@sics.se>
+ */
+
+#include "clock-arch.h"
+#include <print.h>
+
+/* This assumes that this is called within 10s periods */
+static int init = 1;
+static int time = 0;
+static unsigned int prev_timestamp = 0;
+
+static unsigned long clock_second = 0;	// system clock seconds. Used as timebase for stimer
+
+/*---------------------------------------------------------------------------*/
+clock_time_t
+clock_time(void)
+{
+  timer tmr;
+  unsigned t;
+
+  tmr :> t;
+  t = t - (t % 100000);
+
+  if (init) {
+    time = 0;
+    init = 0;
+  }
+  else {
+    unsigned diff = (signed) t - (signed) prev_timestamp;
+    time += diff/100000;    
+  }    
+
+  prev_timestamp = t;
+  return time;
+
+#if 0
+  struct timeval tv;
+  struct timezone tz;
+
+  gettimeofday(&tv, &tz);
+
+  return tv.tv_sec * 1000 + tv.tv_usec / 1000;
+#endif
+}
+
+/*---------------------------------------------------------------------------*/
+/* This function has to be called every second */
+void upd_clock_seconds(void){
+	clock_second++;
+}
+
+/* Set system time base. */
+void clock_set_seconds(unsigned long sec){
+	clock_second = sec;
+}
+
+unsigned long clock_seconds(void){
+	return clock_second;
+}
+
+/*---------------------------------------------------------------------------*/

--- a/module_xtcp/src/xtcp_uip6/uip_arch/uip_arch.c
+++ b/module_xtcp/src/xtcp_uip6/uip_arch/uip_arch.c
@@ -1,0 +1,136 @@
+/*****************************************************************************
+*
+* Filename:         uip_arch.c
+* Author:           Christian Schlittler
+* Version:          1.0
+* Creation date:	03.10.2013
+*
+* Copyright:        Christian Schlittler, christian.schlittler@gmx.ch
+*
+* Project:			XMOS and 6LoWPAN
+* Target:			XMOS sliceKIT with RFSlice extension
+* Compiler:        
+*
+* -----------------------------------------------------------------------------
+*
+* History:
+*
+* -----------------------------------------------------------------------------
+*
+* Usage:
+*
+**************************************************************************** */
+
+#include <xclib.h>
+#include "uip_arch.h"
+
+#include <uip.h>
+
+#if UIP_CONF_LOGGING
+#include <print.h>
+#define PRINTSTR    printstr
+#define PRINTSTRLN  printstrln
+#else
+#define     PRINTSTR(...)
+#define     PRINTSTRLN(...)
+#endif
+
+void uip_log(char msg[]){
+    PRINTSTR("uIP log message: ");
+    PRINTSTRLN(msg);
+}
+
+/* Useful operations on 4-byte words misaligned by 2 */
+void xtcp_swap_words(uint8_t* a, uint8_t* b)
+{
+	short c;
+
+	c = *(short*)(&a[0]);
+	*(short*)(&a[0]) = *(short*)(&b[0]);
+	*(short*)(&b[0]) = (short)c;
+
+	c = *(short*)(&a[2]);
+	*(short*)(&a[2]) = *(short*)(&b[2]);
+	*(short*)(&b[2]) = (short)c;
+}
+
+void xuip_ip4addr_copy(uip_ip4addr_t *src, uip_ip4addr_t *dst){
+	xtcp_swap_words(src->u8, dst->u8);
+}
+
+void xtcp_increment_word(uint8_t* a)
+{
+	unsigned s = ((*(short*)(&a[2])) << 16) + *(short*)(&a[0]);
+	s = byterev(byterev(s)+1);
+	*(short*)(&a[0]) = (short)s;
+	*(short*)(&a[2]) = (short)(s >> 16);
+}
+
+__attribute__ ((noinline))
+void xtcp_copy_word(uint8_t* d, uint8_t* s)
+{
+	*(short*)(&d[0]) = *(short*)(&s[0]);
+	*(short*)(&d[2]) = *(short*)(&s[2]);
+}
+
+__attribute__ ((noinline))
+int xtcp_compare_words(const uint8_t* a, const uint8_t* b)
+{
+	return (*(short*)(&a[0]) == *(short*)(&b[0])) &&
+		   (*(short*)(&a[2]) == *(short*)(&b[2]));
+}
+
+int xuip_ipaddr_cmp(uip_ip4addr_t *a, uip_ip4addr_t *b){
+	return xtcp_compare_words(a->u8, b->u8);
+}
+
+#if UIP_SLIDING_WINDOW
+static int xtcp_get_word(const u8_t *a) {
+  unsigned int aw = ((*(unsigned short*)(&a[2])) << 16) + *(unsigned short*)(&a[0]);
+  return byterev(aw);
+}
+/*static void xtcp_put_word(const u8_t *a, unsigned int s) {
+  *(short*)(&a[0]) = (short)s;
+  *(short*)(&a[2]) = (short)(s >> 16);
+  }*/
+
+#endif
+
+/* -----------------------------------------------------------------------------
+ *
+ *  Alternative faster uip_addition
+ *
+ * -------------------------------------------------------------------------- */
+extern uint8_t uip_acc32[4];		// located in uip6.c
+__attribute__ ((noinline))
+void uip_add32(uint8_t *op32, uint16_t op16) {
+	  unsigned int *res = (unsigned int *)uip_acc32;
+	  unsigned int x = ((*(unsigned short*)(&op32[2])) << 16) + *(unsigned short*)(&op32[0]);
+	  x = byterev(x);
+	  *res = byterev(x + op16);
+}
+
+/* -----------------------------------------------------------------------------
+ *
+ *  Alternative faster checksum computation
+ *
+ * -------------------------------------------------------------------------- */
+
+static int onesReduce(unsigned int sum, int carry) {
+    sum = (sum & 0xffff) + (sum >> 16) + carry;
+    return (sum & 0xffff) + (sum >> 16);
+}
+
+uint16_t chksum(uint16_t sum, const uint8_t *byte_data, uint16_t lengthInBytes) {
+    int i;
+    short* data = (short*)byte_data;
+    unsigned s = sum;
+    for(i = 0; i < (lengthInBytes>>1); i++) {
+        s += byterev(data[i]) >> 16;
+    }
+    if (lengthInBytes & 1) {
+        s += byte_data[2*i] << 8;
+    }
+    sum = onesReduce(s, 0);
+    return sum;
+}

--- a/module_xtcp/src/xtcp_uip6/uip_arch/uip_arch.h
+++ b/module_xtcp/src/xtcp_uip6/uip_arch/uip_arch.h
@@ -1,0 +1,105 @@
+// Copyright (c) 2011, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+
+/**
+ * \addtogroup uip
+ * {@
+ */
+
+/**
+ * \defgroup uiparch Architecture specific uIP functions
+ * @{
+ *
+ * The functions in the architecture specific module implement the IP
+ * check sum and 32-bit additions.
+ *
+ * The IP checksum calculation is the most computationally expensive
+ * operation in the TCP/IP stack and it therefore pays off to
+ * implement this in efficient assembler. The purpose of the uip-arch
+ * module is to let the checksum functions to be implemented in
+ * architecture specific assembler.
+ *
+ */
+
+/**
+ * \file
+ * Declarations of architecture specific functions.
+ * \author Adam Dunkels <adam@dunkels.com>
+ */
+
+/*
+ * Copyright (c) 2001, Adam Dunkels.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This file is part of the uIP TCP/IP stack.
+ *
+ * $Id: uip_arch.h,v 1.2 2006/06/07 09:15:19 adam Exp $
+ *
+ */
+
+#ifndef __UIP_ARCH_H__
+#define __UIP_ARCH_H__
+
+#include <stdint.h>
+
+/**
+ * Carry out a 32-bit addition.
+ *
+ * Because not all architectures for which uIP is intended has native
+ * 32-bit arithmetic, uIP uses an external C function for doing the
+ * required 32-bit additions in the TCP protocol processing. This
+ * function should add the two arguments and place the result in the
+ * global variable uip_acc32.
+ *
+ * \note The 32-bit integer pointed to by the op32 parameter and the
+ * result in the uip_acc32 variable are in network byte order (big
+ * endian).
+ *
+ * \param op32 A pointer to a 4-byte array representing a 32-bit
+ * integer in network byte order (big endian).
+ *
+ * \param op16 A 16-bit integer in host byte order.
+ */
+void uip_add32(uint8_t *op32, uint16_t op16);
+
+/* Alternative faster checksum computation */
+uint16_t chksum(uint16_t sum, const uint8_t *byte_data, uint16_t lengthInBytes);
+
+void xtcp_copy_word(uint8_t*d, uint8_t* s);
+
+void xtcp_swap_words(uint8_t* a, uint8_t* b);
+
+int xtcp_compare_words(const uint8_t* a, const uint8_t* b);
+
+void xtcp_increment_word(uint8_t* a);
+/** @} */
+/** @} */
+
+#endif /* __UIP_ARCH_H__ */

--- a/module_xtcp/src/xtcp_uip6/uip_server.c
+++ b/module_xtcp/src/xtcp_uip6/uip_server.c
@@ -1,0 +1,100 @@
+// Copyright (c) 2011, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+#include <print.h>
+#include <xccompat.h>
+#include <string.h>
+
+#include "xtcp_conf_derived.h"
+
+#ifndef UIP_USE_SINGLE_THREADED_ETHERNET
+
+#include "uip.h"
+#include "uip_arp.h"
+#include "xcoredev.h"
+#include "xtcp_server.h"
+#include "timer.h"
+#include "uip_server.h"
+#include "ethernet_rx_client.h"
+#include "ethernet_tx_client.h"
+#include "uip_xtcp.h"
+
+// Functions from the uip_server_support file
+extern void uip_printip4(const uip_ipaddr_t ip4);
+extern void uip_server_init(chanend xtcp[], int num_xtcp, xtcp_ipconfig_t* ipconfig, unsigned char mac_address[6]);
+extern void xtcpd_check_connection_poll(chanend mac_tx);
+extern void xtcp_tx_buffer(chanend mac_tx);
+extern void xtcp_process_incoming_packet(chanend mac_tx);
+extern void xtcp_process_udp_acks(chanend mac_tx);
+extern void xtcp_process_periodic_timer(chanend mac_tx);
+
+
+// Global variables from the uip_server_support file
+extern int uip_static_ip;
+extern xtcp_ipconfig_t uip_static_ipconfig;
+
+#if XTCP_SEPARATE_MAC
+
+void xtcp_server_uip(chanend mac_rx, chanend mac_tx, chanend xtcp[], int num_xtcp,
+                     xtcp_ipconfig_t *ipconfig) {
+
+	struct uip_timer periodic_timer, arp_timer, autoip_timer;
+	unsigned char hwaddr[6];
+
+	timer_set(&periodic_timer, CLOCK_SECOND / 10);
+	timer_set(&autoip_timer, CLOCK_SECOND / 2);
+	timer_set(&arp_timer, CLOCK_SECOND * 10);
+
+	xcoredev_init(mac_rx, mac_tx);
+
+	mac_get_macaddr(mac_tx, hwaddr);
+
+	uip_server_init(xtcp, num_xtcp, ipconfig, hwaddr);
+
+	// Main uIP service loop
+	while (1)
+	{
+		xtcpd_service_clients(xtcp, num_xtcp);
+
+		xtcpd_check_connection_poll(mac_tx);
+
+		xtcpd_uip_checkstate();
+		uip_len = xcoredev_read(mac_rx, UIP_CONF_BUFFER_SIZE);
+		if (uip_len > 0) {
+			xtcp_process_incoming_packet(mac_tx);
+		}
+
+		xtcp_process_udp_acks(mac_tx);
+
+
+		if (timer_expired(&arp_timer)) {
+			timer_reset(&arp_timer);
+			uip_arp_timer();
+		}
+
+#if UIP_USE_AUTOIP
+		if (timer_expired(&autoip_timer)) {
+			timer_reset(&autoip_timer);
+			autoip_periodic();
+			if (uip_len > 0) {
+				xtcp_tx_buffer(mac_tx);
+			}
+		}
+#endif
+
+		if (timer_expired(&periodic_timer)) {
+
+			xtcp_process_periodic_timer(mac_tx);
+
+			timer_reset(&periodic_timer);
+		}
+
+	}
+	return;
+}
+
+#endif // XTCP_SEPARATE_MAC
+
+#endif

--- a/module_xtcp/src/xtcp_uip6/uip_server.h
+++ b/module_xtcp/src/xtcp_uip6/uip_server.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2011, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+#ifndef _uip_server_h_
+#define _uip_server_h_
+#include <xccompat.h>
+#include "xtcp_client.h"
+
+/**  uIP based xtcp server.
+ *
+ *  \param mac_rx           Rx channel connected to ethernet server
+ *  \param mac_tx           Tx channel connected to ethernet server
+ *  \param xtcp             Client channel array
+ *  \param num_xtcp_clients The number of clients connected to the server
+ *  \param ipconfig         An data structure representing the IP config 
+ *                          (ip address, netmask and gateway) of the device.
+ *                          Leave NULL for automatic address allocation.
+ *
+ *  This function implements an xtcp tcp/ip server in a logical core.
+ *  It uses a port of the uIP stack which is then interfaces over the
+ *  xtcp channel array.
+ *
+ *  The IP setup is based on the ipconfig parameter. If this
+ *  parameter is NULL then an automatic IP address is found (using dhcp or
+ *  ipv4 link local addressing if no dhcp server is present). Otherwise
+ *  it uses the ipconfig structure to allocate a static ip address.
+ * 
+ *  The clients can communicate with the server using the API found 
+ *  in xtcp_client.h 
+ *
+ *  \sa  xtcp_event()
+ **/
+void
+xtcp_server_uip(chanend mac_rx,
+                chanend mac_tx,
+                chanend xtcp[],
+                int num_xtcp_clients,
+                NULLABLE_REFERENCE_PARAM(xtcp_ipconfig_t,ipconfig));
+
+#define uip_server xtcp_server_uip
+
+#endif // _uip_server_h_

--- a/module_xtcp/src/xtcp_uip6/uip_server_support.c
+++ b/module_xtcp/src/xtcp_uip6/uip_server_support.c
@@ -1,0 +1,751 @@
+// Copyright (c) 2011, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+#include <xccompat.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "uip_server_support.h"
+#include "uip_arp.h"
+#include "uip_xtcp.h"
+
+#include "sys/etimer.h"
+#include "sys/ctimer.h"
+#include "sys/process.h"
+#include "net/rime/rimeaddr.h"
+#include "uip.h"
+
+#include "contiki-net.h"
+#include "net/uip-split.h"
+#include "net/uip-packetqueue.h"
+
+#if UIP_CONF_IPV6
+#include "net/uip-nd6.h"
+#include "net/uip-ds6.h"
+#endif /* UIP_CONF_IPV6 */
+
+#if UIP_CONF_IPV6_RPL
+#include "rpl/rpl.h"
+#endif /* UIP_CONF_IPV6_RPL */
+
+#include "xcoredev.h"
+
+#define DEBUG DEBUG_NONE
+#include "net/uip-debug.h"
+
+#if UIP_LOGGING == 1
+#include <stdio.h>
+void uip_log(char *msg);
+#define UIP_LOG(m) uip_log(m)
+#else
+#define UIP_LOG(m)
+#endif
+
+#if !defined(UIP_CONF_IPV4) && !defined(UIP_CONF_IPV6)
+#error Unkown IP protocoll version
+#endif
+
+/* -----------------------------------------------------------------------------
+ * This is the buffer where TCP constructs its packets
+ * -------------------------------------------------------------------------- */
+// unsigned int uip_buf32[(UIP_BUFSIZE + 5) >> 2]; //XXX chsc: XMOS original.
+//#define BUF ((struct uip_eth_hdr *)&uip_buf[0])
+
+uip_buf_t uip_aligned_buf;
+
+#define BUF ((struct uip_eth_hdr *)&uip_buf16(0))
+#define TCPBUF ((struct uip_tcpip_hdr *)&uip_buf[UIP_LLH_LEN])
+
+#if !BUF_32BIT_ALIGN //ORIGINAL
+#define UIP_ICMP_BUF ((struct uip_icmp_hdr *)&uip_buf[UIP_LLIPH_LEN + uip_ext_len])
+#define UIP_IP_BUF ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN])
+#define UIP_TCP_BUF ((struct uip_tcpip_hdr *)&uip_buf[UIP_LLH_LEN])
+#else
+#define UIP_ICMP_BUF ((struct uip_icmp_hdr *)&uip_buf32(UIP_LLIPH_LEN + uip_ext_len))
+#define UIP_IP_BUF ((struct uip_ip_hdr *)&uip_buf32(UIP_LLH_LEN))
+#define UIP_TCP_BUF ((struct uip_tcpip_hdr *)&uip_buf32(UIP_LLH_LEN))
+#endif
+
+#ifdef XTCP_VERBOSE_DEBUG
+#if UIP_CONF_IPV4
+__attribute__ ((noinline)) void uip_printip4(const uip_ipaddr_t ip4) {
+	printf("%i.%i.%i.%i\n",uip_ipaddr1(ip4), uip_ipaddr2(ip4), uip_ipaddr3(ip4), uip_ipaddr4(ip4));
+}
+#endif
+#endif
+
+
+int uip_static_ip = 0;
+xtcp_ipconfig_t uip_static_ipconfig;
+static int dhcp_done = 0;
+
+/* -----------------------------------------------------------------------------
+ * Functions prototypes
+ * -------------------------------------------------------------------------- */
+
+
+
+/* -----------------------------------------------------------------------------
+ *
+ * Function implementation
+ *
+ * -------------------------------------------------------------------------- */
+
+/* -----------------------------------------------------------------------------
+ *
+ * -------------------------------------------------------------------------- */
+
+
+void xtcp_tx_buffer(chanend mac_tx) {
+	uip_split_output(mac_tx);
+	uip_len = 0;
+}
+
+
+static int needs_poll(xtcpd_state_t *s)
+{
+  return (s->s.connect_request | s->s.send_request | s->s.abort_request | s->s.close_request | s->s.ack_request);
+}
+
+static int uip_conn_needs_poll(struct uip_conn *uip_conn)
+{
+  xtcpd_state_t *s = (xtcpd_state_t *) &(uip_conn->appstate);
+  return needs_poll(s);
+}
+
+static int uip_udp_conn_needs_poll(struct uip_udp_conn *uip_udp_conn)
+{
+  xtcpd_state_t *s = (xtcpd_state_t *) &(uip_udp_conn->appstate);
+  return needs_poll(s);
+}
+
+/* -----------------------------------------------------------------------------
+ *
+ * -------------------------------------------------------------------------- */
+
+void xtcpd_check_connection_poll(chanend mac_tx)
+{
+	for (int i = 0; i < UIP_CONNS; i++) {
+		if (uip_conn_needs_poll(&uip_conns[i])) {
+			uip_poll_conn(&uip_conns[i]);
+#if UIP_CONF_IPV6
+            xtcpip_ipv6_output(mac_tx);
+#else /* UIP_CONF_IPV6 */
+            if (uip_len > 0) {
+                uip_arp_out( NULL);
+                xtcp_tx_buffer(mac_tx);
+            }
+#endif /* UIP_CONF_IPV6 */
+		}
+	}
+
+	for (int i = 0; i < UIP_UDP_CONNS; i++) {
+		if (uip_udp_conn_needs_poll(&uip_udp_conns[i])) {
+			uip_udp_periodic(i);
+#if UIP_CONF_IPV6
+             xtcpip_ipv6_output(mac_tx);
+#else
+            if (uip_len > 0) {
+                uip_arp_out(&uip_udp_conns[i]);
+                xtcp_tx_buffer(mac_tx);
+            }
+#endif
+		}
+	}
+}
+
+void xtcp_process_udp_acks(chanend mac_tx)
+{
+	for (int i = 0; i < UIP_UDP_CONNS; i++) {
+		if (uip_udp_conn_has_ack(&uip_udp_conns[i])) {
+			uip_udp_ackdata(i);
+			if (uip_len > 0) {
+#if UIP_CONF_IPV4
+				uip_arp_out(&uip_udp_conns[i]);
+				xtcp_tx_buffer(mac_tx);
+#endif
+#if UIP_CONF_IPV6
+// #warning "Implementation is missing"
+#endif
+			}
+		}
+	}
+}
+
+/* -----------------------------------------------------------------------------
+ * \brief      Deliver an incoming packet to the TCP/IP stack
+ *
+ *             This function is called by theServer to
+ *             deliver an incoming packet to the TCP/IP stack. The
+ *             incoming packet must be present in the uip_buf buffer,
+ *             and the length of the packet must be in the global
+ *             uip_len variable.
+ * -------------------------------------------------------------------------- */
+void xtcpip_input(chanend mac_tx)
+{
+/*_______________*/
+#if UIP_CONF_IPV4 /* ORIGINAL_XMOS */
+	if (BUF->type == htons(UIP_ETHTYPE_IP)) {
+		uip_arp_ipin();
+		uip_input();
+		if (uip_len > 0) {
+			if (uip_udpconnection()
+				&& (TCPBUF->proto != UIP_PROTO_ICMP)
+				&& (TCPBUF->proto != UIP_PROTO_IGMP))
+				uip_arp_out( uip_udp_conn);
+			else
+				uip_arp_out( NULL);
+			xtcp_tx_buffer(mac_tx);
+		}
+	} else if (BUF->type == htons(UIP_ETHTYPE_ARP)) {
+		uip_arp_arpin();
+
+		if (uip_len > 0) {
+			xtcp_tx_buffer(mac_tx);
+		}
+		for (int i = 0; i < UIP_UDP_CONNS; i++) {
+			uip_udp_arp_event(i);
+			if (uip_len > 0) {
+				uip_arp_out(&uip_udp_conns[i]);
+				xtcp_tx_buffer(mac_tx);
+			}
+		}
+	}
+#endif /* UIP_CONF_IPV4 ORIGINAL_XMOS */
+/*_______________*/
+	/* contiki tcpip.c */
+#if UIP_CONF_IP_FORWARD
+  if(uip_len > 0) {
+    tcpip_is_forwarding = 1;
+    if(uip_fw_forward() == UIP_FW_LOCAL) {
+      tcpip_is_forwarding = 0;
+      check_for_tcp_syn();
+      uip_input();
+      if(uip_len > 0) {
+#if UIP_CONF_TCP_SPLIT
+        uip_split_output(mac_tx);
+#else /* UIP_CONF_TCP_SPLIT */
+#if UIP_CONF_IPV6
+        xtcpip_ipv6_output(mac_tx);
+#else
+	PRINTF("tcpip packet_input forward output len %d\n", uip_len);
+        xtcpip_output(mac_tx);
+#endif
+#endif /* UIP_CONF_TCP_SPLIT */
+      }
+    }
+    tcpip_is_forwarding = 0;
+  }
+#else /* UIP_CONF_IP_FORWARD */
+  if(uip_len > 0) {
+    uip_input();
+    if(uip_len > 0) {
+#if UIP_CONF_TCP_SPLIT
+      uip_split_output(mac_tx);
+#else /* UIP_CONF_TCP_SPLIT */
+#if UIP_CONF_IPV6
+      xtcpip_ipv6_output(mac_tx);
+#else
+      PRINTF("tcpip packet_input output len %d\n", uip_len);
+      tcpip_output();
+#endif
+#endif /* UIP_CONF_TCP_SPLIT */
+    }
+  }
+#endif /* UIP_CONF_IP_FORWARD */
+}
+
+
+/* -----------------------------------------------------------------------------
+ * Output packet to layer 2
+ * The eventual parameter is the MAC address of the destination.
+ * -------------------------------------------------------------------------- */
+#if UIP_CONF_IPV6
+uint8_t
+xtcpip_output(uip_lladdr_t *lladdr, chanend mac_tx)
+{
+  /*
+   * If L3 dest is multicast, build L2 multicast address
+   * as per RFC 2464 section 7
+   * else fill with the addrsess in argument
+   */
+  if(lladdr == NULL) {
+	/* the dest must be multicast */
+	  (&BUF->dest)->addr[0] = 0x33;
+	  (&BUF->dest)->addr[1] = 0x33;
+	  (&BUF->dest)->addr[2] = UIP_TCP_BUF->destipaddr.u8[12];
+	  (&BUF->dest)->addr[3] = UIP_TCP_BUF->destipaddr.u8[13];
+	  (&BUF->dest)->addr[4] = UIP_TCP_BUF->destipaddr.u8[14];
+	  (&BUF->dest)->addr[5] = UIP_TCP_BUF->destipaddr.u8[15];
+  } else {
+	  memcpy(&BUF->dest, lladdr, UIP_LLADDR_LEN);
+  }
+
+  memcpy(&BUF->src, &uip_lladdr, UIP_LLADDR_LEN);
+  BUF->type = UIP_HTONS(UIP_ETHTYPE_IPV6);
+
+  uip_len += sizeof(struct uip_eth_hdr);
+  xcoredev_send(mac_tx);
+  return 0;
+}
+#endif
+
+#if UIP_CONF_IPV4
+uint8_t
+xtcpip_output(chanend mac_tx){
+
+}
+#endif /* UIP_CONF_IPV4 */
+
+/* -----------------------------------------------------------------------------
+ * This function does address resolution and then calls xtcpip_output
+ * ---------------------------------------------------------------------------*/
+#if UIP_CONF_IPV6
+void
+xtcpip_ipv6_output(chanend mac_tx)
+{
+	uip_ds6_nbr_t *nbr = NULL;
+	uip_ipaddr_t *nexthop;
+
+	if(uip_len == 0) {
+		return;
+	}
+
+	if(uip_len > UIP_LINK_MTU) {
+		UIP_LOG("tcpip_ipv6_output: Packet to big");
+		uip_len = 0;
+		return;
+	}
+
+	if(uip_is_addr_unspecified(&UIP_IP_BUF->destipaddr)){
+			UIP_LOG("tcpip_ipv6_output: Destination address unspecified");
+		uip_len = 0;
+		return;
+	}
+
+	if(!uip_is_addr_mcast(&UIP_IP_BUF->destipaddr)) {
+		/* Next hop determination */
+		nbr = NULL;
+
+		/* We first check if the destination address is on our immediate
+			link. If so, we simply use the destination address as our
+			nexthop address. */
+		if(uip_ds6_is_addr_onlink(&UIP_IP_BUF->destipaddr)){
+			nexthop = &UIP_IP_BUF->destipaddr;
+		} else {
+			uip_ds6_route_t *route;
+			/* Check if we have a route to the destination address. */
+			route = uip_ds6_route_lookup(&UIP_IP_BUF->destipaddr);
+
+			/* No route was found - we send to the default route instead. */
+			if(route == NULL) {
+				PRINTF("tcpip_ipv6_output: no route found, using default route\n");
+				nexthop = uip_ds6_defrt_choose();
+				if(nexthop == NULL) {
+#ifdef UIP_FALLBACK_INTERFACE
+					PRINTF("FALLBACK: removing ext hdrs & setting proto %d %d\n",
+							uip_ext_len, *((uint8_t *)UIP_IP_BUF + 40));
+					if(uip_ext_len > 0) {
+						extern void remove_ext_hdr(void);
+						uint8_t proto = *((uint8_t *)UIP_IP_BUF + 40);
+						remove_ext_hdr();
+						/* This should be copied from the ext header... */
+						UIP_IP_BUF->proto = proto;
+					}
+					UIP_FALLBACK_INTERFACE.output();
+#else
+					PRINTF("tcpip_ipv6_output: Destination off-link but no route\n");
+#endif /* !UIP_FALLBACK_INTERFACE */
+					uip_len = 0;
+					return;
+				}
+
+			} else {
+				/* A route was found, so we look up the nexthop neighbor for
+				   the route. */
+				nexthop = uip_ds6_route_nexthop(route);
+
+				/* If the nexthop is dead, for example because the neighbor
+				   never responded to link-layer acks, we drop its route. */
+				if(nexthop == NULL) {
+#if UIP_CONF_IPV6_RPL
+					/* If we are running RPL, and if we are the root of the
+					* network, we'll trigger a global repair berfore we remove
+					* the route. */
+					rpl_dag_t *dag;
+					rpl_instance_t *instance;
+
+					dag = (rpl_dag_t *)route->state.dag;
+					if(dag != NULL) {
+						instance = dag->instance;
+
+						rpl_repair_root(instance->instance_id);
+					}
+#endif /* UIP_CONF_RPL */
+					uip_ds6_route_rm(route);
+
+					/* We don't have a nexthop to send the packet to, so we drop
+					* it. */
+					return;
+				}
+			}
+#if TCPIP_CONF_ANNOTATE_TRANSMISSIONS
+			if(nexthop != NULL) {
+				static uint8_t annotate_last;
+				static uint8_t annotate_has_last = 0;
+
+				if(annotate_has_last) {
+					printf("#L %u 0; red\n", annotate_last);
+				}
+				printf("#L %u 1; red\n", nexthop->u8[sizeof(uip_ipaddr_t) - 1]);
+				annotate_last = nexthop->u8[sizeof(uip_ipaddr_t) - 1];
+				annotate_has_last = 1;
+			}
+#endif /* TCPIP_CONF_ANNOTATE_TRANSMISSIONS */
+		}
+
+		/* End of next hop determination */
+
+#if UIP_CONF_IPV6_RPL
+		if(rpl_update_header_final(nexthop)) {
+			uip_len = 0;
+			return;
+		}
+#endif /* UIP_CONF_IPV6_RPL */
+		nbr = uip_ds6_nbr_lookup(nexthop);
+		if(nbr == NULL) {
+#if UIP_ND6_SEND_NA
+			if((nbr = uip_ds6_nbr_add(nexthop, NULL, 0, NBR_INCOMPLETE)) == NULL) {
+				uip_len = 0;
+				return;
+			} else {
+#if UIP_CONF_IPV6_QUEUE_PKT
+				/* Copy outgoing pkt in the queuing buffer for later transmit. */
+				if(uip_packetqueue_alloc(&nbr->packethandle, UIP_DS6_NBR_PACKET_LIFETIME) != NULL) {
+					memcpy(uip_packetqueue_buf(&nbr->packethandle), UIP_IP_BUF, uip_len);
+					uip_packetqueue_set_buflen(&nbr->packethandle, uip_len);
+				}
+#endif
+				/* RFC4861, 7.2.2:
+				* "If the source address of the packet prompting the solicitation is the
+				* same as one of the addresses assigned to the outgoing interface, that
+				* address SHOULD be placed in the IP Source Address of the outgoing
+				* solicitation.  Otherwise, any one of the addresses assigned to the
+				* interface should be used."*/
+				if(uip_ds6_is_my_addr(&UIP_IP_BUF->srcipaddr)){
+					uip_nd6_ns_output(&UIP_IP_BUF->srcipaddr, NULL, &nbr->ipaddr);
+				} else {
+					uip_nd6_ns_output(NULL, NULL, &nbr->ipaddr);
+				}
+
+				stimer_set(&nbr->sendns, uip_ds6_if.retrans_timer / 1000);
+				nbr->nscount = 1;
+			}
+#endif /* UIP_ND6_SEND_NA */
+		} else {
+#if UIP_ND6_SEND_NA
+			if(nbr->state == NBR_INCOMPLETE) {
+				PRINTF("tcpip_ipv6_output: nbr cache entry incomplete\n");
+#if UIP_CONF_IPV6_QUEUE_PKT
+				/* Copy outgoing pkt in the queuing buffer for later transmit and set
+				*  the destination nbr to nbr. */
+				if(uip_packetqueue_alloc(&nbr->packethandle, UIP_DS6_NBR_PACKET_LIFETIME) != NULL) {
+					memcpy(uip_packetqueue_buf(&nbr->packethandle), UIP_IP_BUF, uip_len);
+					uip_packetqueue_set_buflen(&nbr->packethandle, uip_len);
+				}
+#endif /*UIP_CONF_IPV6_QUEUE_PKT*/
+				uip_len = 0;
+				return;
+			}
+			/* Send in parallel if we are running NUD (nbc state is either STALE,
+			*   DELAY, or PROBE). See RFC 4861, section 7.7.3 on node behavior. */
+			if(nbr->state == NBR_STALE) {
+				nbr->state = NBR_DELAY;
+				stimer_set(&nbr->reachable, UIP_ND6_DELAY_FIRST_PROBE_TIME);
+				nbr->nscount = 0;
+				PRINTF("tcpip_ipv6_output: nbr cache entry stale moving to delay\n");
+			}
+#endif /* UIP_ND6_SEND_NA */
+
+			xtcpip_output(uip_ds6_nbr_get_ll(nbr), mac_tx);
+
+#if UIP_CONF_IPV6_QUEUE_PKT
+			/*
+			 * Send the queued packets from here, may not be 100% perfect though.
+			 * This happens in a few cases, for example when instead of receiving a
+			 * NA after sendiong a NS, you receive a NS with SLLAO: the entry moves
+			 * to STALE, and you must both send a NA and the queued packet.
+			 */
+			if(uip_packetqueue_buflen(&nbr->packethandle) != 0) {
+				uip_len = uip_packetqueue_buflen(&nbr->packethandle);
+				memcpy(UIP_IP_BUF, uip_packetqueue_buf(&nbr->packethandle), uip_len);
+				uip_packetqueue_free(&nbr->packethandle);
+				xtcpip_output(uip_ds6_nbr_get_ll(nbr), mac_tx);
+			}
+#endif /*UIP_CONF_IPV6_QUEUE_PKT*/
+
+			uip_len = 0;
+			return;
+		}
+		return;
+	}
+
+	/* Multicast IP destination address. */
+	xtcpip_output(NULL, mac_tx);
+	uip_len = 0;
+	uip_ext_len = 0;
+}
+#endif /* UIP_CONF_IPV6 */
+/* -----------------------------------------------------------------------------
+ * Process periodical stuff.
+ *
+ * In contiki, this is handlet by the eventhandler of the tcpip.c file
+ * with the process event "PROCESS_EVENT_TIMER".
+ * -------------------------------------------------------------------------- */
+void xtcp_process_timer(chanend mac_tx, xtcp_tmr_event_type_t event)
+{
+#if UIP_IGMP
+  igmp_periodic();
+  if(uip_len > 0) {
+    xtcp_tx_buffer(mac_tx);
+  }
+#endif
+
+  if(event == XTCP_TMR_PERIODIC) {
+#if UIP_TCP
+    for(int i = 0; i < UIP_CONNS; ++i) {
+      if(uip_conn_active(i)) {
+        uip_periodic(i);
+#if UIP_CONF_IPV6
+        xtcpip_ipv6_output(mac_tx);
+#else
+        if(uip_len > 0) {
+          PRINTF("tcpip_output from periodic len %d\n", uip_len);
+          tcpip_output();
+          PRINTF("tcpip_output after periodic len %d\n", uip_len);
+        }
+#endif /* UIP_CONF_IPV6 */
+      }
+    }
+#endif /* UIP_TCP */
+#if UIP_CONF_IP_FORWARD
+    uip_fw_periodic();
+#endif /* UIP_CONF_IP_FORWARD */
+  }
+  /*XXX CHSC HACK*/
+#if UIP_CONF_IPV6
+#if UIP_CONF_IPV6_REASSEMBLY
+        /*
+         * check the timer for reassembly
+         */
+        if(etimer_expired(&uip_reass_timer)) {
+          uip_reass_over();
+          tcpip_ipv6_output();
+        }
+#endif /* UIP_CONF_IPV6_REASSEMBLY */
+        /*
+         * check the different timers for neighbor discovery and
+         * stateless autoconfiguration
+         */
+        /*if(data == &uip_ds6_timer_periodic &&
+           etimer_expired(&uip_ds6_timer_periodic)) {
+          uip_ds6_periodic();
+          tcpip_ipv6_output();
+        }*/
+#if !UIP_CONF_ROUTER
+        if(etimer_expired(&uip_ds6_timer_rs)) {
+          uip_ds6_send_rs();
+          xtcpip_ipv6_output(mac_tx);
+        }
+#endif /* !UIP_CONF_ROUTER */
+        if(etimer_expired(&uip_ds6_timer_periodic)) {
+          uip_ds6_periodic();
+          xtcpip_ipv6_output(mac_tx);
+        }
+#endif /* UIP_CONF_IPV6 */
+
+}
+#if UIP_CONF_IPV4
+#if UIP_USE_DHCP
+void dhcpc_configured(const struct dhcpc_state *s) {
+#ifdef XTCP_VERBOSE_DEBUG
+	printf("dhcp: ");uip_printip4(s->ipaddr);printf("\n");
+#endif
+#if UIP_USE_AUTOIP
+	autoip_stop();
+#endif
+	uip_sethostaddr(s->ipaddr);
+	uip_setdraddr(s->default_router);
+	uip_setnetmask(s->netmask);
+	uip_xtcp_up();
+	dhcp_done = 1;
+}
+#endif
+
+#if UIP_USE_AUTOIP
+void autoip_configured(uip_ipaddr_t autoip_ipaddr) {
+	if (!dhcp_done) {
+		uip_ipaddr_t ipaddr;
+#ifdef XTCP_VERBOSE_DEBUG
+		printf("ipv4ll: ");
+		uip_printip4(autoip_ipaddr);
+		printf("\n");
+#endif /* XTCP_VERBOSE_DEBUG */
+		uip_sethostaddr(autoip_ipaddr);
+		uip_ipaddr(ipaddr, 255, 255, 0, 0);
+		uip_setnetmask(ipaddr);
+		uip_ipaddr(ipaddr, 0, 0, 0, 0);
+		uip_setdraddr(ipaddr);
+		uip_xtcp_up();
+	}
+}
+#endif /* UIP_USE_AUTOIP */
+
+
+#endif /* UIP_CONF_IPV4 */
+
+/* -----------------------------------------------------------------------------
+ * When a cable is plugged in, this function is called
+ * ---------------------------------------------------------------------------*/
+void uip_linkup() {
+	if (uip_xtcp_get_ifstate()){
+		uip_xtcp_down();
+	}
+#if UIP_CONF_IPV4
+	if (uip_static_ip) {
+		uip_sethostaddr(&uip_static_ipconfig.ipaddr);
+		uip_setdraddr(&uip_static_ipconfig.gateway);
+		uip_setnetmask(&uip_static_ipconfig.netmask);
+		uip_xtcp_up();
+	} else {
+		dhcp_done = 0;
+#if UIP_USE_DHCP
+		dhcpc_stop();
+#endif
+#if UIP_USE_AUTOIP
+#if UIP_USE_DHCP
+		autoip_stop();
+#else
+		autoip_start();
+#endif
+#endif
+#if UIP_USE_DHCP
+		dhcpc_start();
+#endif
+	}
+#endif /* UIP_CONF_IPVx */
+}
+
+/* -----------------------------------------------------------------------------
+ * When a cable is unplugged in, this function is called
+ * ---------------------------------------------------------------------------*/
+void uip_linkdown() {
+	dhcp_done = 0;
+#if UIP_USE_DHCP
+	dhcpc_stop();
+#endif
+#if UIP_USE_AUTOIP
+	autoip_stop();
+#endif
+	uip_xtcp_down();
+}
+
+/* ********************************************************************** */
+
+/* -----------------------------------------------------------------------------
+ * Initialise the uip_server
+ * -------------------------------------------------------------------------- */
+void uip_server_init(chanend xtcp[], int num_xtcp,
+					 xtcp_ipconfig_t *ipconfig,
+					 unsigned char *mac_address)
+{
+	if (ipconfig != NULL)
+		memcpy(&uip_static_ipconfig, ipconfig, sizeof(xtcp_ipconfig_t));
+
+	/* set the mac_adress */
+	memcpy(&uip_lladdr, mac_address, 6);
+
+#if 0 //XXX CHSC: not necessary? Be carefully with erasing the mac address...
+	/* The following line sets the uIP's link-layer address. This must be done
+	 * before the tcpip_process is started since in its initialisation
+	 * routine the function uip_netif_init() will be called from inside
+	 * uip_init()and there the default IPv6 address will be set by combining
+	 * the link local prefix (fe80::/64)and the link layer address. */
+	rimeaddr_copy((rimeaddr_t*) &uip_lladdr.addr, &rimeaddr_node_addr);
+#endif
+//TODO chsc: port the rtimer module (if really needed)
+//	/* rtimers needed for radio cycling */
+//	rtimer_init();
+
+
+	/* Initialise the process module */
+	process_init();
+
+	/* etimers must be started before ctimer_init */
+	process_start(&etimer_process, NULL);
+
+	ctimer_init();
+
+	/* this calls have to be made before the uip_init
+	 * not exactely proved why. CHSC
+	 *  */
+	etimer_request_poll();
+	process_run();
+
+	uip_init();
+
+#if UIP_CONF_IPV6 && UIP_CONF_IPV6_RPL
+	rpl_init();
+#endif /* UIP_CONF_IPV6_RPL */
+
+#if UIP_IGMP
+	igmp_init();
+#endif	/* UIP_IGMP */
+
+	if (ipconfig != NULL && (*((int*)ipconfig->ipaddr.u8) != 0)) {
+		uip_static_ip = 1;
+	}
+
+	if (ipconfig == NULL)
+	{
+		uip_ipaddr_t ipaddr;
+#if UIP_CONF_IPV4
+		uip_ipaddr(&ipaddr, 0, 0, 0, 0);
+		uip_sethostaddr(&ipaddr);
+		uip_setdraddr(&ipaddr);
+		uip_setnetmask(&ipaddr);
+#elif UIP_CONF_IPV6
+		uip_ip6addr(&ipaddr, 0, 0, 0, 0
+				           , 0, 0, 0, 0);
+#endif	/* UIP_CONF_IPVx */
+	} else {
+#if UIP_CONF_IPV4
+		uip_sethostaddr(&ipconfig->ipaddr);
+		uip_setdraddr(&ipconfig->gateway);
+		uip_setnetmask(&ipconfig->netmask);
+#ifdef XTCP_VERBOSE_DEBUG
+		printf("Address: ");uip_printip4(uip_hostaddr);printf("\n");
+		printf("Gateway: ");uip_printip4(uip_draddr);printf("\n");
+		printf("Netmask: ");uip_printip4(uip_netmask);printf("\n");
+#endif /* XTCP_VERBOSE_DEBUG */
+#elif UIP_CONF_IPV6
+
+#endif /* UIP_CONF_IPVx */
+	}
+
+#if UIP_CONF_IPV4
+	{
+#if UIP_USE_AUTOIP
+		int hwsum = mac_address[0] + mac_address[1] + mac_address[2]
+				+ mac_address[3] + mac_address[4] + mac_address[5];
+		autoip_init(hwsum + (hwsum << 16) + (hwsum << 24));
+#endif
+#if UIP_USE_DHCP
+		dhcpc_init(uip_lladdr.addr, 6);
+#endif
+	}
+#endif /* UIP_CONF_IPV4 */
+	xtcpd_init(xtcp, num_xtcp);
+}

--- a/module_xtcp/src/xtcp_uip6/uip_server_support.h
+++ b/module_xtcp/src/xtcp_uip6/uip_server_support.h
@@ -1,0 +1,47 @@
+/*****************************************************************************
+*
+* Filename:         uip_server_support.h
+* Author:           Christian Schlittler
+* Version:          1.0
+* Creation date:	25.10.2013
+*
+* Copyright:        Christian Schlittler, christian.schlittler@gmx.ch
+*
+* Project:			XMOS and 6LoWPAN
+* Target:			XMOS sliceKIT with RFSlice extension
+* Compiler:        
+*
+* -----------------------------------------------------------------------------
+*
+* History:
+*
+* -----------------------------------------------------------------------------
+*
+* Usage:
+*
+**************************************************************************** */
+
+#ifndef UIP_SERVER_SUPPORT_H_
+#define UIP_SERVER_SUPPORT_H_
+
+#include <xccompat.h>
+#include <xtcp_client.h>
+
+typedef enum xtcp_tmr_event_type_t {
+	XTCP_TMR_PERIODIC,
+} xtcp_tmr_event_type_t;
+
+void uip_server_init(chanend xtcp[], int num_xtcp,
+                     REFERENCE_PARAM(xtcp_ipconfig_t, ipconfig),
+                     unsigned char mac_address[6]);
+void xtcpd_check_connection_poll(chanend mac_tx);
+void xtcp_tx_buffer(chanend mac_tx);
+void xtcp_process_incoming_packet(chanend mac_tx);
+void xtcp_process_udp_acks(chanend mac_tx);
+void xtcp_process_timer(chanend mac_tx, xtcp_tmr_event_type_t event);
+
+void xtcpip_input(chanend mac_tx);
+void xtcpip_ipv6_output(chanend mac_tx);
+
+
+#endif /* UIP_SERVER_SUPPORT_H_ */

--- a/module_xtcp/src/xtcp_uip6/uip_single_server.h
+++ b/module_xtcp/src/xtcp_uip6/uip_single_server.h
@@ -1,0 +1,28 @@
+#include <xs1.h>
+
+#include "mii.h"
+#include "smi.h"
+#include "xtcp_client.h"
+
+/**
+ * The top level thread function for a single threaded XTCP server, interfacing
+ * to a single thread ethernet MII.
+ * *
+ * \note This function should be used in a top level 'par' in the main function.
+ *       It will internally create the single MII thread.
+ *
+ * \param p_mii_resetn   Optional port which resets the PHY
+ * \param smi            Structure describing the SMI ports
+ * \param mii            Structure describing the MII ports
+ * \param xtcp           Array of client comms channels
+ * \param num_xtcp       The number of TCP client channels
+ * \param ipconfig       The configuration structure for the IP address
+ * \param mac_address    The unicast MAC address for this device
+ *
+ */
+void uip_single_server(out port ?p_mii_resetn,
+                       smi_interface_t &smi,
+                       mii_interface_lite_t &mii,
+                       chanend xtcp[], int num_xtcp,
+                       xtcp_ipconfig_t& ipconfig,
+                       char mac_address[6]);

--- a/module_xtcp/src/xtcp_uip6/uip_single_server.xc
+++ b/module_xtcp/src/xtcp_uip6/uip_single_server.xc
@@ -1,0 +1,318 @@
+/*****************************************************************************
+*
+* Filename:         uip_single_server.xc
+* Author:           David Lacey
+*                   Christian Schlittler
+* Version:          1.0
+* Creation date:	15.10.2013
+*
+* Copyright:        Christian Schlittler, christian.schlittler@gmx.ch
+*                   2013, ZHAW School of Engineering
+*                   2013, XMOS Ltd, All rights reserved
+*                   This software is freely distributable under a derivative of the
+*                   University of Illinois/NCSA Open Source License posted in
+*
+* Project:          XMOS and 6LoWPAN
+* Target:           XMOS sliceKIT with RFSlice extension
+* Compiler:         xcc with xTIMEcomposer 13.0.0beta
+*
+* -----------------------------------------------------------------------------
+*
+* History:
+*
+* This code was written by David Lacey to run the uIP protocol stack in V1.0. Now
+* an extension of the protocol stack to IPv6 is needed, so a newer version of
+* uip is used. Therefore, some adaption had to be made in this file.
+*
+* -----------------------------------------------------------------------------
+*
+* Usage:
+*
+**************************************************************************** */
+
+// Copyright (c) 2011, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+
+
+#include <xs1.h>
+#include <xclib.h>
+#include <safestring.h>
+#include <print.h>
+#include "xtcp_conf_derived.h"
+#include "uip.h"
+#include "uip-conf.h"
+
+#define SIZE_ESTIMATE 0
+
+#if !XTCP_SEPARATE_MAC
+
+#include "xtcp_client.h"
+
+#ifndef UIP_SINGLE_THREAD_RX_BUFFER_SIZE
+#define UIP_SINGLE_THREAD_RX_BUFFER_SIZE (3200*4)
+#endif
+
+#define UIP_MIN_SINGLE_THREAD_RX_BUFFER_SIZE (1524*4)
+
+#if (UIP_SINGLE_THREAD_RX_BUFFER_SIZE) < (UIP_MIN_SINGLE_THREAD_RX_BUFFER_SIZE)
+#warning UIP_SINGLE_THREAD_RX_BUFFER_SIZE is set too small for correct operation
+#endif
+
+
+
+#include "xtcp_server.h"
+#include "uip_xtcp.h"
+#include "uip.h"
+#include "uip_server_support.h"
+
+#include "smi.h"
+#include "uip_single_server.h"
+#include "mii_driver.h"
+#include "mii_client.h"
+
+extern int uip_static_ip;
+extern xtcp_ipconfig_t uip_static_ipconfig;
+
+/* -----------------------------------------------------------------------------
+ * function to make the uIPv6 stack running
+ *
+ * The stack has been extracted from the contiki os
+ * and ported to use it standalone on the XMOS
+ * platform together with the standard XMOS
+ * Ethernet MAC.
+ *
+ * This functions are necessary the run the TCP/IP
+ * stack.
+ * -------------------------------------------------------------------------- */
+extern void etimer_request_poll(void); 	// Function form etimer
+extern int process_run(void);			// poll the processces
+
+/*----------------------------------------------------------------------------*/
+#if !SIZE_ESTIMATE
+// Global variables from uip_server_support
+extern unsigned short uip_len;
+
+#define XTCP_UIP_BUF32	1
+#define xuip_buf32 (uip_aligned_buf.u32)
+
+// Global functions from the uip stack
+extern void uip_arp_timer(void);
+extern void autoip_periodic();
+extern void igmp_periodic();
+#endif /* SIZE_ESTIMATE */
+
+#pragma unsafe arrays
+static void
+copy_packet(uint32_t dst[], unsigned src, unsigned len)
+{
+	unsigned word_len = (len+3) >> 2;
+	unsigned d;
+	for (unsigned i=0; i<word_len; ++i)
+	{
+		asm( "ldw %0, %1[%2]" : "=r"(d) : "r"(src) , "r"(i) );
+		asm( "stw %0, %1[%2]" :: "r"(d) , "r"(dst) , "r"(i) );
+	}
+}
+
+/*------------------------------------------------------------------------------
+ * theServer
+ *
+ * This function handles the incoming and outgoing messages. This is the
+ * nerve centre of the TPC/IP protocol and the Ethernet MAC.
+ *
+ * \param mac_rx			Receive channel of the Ethernet MAC
+ * \param mac_tx			Transmit channel to the Ethernet MAC
+ * \param cNotifications
+ * \param smi
+ *
+ * \param xtcp				Channels to register applications listen/write to
+ * \param num_xtcp			Number of xtcp channels.
+ * \param ipconfig			IP address. Depends if it is used with
+ * 							IPv4 or IPv6.
+ *
+ * \param mac_address		the 48-bit Ethernet MAC address
+ * ---------------------------------------------------------------------------*/
+
+static void theServer(chanend mac_rx, chanend mac_tx,
+					  chanend cNotifications,
+                      smi_interface_t &smi,
+                      chanend xtcp[], int num_xtcp,
+                      xtcp_ipconfig_t& ipconfig,
+                      char mac_address[6]) {
+#define TIMEOUT		10000000		// 10'000'000 x 10ns = 0.1 sec.
+	int address, length, timeStamp;
+
+	timer tmr;
+	unsigned timeout;
+#if UIP_CONF_IPV4
+	unsigned arp_timer=0;
+#endif
+	unsigned stimer_upd=0;
+
+#if UIP_USE_AUTOIP
+	unsigned autoip_timer=0;
+#endif
+
+	// Control structure for MII LLD
+	struct miiData miiData;
+
+	// The Receive packet buffer
+	int b[UIP_SINGLE_THREAD_RX_BUFFER_SIZE/4];
+#if !SIZE_ESTIMATE
+	uip_server_init(xtcp, num_xtcp, ipconfig, mac_address);
+#endif
+	mii_buffer_init(miiData, mac_rx, cNotifications, b, UIP_SINGLE_THREAD_RX_BUFFER_SIZE/4);
+	mii_out_init(mac_tx);
+
+	/* Time base for the protocol stack */
+	tmr :> timeout;
+	timeout += TIMEOUT;
+
+	while (1) {
+#if !SIZE_ESTIMATE
+		xtcpd_service_clients(xtcp, num_xtcp);
+
+		xtcpd_check_connection_poll(mac_tx);
+
+		xtcpd_uip_checkstate();
+		xtcp_process_udp_acks(mac_tx);
+
+		/* ***********************************
+		 * call of the etimer module
+		 *
+		 * this could be optimised if you would
+		 * use a dedicated xCore timer for this.
+		 * *********************************** */
+		etimer_request_poll();
+
+		/* ***********************************
+		 * periodic call of the process
+		 * *********************************** */
+		process_run();
+#endif /* SIZE_ESTIMATE */
+		select {
+		/* ***********************************
+		 * Do some periodical stuff
+		 * *********************************** */
+		case tmr when timerafter(timeout) :> unsigned:
+			timeout += TIMEOUT;
+
+			// Check for the link state
+			{
+				static int linkstate=0;
+				int status = smi_check_link_state(smi);
+				if (!status && linkstate) {
+				  uip_linkdown();
+				}
+				if (status && !linkstate) {
+				  uip_linkup();
+				}
+				linkstate = status;
+			}
+
+#if UIP_CONF_IPV4
+			if (++arp_timer == 100) {
+				arp_timer=0;
+				uip_arp_timer();
+			}
+#endif /* UIP_CONF_IPV4 */
+
+#if UIP_USE_AUTOIP
+			if (++autoip_timer == 5) {
+				autoip_timer = 0;
+				autoip_periodic();
+				if (uip_len > 0) {
+					xtcp_tx_buffer(mac_tx);
+				}
+			}
+#endif
+#if !SIZE_ESTIMATE
+			/* update second timer */
+			stimer_upd = (stimer_upd + 1)%10;
+			if(stimer_upd == 0){
+				upd_clock_seconds();
+			}
+
+			xtcp_process_timer(mac_tx, XTCP_TMR_PERIODIC);
+#endif /* SIZE_ESTIMATE */
+			break;
+
+		/* ************************************
+		 * A package is coming in from the MAC
+		 * ************************************ */
+		case inuchar_byref(cNotifications, miiData.notifySeen):
+			do {
+				{address,length,timeStamp} = mii_get_in_buffer(miiData);
+				if (address != 0) {
+					static unsigned pcnt=1;
+					if (length <= UIP_BUFSIZE) {
+						uip_len = length;
+#if !SIZE_ESTIMATE
+						copy_packet(xuip_buf32, address, length);
+#endif
+#if BUF_32BIT_ALIGN
+						/* XXX CHSC: Alignment hack: shift the hole buffer 2 position to align it on 32bit  */
+						for(int i = sizeof(uip_aligned_buf)-3; i>1; i--){
+							uip_aligned_buf.u8[i+2] = uip_aligned_buf.u8[i];
+						}
+#endif
+						/* Deliver an incoming packet to the TCP/IP stack */
+#if !SIZE_ESTIMATE
+						xtcpip_input(mac_tx);
+#endif
+					}
+					mii_free_in_buffer(miiData, address);
+					mii_restart_buffer(miiData);
+				}
+			} while (address!=0);
+			break;
+
+		default:
+			break;
+		}
+	}
+}
+
+/*-----------------------------------------------------------------------------
+ * This function is just here to stop the compiler warning about an unused
+ * chanend.
+ *----------------------------------------------------------------------------*/
+static inline void doNothing(chanend c) {
+  asm(""::"r"(c));
+}
+
+/*-----------------------------------------------------------------------------
+ * uip_single_server
+ *
+ * \param	p_mii_resetn
+ * \param	smi
+ * \param	mii
+ * \param	xtcp
+ * \param	num_xtcp
+ * \param	ipconfig
+ * \param	mac_address
+ *---------------------------------------------------------------------------*/
+void uip_single_server(out port ?p_mii_resetn,
+                       smi_interface_t &smi,
+                       mii_interface_lite_t &mii,
+                       chanend xtcp[],
+                       int num_xtcp,
+                       xtcp_ipconfig_t& ipconfig,
+                       char mac_address[6]) {
+    chan cIn, cOut;
+    chan notifications;
+	mii_initialise(p_mii_resetn, mii);
+#ifndef MII_NO_SMI_CONFIG
+	smi_init(smi);
+	eth_phy_config(1, smi);
+#endif
+	par {
+		{doNothing(notifications);mii_driver(mii, cIn, cOut);}
+		theServer(cIn, cOut, notifications, smi, xtcp, num_xtcp, ipconfig, mac_address);
+	}
+}
+/*---------------------------------------------------------------------------*/
+#endif /* !XTCP_SEPARATE_MAC */

--- a/module_xtcp/src/xtcp_uip6/uip_xtcp.c
+++ b/module_xtcp/src/xtcp_uip6/uip_xtcp.c
@@ -1,0 +1,800 @@
+// Copyright (c) 2011, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+#include <string.h>
+#include <print.h>
+#include <stdio.h>
+
+#include "uip_xtcp.h"
+#include "xtcp_client.h"
+#include "xtcp_server.h"
+#include "xtcp_server_impl.h"
+
+#include "uipopt.h"
+#include "contiki-net.h"
+
+
+
+#define DEBUG DEBUG_NONE
+#include "net/uip-debug.h"
+
+#define DHCPC_SERVER_PORT  67
+#define DHCPC_CLIENT_PORT  68
+
+#define DHCPV6_SERVER_PORT  547
+#define DHCPV6_CLIENT_PORT  546
+
+
+#ifndef NULL
+#define NULL ((void *) 0)
+#endif
+
+#define MAX_GUID 200
+static int guid = 1;		// Globally Unique Identifier => identification
+							// of a connection.
+
+#if ((UIP_UDP_CONNS+UIP_CONNS) > MAX_GUID)
+  #error "Cannot have more connections than GUIDs"
+#endif
+
+struct xtcp_cons_t{
+	chanend *links;						// pointer to the chanend of the clients
+	int nr;								// number of connected clients
+	int prev_ifstate[MAX_XTCP_CLIENTS];	// last interface state (up/down) informed
+										// to the connected application
+}xtcp_cons;
+
+#define NUM_TCP_LISTENERS 10
+#define NUM_UDP_LISTENERS 10
+
+#define BUF ((struct uip_tcpip_hdr *)&uip_buf[UIP_LLH_LEN])
+#define UDPBUF ((struct uip_udpip_hdr *)&uip_buf[UIP_LLH_LEN])
+
+/**
+ * \internal Structure for holding a TCP port and the link number.
+ */
+struct listener_info_t {
+  int active;			// 1 = active, 0 = inactive
+  int port_number;		// TCP port number
+  int linknum;			//
+};
+
+
+
+struct listener_info_t tcp_listeners[NUM_TCP_LISTENERS] = {{0}};
+struct listener_info_t udp_listeners[NUM_UDP_LISTENERS] = {{0}};
+
+extern u16_t uip_slen;	// max length of a package
+
+/* ****************************************************************************
+ *
+ * Functions to handle tcp/upd listeners
+ *
+ * ************************************************************************** */
+__attribute__ ((noinline))
+static int get_listener_linknum(struct listener_info_t listeners[],
+                                int n,
+                                int local_port)
+{
+  int i, linknum = -1;
+  for (i=0;i<n;i++)
+    if (listeners[i].active &&
+        local_port == listeners[i].port_number) {
+      linknum = listeners[i].linknum;
+      break;
+    }
+  return linknum;
+}
+
+static void unregister_listener(struct listener_info_t listeners[],
+                                int linknum,
+                                int port_number,
+                                int n){
+
+  int i;
+  for (i=0;i<n;i++){
+    if (listeners[i].port_number == HTONS(port_number) &&
+        listeners[i].active)
+      {
+        listeners[i].active = 0;
+      }
+  }
+}
+/* -------------------------------------------------------------------------- */
+static void register_listener(struct listener_info_t listeners[],
+                              int linknum,
+                              int port_number,
+                              int n)
+{
+  int i;
+
+    for (i=0;i<n;i++)
+      if (!listeners[i].active)
+        break;
+    
+    if (i==n) {
+      // Error: max number of listeners reached
+    }
+    else {
+      listeners[i].active = 1;
+      listeners[i].port_number = HTONS(port_number);
+      listeners[i].linknum = linknum;
+    }
+}
+
+/* -------------------------------------------------------------------------- */
+void xtcpd_unlisten(int linknum, int port_number){
+  unregister_listener(tcp_listeners, linknum, port_number, NUM_TCP_LISTENERS);
+  uip_unlisten(HTONS(port_number));
+}
+
+/* -------------------------------------------------------------------------- */
+void xtcpd_listen(int linknum, int port_number, xtcp_protocol_t p)
+{
+	switch(p){
+	case XTCP_PROTOCOL_TCP:
+	    register_listener(tcp_listeners, linknum, port_number, NUM_TCP_LISTENERS);
+	    uip_listen(HTONS(port_number));
+		break;
+
+	case XTCP_PROTOCOL_UDP:
+	    register_listener(udp_listeners, linknum, port_number, NUM_UDP_LISTENERS);
+	    uip_udp_listen(HTONS(port_number));
+		break;
+
+	default:
+		PRINTF("xtcpd_listen: Unknown protocol.");
+		break;
+	}
+
+  return;
+}
+/* ************************************************************************** */
+
+
+/* -----------------------------------------------------------------------------
+ *
+ * -------------------------------------------------------------------------- */
+static struct xtcpd_state_t  *lookup_xtcpd_state(int conn_id) {
+  int i=0;
+  for (i=0;i<((UIP_CONNS>UIP_UDP_CONNS) ? UIP_CONNS : UIP_UDP_CONNS);i++) {
+    if (i < UIP_CONNS) {
+      xtcpd_state_t *s = (xtcpd_state_t *) &(uip_conns[i].appstate);
+      if (s->conn.id == conn_id) return s;
+    }
+    if (i < UIP_UDP_CONNS) {
+        xtcpd_state_t *s = (xtcpd_state_t *) &(uip_udp_conns[i].appstate);
+        if (s->conn.id == conn_id) return s;
+    }
+  }
+  return NULL;
+}
+
+/* -----------------------------------------------------------------------------
+ *
+ * -------------------------------------------------------------------------- */
+static void init_xtcpd_state(xtcpd_state_t *s,
+							 xtcp_protocol_t protocol,
+							 xtcp_ipaddr_t remote_addr,
+							 int local_port,
+							 int remote_port,
+							 void *conn) {
+  int linknum;
+  int connect_request = s->s.connect_request;
+  int connection_type = s->conn.connection_type;
+
+  if (connect_request) {
+    linknum = s->linknum;
+  } else {
+    connection_type = XTCP_SERVER_CONNECTION;
+    if (protocol == XTCP_PROTOCOL_TCP) {
+      linknum = get_listener_linknum(tcp_listeners, NUM_TCP_LISTENERS, local_port);
+    }
+    else {
+      linknum = get_listener_linknum(udp_listeners, NUM_UDP_LISTENERS, local_port);
+    }
+  }
+
+  memset(s, 0, sizeof(xtcpd_state_t));
+
+  // Find and use a GUID that is not being used by another connection
+  while (lookup_xtcpd_state(guid) != NULL)
+  {
+    guid++;
+    if (guid > MAX_GUID)
+      guid = 1;
+  }
+
+  s->conn.connection_type = connection_type;
+  s->linknum = linknum;
+  s->conn.id = guid;
+  s->conn.local_port = HTONS(local_port);
+  s->conn.remote_port = HTONS(remote_port);
+  s->conn.protocol = protocol;
+  s->s.uip_conn = (int) conn;
+#ifdef XTCP_ENABLE_PARTIAL_PACKET_ACK
+  s->s.accepts_partial_ack = 0;
+#endif
+  XTCP_IPADDR_CPY(s->conn.remote_addr.u8, remote_addr.u8);
+}
+
+/* -----------------------------------------------------------------------------
+ *
+ * -------------------------------------------------------------------------- */
+static int do_xtcpd_send(chanend c,
+                  xtcp_event_type_t event,
+                  xtcpd_state_t *s,
+                  unsigned char data[],
+                  int mss)
+{
+  int len;
+#ifdef XTCP_ENABLE_PARTIAL_PACKET_ACK
+  int outstanding=0;
+  if (!uip_udpconnection()) {
+    if (!s->s.accepts_partial_ack && uip_conn->len > 1)
+      return 0;
+
+    outstanding = uip_conn->len;
+    if (outstanding == 1)
+      outstanding = 0;
+    s->conn.outstanding = outstanding;
+
+  }
+#endif
+
+  xtcpd_service_clients_until_ready(s->linknum, xtcp_cons.links, xtcp_cons.nr);
+  len = xtcpd_send(c,event,s,data,mss);
+
+#ifdef XTCP_ENABLE_PARTIAL_PACKET_ACK
+  if (!uip_udpconnection()) {
+    if (outstanding != 0 &&
+        len > outstanding) {
+      len = len - outstanding;
+      memmove((char *) uip_appdata,
+              &((char *)uip_appdata)[outstanding],
+              len);
+    }
+    else if (outstanding > 0) {
+      len = 0;
+    }
+  }
+#endif
+  return len;
+}
+
+/* -----------------------------------------------------------------------------
+ *
+ * -------------------------------------------------------------------------- */
+static void xtcpd_event(xtcp_event_type_t event,
+                        xtcpd_state_t *s)
+{
+  if (s->linknum != -1) {
+    xtcpd_service_clients_until_ready(s->linknum, xtcp_cons.links, xtcp_cons.nr);
+    xtcpd_send_event(xtcp_cons.links[s->linknum], event, s);
+  }
+}
+
+/* -----------------------------------------------------------------------------
+ *
+ * -------------------------------------------------------------------------- */
+void xtcpd_bind_local(int linknum, int conn_id, int port_number)
+{
+  xtcpd_state_t *s = lookup_xtcpd_state(conn_id);
+  s->conn.local_port = port_number;
+  if (s->conn.protocol == XTCP_PROTOCOL_UDP) 
+    ((struct uip_udp_conn *) s->s.uip_conn)->lport = HTONS(port_number);    
+  else 
+    ((struct uip_conn *) s->s.uip_conn)->lport = HTONS(port_number);    
+}
+
+/* -----------------------------------------------------------------------------
+ *
+ * -------------------------------------------------------------------------- */
+void xtcpd_bind_remote(int linknum, 
+                       int conn_id, 
+                       xtcp_ipaddr_t addr,
+                       int port_number)
+{
+  xtcpd_state_t *s = lookup_xtcpd_state(conn_id);
+  if (s->conn.protocol == XTCP_PROTOCOL_UDP) {
+    struct uip_udp_conn *conn = (struct uip_udp_conn *) s->s.uip_conn;
+    s->conn.remote_port = port_number;
+    conn->rport = HTONS(port_number);    
+    XTCP_IPADDR_CPY(s->conn.remote_addr.u8, addr.u8);
+    XTCP_IPADDR_CPY(conn->ripaddr.u8, addr.u8);
+//    conn->ripaddr.u16[0] = (addr[1] << 8) | addr[0];
+//    conn->ripaddr.u16[1] = (addr[3] << 8) | addr[2];
+  }            
+}
+
+/* -----------------------------------------------------------------------------
+ *
+ * -------------------------------------------------------------------------- */
+void xtcpd_connect(int linknum, int port_number, xtcp_ipaddr_t addr, 
+                   xtcp_protocol_t p) {
+  uip_ipaddr_t uipaddr;
+#if UIP_CONF_IPV4
+  uip_ipaddr(&uipaddr, addr.u8[0], addr.u8[1], addr.u8[2], addr.u8[3]);
+#elif UIP_CONF_IPV6
+  uip_ip6addr(&uipaddr, addr.u16[0], addr.u16[1], addr.u16[2], addr.u16[3],
+		                addr.u16[4], addr.u16[5], addr.u16[6], addr.u16[7]);
+#endif /* UIP_CONF_IPVx */
+  if (p == XTCP_PROTOCOL_TCP) {
+    struct uip_conn *conn = uip_connect(&uipaddr, HTONS(port_number)); 
+    if (conn != NULL) {
+         xtcpd_state_t *s = (xtcpd_state_t *) &(conn->appstate);
+         s->linknum = linknum;
+         s->s.connect_request = 1;      
+         s->conn.connection_type = XTCP_CLIENT_CONNECTION;
+       }
+  }
+  else {
+    struct uip_udp_conn *conn;
+    conn = uip_udp_new(&uipaddr, HTONS(port_number));
+    if (conn != NULL) {
+      xtcpd_state_t *s = (xtcpd_state_t *) &(conn->appstate);
+      s->linknum = linknum;
+      s->s.connect_request = 1;      
+      s->conn.connection_type = XTCP_CLIENT_CONNECTION;
+    }
+  }
+  return;
+}
+
+/* -----------------------------------------------------------------------------
+ *
+ * -------------------------------------------------------------------------- */
+void xtcpd_init_send(int linknum, int conn_id)
+{
+  xtcpd_state_t *s = lookup_xtcpd_state(conn_id);
+
+  if (s != NULL) {
+    s->s.send_request++;
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+void xtcpd_init_send_from_uip(struct uip_conn *conn)
+{
+  xtcpd_state_t *s = &(conn->appstate);
+  s->s.send_request++;
+}
+
+/* -------------------------------------------------------------------------- */
+void xtcpd_set_appstate(int linknum, int conn_id, xtcp_appstate_t appstate)
+{
+  xtcpd_state_t *s = lookup_xtcpd_state(conn_id);
+  if (s != NULL) {
+    s->conn.appstate = appstate;
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+void xtcpd_abort(int linknum, int conn_id)
+{
+  xtcpd_state_t *s = lookup_xtcpd_state(conn_id);
+  if (s != NULL) {
+    s->s.abort_request = 1;
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+void xtcpd_close(int linknum, int conn_id)
+{
+  xtcpd_state_t *s = lookup_xtcpd_state(conn_id);
+  if (s != NULL) {
+    s->s.close_request = 1;
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+void xtcpd_ack_recv_mode(int conn_id)
+{
+  xtcpd_state_t *s = lookup_xtcpd_state(conn_id);
+  if (s != NULL) {
+    s->s.ack_recv_mode = 1;
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+void xtcpd_ack_recv(int conn_id)
+{
+  xtcpd_state_t *s = lookup_xtcpd_state(conn_id);
+  if (s != NULL) {
+    ((struct uip_conn *) s->s.uip_conn)->tcpstateflags &= ~UIP_STOPPED;
+    s->s.ack_request = 1;
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+void xtcpd_pause(int conn_id)
+{
+  xtcpd_state_t *s = lookup_xtcpd_state(conn_id);
+  if (s != NULL) {
+    ((struct uip_conn *) s->s.uip_conn)->tcpstateflags |= UIP_STOPPED;
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+void xtcpd_unpause(int conn_id)
+{
+  xtcpd_state_t *s = lookup_xtcpd_state(conn_id);
+  if (s != NULL) {
+    ((struct uip_conn *) s->s.uip_conn)->tcpstateflags &= ~UIP_STOPPED;
+    s->s.ack_request = 1;
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+#ifdef XTCP_ENABLE_PARTIAL_PACKET_ACK
+void xtcpd_accept_partial_ack(int conn_id)
+{
+  xtcpd_state_t *s = lookup_xtcpd_state(conn_id);
+  if (s != NULL) {
+    s->s.accepts_partial_ack = 1;
+  }
+}
+#endif
+
+/* -----------------------------------------------------------------------------
+ *
+ * -------------------------------------------------------------------------- */
+void xtcpd_set_poll_interval(int linknum, int conn_id, int poll_interval)
+{
+  xtcpd_state_t *s = lookup_xtcpd_state(conn_id);
+  if (s != NULL && s->conn.protocol == XTCP_PROTOCOL_UDP) {
+    s->s.poll_interval = poll_interval;
+    timer_set(&(s->s.tmr), poll_interval * CLOCK_SECOND/1000);
+  }
+}
+
+/* -----------------------------------------------------------------------------
+ *
+ * -------------------------------------------------------------------------- */
+static void uip_xtcpd_handle_poll(xtcpd_state_t *s)
+{
+ if (s->s.ack_request) {
+   uip_flags |= UIP_NEWDATA;
+   uip_slen = 0;
+   s->s.ack_request = 0;
+ }
+
+  if (s->s.abort_request) {
+    /* ----------------------------------- */
+    if (uip_udpconnection()) {
+      uip_udp_conn->lport = 0;
+      xtcpd_event(XTCP_CLOSED, s);    
+    } else {
+      uip_abort();
+    }
+    s->s.abort_request = 0;
+  } else if (s->s.close_request) {
+    /* ----------------------------------- */
+    if (uip_udpconnection()) {
+      uip_udp_conn->lport = 0;
+      xtcpd_event(XTCP_CLOSED, s);    
+    }
+    else
+      uip_close();
+    s->s.close_request = 0;
+  } else if (s->s.connect_request) {
+      /* ----------------------------------- */
+      if (uip_udpconnection()) {
+      init_xtcpd_state(s,
+                       XTCP_PROTOCOL_UDP,
+                       *((xtcp_ipaddr_t *) (&uip_udp_conn->ripaddr)),
+                       uip_udp_conn->lport,
+                       uip_udp_conn->rport,
+                       uip_udp_conn);
+      xtcpd_event(XTCP_NEW_CONNECTION, s);
+      s->s.connect_request = 0;
+    }
+  } else if (s->s.send_request) {
+     /* ----------------------------------- */
+    int len;
+    if (s->linknum != -1) {
+      len = do_xtcpd_send(xtcp_cons.links[s->linknum],
+                       XTCP_REQUEST_DATA,
+                       s, 
+                       uip_appdata,
+                       uip_udpconnection() ? XTCP_CLIENT_BUF_SIZE : uip_mss());
+      uip_send(uip_appdata, len);
+    }
+    s->s.send_request--;
+  } else if (s->s.poll_interval != 0 &&
+           timer_expired(&(s->s.tmr))){
+    /* ----------------------------------- */
+    xtcpd_event(XTCP_POLL, s);
+    timer_set(&(s->s.tmr), s->s.poll_interval);
+  }
+}
+
+
+/* -----------------------------------------------------------------------------
+ * xtcpd_appcall
+ *
+ * this function is called, when a package comes in for an upper layer
+ * application.
+ * -------------------------------------------------------------------------- */
+void 
+xtcpd_appcall(void)
+{
+  xtcpd_state_t *s;
+
+  /* --------------- DHCP (v4)  --------------- */
+  if (uip_udpconnection() &&
+      (uip_udp_conn->lport == HTONS(DHCPC_CLIENT_PORT) ||
+       uip_udp_conn->lport == HTONS(DHCPC_SERVER_PORT))) {
+#if UIP_USE_DHCP
+    dhcpc_appcall();
+#endif
+    return;
+  }
+
+  /* --------- set up a new connection  ---------- */
+  if (uip_udpconnection()){
+    s = (xtcpd_state_t *) &(uip_udp_conn->appstate);
+    if (uip_newdata()) {
+    	// Set remote port to upper layer state
+      s->conn.remote_port = HTONS(UDPBUF->srcport);
+      uip_ipaddr_copy(s->conn.remote_addr.u8, BUF->srcipaddr.u8);
+    }
+  } else if (uip_conn == NULL) {
+      // dodgy uip_conn
+      return;
+  } else {
+    s = (xtcpd_state_t *) &(uip_conn->appstate);
+  }
+
+  /* ------ passing new connection event up to the upper xtcp layer  ---- */
+  if (uip_connected()) {
+    if (!uip_udpconnection()) {
+      init_xtcpd_state(s,
+                       XTCP_PROTOCOL_TCP,
+                       *((xtcp_ipaddr_t *) (&uip_conn->ripaddr)),
+                       uip_conn->lport,
+                       uip_conn->rport,
+                       uip_conn);
+      xtcpd_event(XTCP_NEW_CONNECTION, s);
+    } else {
+      init_xtcpd_state(s,
+                       XTCP_PROTOCOL_UDP,
+                       *((xtcp_ipaddr_t *) (&uip_udp_conn->ripaddr)),
+                       uip_udp_conn->lport,
+                       uip_udp_conn->rport,
+                       uip_udp_conn);   
+      xtcpd_event(XTCP_NEW_CONNECTION, s);
+    }
+  }
+
+  /* --------------- new data event to deliver  --------------- */
+  if (uip_newdata() && uip_len > 0) {
+    if (s->linknum != -1) {
+      xtcpd_service_clients_until_ready(s->linknum, xtcp_cons.links, xtcp_cons.nr);
+      xtcpd_recv(xtcp_cons.links, s->linknum, xtcp_cons.nr,
+                 s, 
+                 uip_appdata, 
+                 uip_datalen());
+      if (!uip_udpconnection() && s->s.ack_recv_mode) {
+        uip_stop();
+      }
+    }
+  } else if (uip_aborted()) {
+    xtcpd_event(XTCP_ABORTED, s);
+    return;
+  } else if (uip_timedout()) {
+    xtcpd_event(XTCP_TIMED_OUT, s);
+    return;
+  }
+
+  /* ------------ passing acknowleg event to upper layer  ------------- */
+  if (uip_acked()) {
+    int len;
+    if (s->linknum != -1) {
+      len =
+        do_xtcpd_send(xtcp_cons.links[s->linknum],
+                      XTCP_SENT_DATA,
+                      s,
+                      uip_appdata,
+                      uip_udpconnection() ? XTCP_CLIENT_BUF_SIZE : uip_mss());
+
+      uip_send(uip_appdata, len);
+    }
+  }  
+
+  /* -------------- retransmit the last package  -------------- */
+  if (uip_rexmit()) {
+    int len;
+    if (s->linknum != -1) {
+      xtcpd_service_clients_until_ready(s->linknum, xtcp_cons.links, xtcp_cons.nr);
+#ifdef XTCP_ENABLE_PARTIAL_PACKET_ACK
+      s->conn.outstanding = 0;
+#endif
+      len = xtcpd_send(xtcp_cons.links[s->linknum],
+                       XTCP_RESEND_DATA, 
+                       s, 
+                       uip_appdata,
+                       uip_udpconnection() ? XTCP_CLIENT_BUF_SIZE : uip_mss());
+      if (len != 0)
+        uip_send(uip_appdata, len);
+    }    
+  }
+
+  /* --------------- poll a connection --------------- */
+  if (uip_poll()) {
+    uip_xtcpd_handle_poll(s);
+  }  
+
+#if XTCP_ENABLE_PUSH_FLAG_NOTIFICATION
+  if (uip_tcp_push()) {
+    xtcpd_event(XTCP_PUSH_DATA, s);
+  }
+#endif
+
+  /* ------------- connection close event  ------------ */
+  if (uip_closed()) {
+    if (!s->s.closed){
+      s->s.closed = 1;
+
+      xtcpd_event(XTCP_CLOSED, s);
+    }
+    return;
+  }
+
+}
+
+/* -----------------------------------------------------------------------------
+ * TODO: CHSC
+ * ICMP6 call
+ *
+ * If we receive a ICMPv6 telegram, the application could be informed. In the
+ * future, here should be a mechanism like the xtcpd_appcall one, which
+ * informs the application about the ICMPv6 telegrams.
+ *
+ * One interessting event could be Router Solicitation (133) or Neigbor
+ * Solicitation (135)
+ * -------------------------------------------------------------------------- */
+#if UIP_CONF_IPV6
+void
+xtcpd_icmp6_call(uint8_t type){
+	PRINTF("%s: type: %i\n", __func__, type);
+	switch(type){
+    case ICMP6_NA:
+    case ICMP6_RA:
+		uip_xtcp_up();
+		break;
+
+	default:
+		break;
+	}
+}
+#endif
+
+/* -----------------------------------------------------------------------------
+ * General stack information (set/get) functions
+ * -------------------------------------------------------------------------- */
+static int uip_ifstate = 0;
+void xtcpd_get_ipconfig(xtcp_ipconfig_t *ipconfig) 
+{
+#if UIP_CONF_IPV4
+  ipconfig->v = 4;
+  memcpy(&ipconfig->ipaddr, &uip_hostaddr, sizeof(xtcp_ipconfig_t));
+  memcpy(&ipconfig->netmask, &uip_netmask, sizeof(xtcp_ipconfig_t));
+  memcpy(&ipconfig->gateway, &uip_draddr, sizeof(xtcp_ipconfig_t));
+#elif UIP_CONF_IPV6
+  //TODO CHSC: Implement IPv6 get
+  memset(ipconfig, 0, sizeof(xtcp_ipconfig_t));
+  ipconfig->v = 6;
+
+  uip_ds6_addr_t *temp_uip_ds6_addr;
+  temp_uip_ds6_addr = uip_ds6_get_global(-1);
+
+  if(temp_uip_ds6_addr != NULL)
+    memcpy(&ipconfig->ipaddr, &temp_uip_ds6_addr->ipaddr, sizeof(uip_ipaddr_t));
+
+  /* dump uip_ds6_if */
+  PRINTF("Dump uip_ds6_if:\n");
+  PRINTF("  link_mtu:               %i\n", uip_ds6_if.link_mtu);
+  PRINTF("  cur_hop_limit:          %i\n", uip_ds6_if.cur_hop_limit);
+  PRINTF("  base_reachable_time:    %i\n", uip_ds6_if.base_reachable_time);
+  PRINTF("  reachable_time:         %i\n", uip_ds6_if.reachable_time);
+  PRINTF("  retrans_timer:          %i\n", uip_ds6_if.retrans_timer);
+  PRINTF("  maxdadns:               %i\n", uip_ds6_if.maxdadns);
+  PRINTF("--ADDR LIST\n");
+  for(int i=0; i<UIP_DS6_ADDR_NB; i++){
+	  PRINT6ADDR(&uip_ds6_if.addr_list[i].ipaddr);
+	  PRINTF("  is used: %s\n", uip_ds6_if.addr_list[i].isused ? "yes" : "no");
+  }
+  PRINTF("--AADDR LIST\n");
+  for(int i=0; i<UIP_DS6_AADDR_NB; i++){
+	  PRINT6ADDR(&uip_ds6_if.aaddr_list[i].ipaddr);
+	  PRINTF("  is used: %s\n", uip_ds6_if.aaddr_list[i].isused ? "yes" : "no");
+  }
+  PRINTF("--MADDR LIST\n");
+  for(int i=0; i<UIP_DS6_MADDR_NB; i++){
+	  PRINT6ADDR(&uip_ds6_if.maddr_list[i].ipaddr);
+	  PRINTF("  is used: %s\n", uip_ds6_if.maddr_list[i].isused ? "yes" : "no");
+  }
+
+#endif
+}
+
+void xtcpd_get_mac_address(unsigned char mac_addr[]){
+	memcpy(mac_addr, uip_lladdr.addr, sizeof(uip_lladdr));
+}
+
+/* -----------------------------------------------------------------------------
+ * Inform the connect applications about a state change in the state
+ * of the link
+ * -------------------------------------------------------------------------- */
+void xtcpd_uip_checkstate(void)
+{
+  for (int i=0;i<xtcp_cons.nr;i++) {
+    if (uip_ifstate != xtcp_cons.prev_ifstate[i]) {
+    	  /* queue configuration change */
+    	  if (uip_ifstate) {
+    	    xtcpd_queue_event(xtcp_cons.links[i], i, XTCP_IFUP);
+    	  }
+    	  else {
+    	    xtcpd_queue_event(xtcp_cons.links[i], i, XTCP_IFDOWN);
+    	  }
+      xtcp_cons.prev_ifstate[i] = uip_ifstate;
+    }
+  }
+}
+
+/* -----------------------------------------------------------------------------
+ * Interface state functions
+ * -------------------------------------------------------------------------- */
+void uip_xtcp_up(void) {
+  uip_ifstate = 1;
+}
+
+void uip_xtcp_down(void) {
+  uip_ifstate = 0;
+}
+
+int uip_xtcp_get_ifstate() 
+{
+  return uip_ifstate;
+}
+
+
+/* -----------------------------------------------------------------------------
+ *	IGMP functions
+ * -------------------------------------------------------------------------- */
+void xtcpd_join_group(xtcp_ipaddr_t addr)
+{
+#if UIP_IGMP
+  uip_ipaddr_t ipaddr;
+  uip_ipaddr(ipaddr, addr[0], addr[1], addr[2], addr[3]);
+  igmp_join_group(ipaddr);
+#endif
+}
+
+void xtcpd_leave_group(xtcp_ipaddr_t addr)
+{
+#if UIP_IGMP
+  uip_ipaddr_t ipaddr;
+  uip_ipaddr(ipaddr, addr[0], addr[1], addr[2], addr[3]);
+  igmp_leave_group(ipaddr);
+#endif
+}
+
+/* -----------------------------------------------------------------------------
+ * Initialise xtcpd
+ * -------------------------------------------------------------------------- */
+void xtcpd_init(chanend xtcp_links_init[], int n)
+{
+  int i;
+  xtcp_cons.links = xtcp_links_init;
+  xtcp_cons.nr = n;
+  uip_ifstate = 0;
+  if(n>MAX_XTCP_CLIENTS)
+    PRINTF("%s: Panic - to many connected applications!\n", __func__);
+  for(i=0;i<MAX_XTCP_CLIENTS;i++)
+    xtcp_cons.prev_ifstate[i] = 0;
+  xtcpd_server_init();
+}

--- a/module_xtcp/src/xtcp_uip6/uip_xtcp.h
+++ b/module_xtcp/src/xtcp_uip6/uip_xtcp.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2011, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+#ifndef _UIP_XTCP_H_
+#define _UIP_XTCP_H_
+
+#include <xccompat.h>
+#include <stdint.h>
+
+void xtcpd_uip_checkstate(void);
+void uip_xtcp_up(void);
+void uip_xtcp_down(void);
+void uip_xtcp_checklink(chanend connect_status);
+int uip_xtcp_get_ifstate(void);
+void uip_linkdown(void);
+void uip_linkup(void);
+void uip_xtcp_null_events(void);
+
+/**
+ * \brief Output packet to layer 2
+ * The eventual parameter is the MAC address of the destination.
+ */
+#if UIP_CONF_IPV6
+uint8_t xtcpip_output(uip_lladdr_t *, chanend mac_tx);
+#else
+uint8_t xtcpip_output(chanend mac_tx);
+#endif
+
+/**
+ * \brief This function does address resolution and then calls tcpip_output
+ */
+#if UIP_CONF_IPV6
+void xtcpip_ipv6_output(chanend mac_tx);
+#endif
+
+#endif // _UIP_XTCP_H_

--- a/module_xtcp/src/xtcp_uip6/xcoredev.h
+++ b/module_xtcp/src/xtcp_uip6/xcoredev.h
@@ -1,0 +1,15 @@
+// Copyright (c) 2011, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+#ifndef __XCOREDEV_H__
+#define __XCOREDEV_H__
+
+#include <xccompat.h>
+
+void xcoredev_init(chanend mac_rx, chanend mac_tx);
+unsigned int xcoredev_read(chanend mac_rx, int n);
+void xcoredev_send(chanend mac_tx);
+
+#endif /* __XCOREDEV_H__ */

--- a/module_xtcp/src/xtcp_uip6/xcoredev.xc
+++ b/module_xtcp/src/xtcp_uip6/xcoredev.xc
@@ -1,0 +1,155 @@
+// Copyright (c) 2011, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+#include <print.h>
+#include <xs1.h>
+#include "uip_xtcp.h"
+#include "xtcp_conf_derived.h"
+
+#if XTCP_SEPARATE_MAC
+
+#include "ethernet_rx_client.h"
+#include "ethernet_tx_client.h"
+#include "mac_filter.h"
+
+extern unsigned short uip_len;
+extern unsigned int uip_buf32[];
+
+/*---------------------------------------------------------------------------*/
+void
+xcoredev_init(chanend rx, chanend tx)
+{
+  // Configure the mac link to send the server anything
+  // arp or ip
+  mac_set_custom_filter(rx, MAC_FILTER_ARPIP);
+  mac_request_status_packets(rx);
+}
+
+/*---------------------------------------------------------------------------*/
+#pragma unsafe arrays
+unsigned int
+xcoredev_read(chanend rx, int n)
+{
+  unsigned int len = 0;
+  unsigned int src_port;
+  select 
+    {
+    case safe_mac_rx(rx, (uip_buf32, unsigned char[]), len, src_port, n):
+      if (len == STATUS_PACKET_LEN) {
+        if ((uip_buf32, unsigned char[])[0]) {
+          uip_linkup();
+        }
+        else {
+          uip_linkdown();
+        }
+        return 0;
+      }
+      break;
+    default:      
+      break;
+    }
+  return len <= n ? len : 0;
+}
+
+/*---------------------------------------------------------------------------*/
+void
+xcoredev_send(chanend tx)
+{
+  int len = uip_len;
+  if (len != 0) {
+    if (len < 64)  {
+      for (int i=len;i<64;i++) 
+        (uip_buf32, unsigned char[])[i] = 0;      
+      len=64;
+    }
+
+    mac_tx(tx, uip_buf32, len, -1);
+  }
+}
+/*---------------------------------------------------------------------------*/
+
+#else /* XTCP_SEPARATE_MAC */
+
+#include "net/uip.h"
+#include "mii_client.h"
+
+// Global variables from uip_server_support
+extern unsigned short uip_len;
+
+#define xuip_buf32 (uip_aligned_buf.u32)
+
+#ifndef UIP_MAX_TRANSMIT_SIZE
+#define UIP_MAX_TRANSMIT_SIZE 1520
+#endif
+
+#pragma unsafe arrays
+void xcoredev_send(chanend tx)
+{
+#ifdef UIP_SINGLE_SERVER_DOUBLE_BUFFER_TX
+    static int txbuf0[(UIP_MAX_TRANSMIT_SIZE+3)/4];
+    static int txbuf1[(UIP_MAX_TRANSMIT_SIZE+3)/4];
+    static int tx_buf_in_use=0;
+    static int n=0;
+    int len = uip_len;
+    unsigned nWords;
+    if (len<60) {
+        for (int i=len;i<60;i++)
+            (xuip_buf32, unsigned char[])[i] = 0;
+        len=60;
+    }
+    nWords = (len+3)>>2;
+
+    if (len > UIP_MAX_TRANSMIT_SIZE) {
+#ifdef UIP_DEBUG_MAX_TRANSMIT_SIZE
+        printstr("Error: Trying to send too big a packet: ");
+        printint(len);
+        printstr(" bytes.\n");
+#endif
+        return;
+    }
+    switch (n) {
+    case 0:
+        for (unsigned i=0; i<nWords; ++i) { txbuf0[i] = xuip_buf32[i]; }
+        if (tx_buf_in_use) mii_out_packet_done(tx, txbuf1);
+        mii_out_packet(tx, txbuf0, 0, len);
+        n = 1;
+        break;
+    case 1:
+        for (unsigned i=0; i<nWords; ++i) { txbuf1[i] = xuip_buf32[i]; }
+        if (tx_buf_in_use) mii_out_packet_done(tx, txbuf0);
+        mii_out_packet(tx, txbuf1, 0, len);
+        n = 0;
+        break;
+    }
+    tx_buf_in_use=1;
+#else
+    static int txbuf[(UIP_MAX_TRANSMIT_SIZE+3)/4];
+    static int tx_buf_in_use=0;
+    unsigned nWords;
+    int len=uip_len;
+
+#if BUF_32BIT_ALIGN
+    //XXX CHSC: Alignment Hack
+    for(int i = 0; i<uip_len; i++){
+      uip_aligned_buf.u8[i] = uip_aligned_buf.u8[i+2];
+    }
+    // End of alignment hack
+#endif /* BUF_32BIT_ALIGN */
+
+    if (tx_buf_in_use)
+        mii_out_packet_done(tx);
+    if (len<60) {
+        for (int i=len;i<60;i++){
+            (xuip_buf32, unsigned char[])[i] = 0;
+        }
+        len=60;
+    }
+    nWords = (len+3)>>2;
+    for (unsigned i=0; i<nWords; ++i) { txbuf[i] = xuip_buf32[i]; }
+    mii_out_packet(tx, txbuf, 0, len);
+    tx_buf_in_use=1;
+#endif /* UIP_SINGLE_SERVER_DOUBLE_BUFFER_TX */
+}
+#endif /* XTCP_SEPARATE_MAC */

--- a/module_xtcp/src/xtcp_uip6/xtcp_server_conf.h
+++ b/module_xtcp/src/xtcp_uip6/xtcp_server_conf.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2011, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+#include "timer.h"
+#include "xtcp_client.h"
+
+typedef struct xtcp_server_state_t {
+  int send_request;
+  int abort_request;
+  int close_request;  
+  int poll_interval;
+  int connect_request;
+  int ack_request;
+  int closed;
+  struct uip_timer tmr;
+  int uip_conn;
+  int ack_recv_mode;
+#ifdef XTCP_ENABLE_PARTIAL_PACKET_ACK
+  int accepts_partial_ack;
+#endif
+} xtcp_server_state_t;


### PR DESCRIPTION
Add IPv6 support. Not fully documented. IPv6 support can be enabled in the application makefile by:
XTCP_IPV6 = 1
ifeq ($(XTCP_IPV6),1)
XCC_FLAGS = -O2 -g -DIPV6=1
else
XCC_FLAGS = -O2 -g -DIPV6=0
endif
If nothing (xtcp_ipv6) is defined, then module_xtcp will assume the usual ipv4.
