### PR TITLE
Added support for a txt record in TXT responses

### DIFF
--- a/module_zeroconf/mdns/mdns.h
+++ b/module_zeroconf/mdns/mdns.h
@@ -12,6 +12,10 @@
 #define MDNS_MAX_NAME_LENGTH             100
 #endif
 
+#ifndef MDNS_MAX_TXT_LENGTH
+#define MDNS_MAX_TXT_LENGTH              100
+#endif
+
 #ifndef MDNS_NUM_TABLE_ENTRIES
 #define MDNS_NUM_TABLE_ENTRIES            5
 #endif


### PR DESCRIPTION
Slight change to support TXT records. Very useful for sending a short bit of information (like a UID) to Bonjour services which often grab the first TXT record when resolving an mdns entry.
